### PR TITLE
feat(auth): align mobile sensitive user gating

### DIFF
--- a/lib/features/auth/domain/entities/authorization_snapshot.dart
+++ b/lib/features/auth/domain/entities/authorization_snapshot.dart
@@ -53,6 +53,27 @@ class AuthorizationSnapshot extends Equatable {
 
   bool get hasCanonicalPermissions => effectivePermissions.isNotEmpty;
 
+  Set<String> get resolvedRoleNames {
+    final roles = <String>{};
+
+    void addRole(String? roleName) {
+      final normalized = roleName?.trim().toLowerCase();
+      if (normalized != null && normalized.isNotEmpty) {
+        roles.add(normalized);
+      }
+    }
+
+    for (final grant in globalGrants) {
+      addRole(grant.roleName);
+    }
+
+    for (final grant in clubAssignments) {
+      addRole(grant.roleName);
+    }
+
+    return roles;
+  }
+
   @override
   List<Object?> get props => [
         effectivePermissions,

--- a/lib/features/auth/domain/utils/authorization_utils.dart
+++ b/lib/features/auth/domain/utils/authorization_utils.dart
@@ -39,6 +39,27 @@ Set<String> _extractLegacyRoles(UserEntity user) {
   return <String>{};
 }
 
+Set<String> extractUserRoles(UserEntity? user) {
+  if (user == null) {
+    return <String>{};
+  }
+
+  final resolvedRoles = user.authorization?.resolvedRoleNames ?? <String>{};
+  if (resolvedRoles.isNotEmpty) {
+    return resolvedRoles;
+  }
+
+  if (!kRbacLegacyFallbackEnabled) {
+    return <String>{};
+  }
+
+  final legacyRoles = _extractLegacyRoles(user);
+  if (legacyRoles.isNotEmpty) {
+    _logLegacyFallbackEvent();
+  }
+  return legacyRoles;
+}
+
 void _logCanonicalEvent() {
   if (_canonicalEventLogged) return;
   _canonicalEventLogged = true;
@@ -101,11 +122,11 @@ bool canByPermissionOrLegacyRole(
     return true;
   }
 
-  if (!kRbacLegacyFallbackEnabled || user == null || legacyRoles.isEmpty) {
+  if (user == null || legacyRoles.isEmpty) {
     return false;
   }
 
-  final roles = _extractLegacyRoles(user);
+  final roles = extractUserRoles(user);
   if (roles.isEmpty) {
     return false;
   }
@@ -119,4 +140,37 @@ bool canByPermissionOrLegacyRole(
   }
 
   return intersects;
+}
+
+bool isUserOwner(UserEntity? user, String targetUserId) {
+  final normalizedTarget = targetUserId.trim();
+  if (user == null || normalizedTarget.isEmpty) {
+    return false;
+  }
+
+  return user.id.trim() == normalizedTarget;
+}
+
+bool canViewAdministrativeCompletionForUser(
+  UserEntity? user, {
+  required String targetUserId,
+}) {
+  return isUserOwner(user, targetUserId) ||
+      hasAnyPermission(user, const {'users:read_detail', 'users:update'});
+}
+
+bool canManageAdministrativeCompletionForUser(
+  UserEntity? user, {
+  required String targetUserId,
+}) {
+  return isUserOwner(user, targetUserId) ||
+      hasAnyPermission(user, const {'users:update'});
+}
+
+bool canAccessSensitiveUserDataForUser(
+  UserEntity? user, {
+  required String targetUserId,
+}) {
+  return isUserOwner(user, targetUserId) ||
+      hasAnyPermission(user, const {'users:read_detail'});
 }

--- a/lib/features/auth/domain/utils/authorization_utils.dart
+++ b/lib/features/auth/domain/utils/authorization_utils.dart
@@ -7,6 +7,46 @@ const bool kRbacLegacyFallbackEnabled =
 bool _canonicalEventLogged = false;
 bool _legacyFallbackEventLogged = false;
 
+enum SensitiveUserFamily {
+  health,
+  emergencyContacts,
+  legalRepresentative,
+  postRegistration,
+}
+
+const Map<SensitiveUserFamily, Set<String>> _sensitiveFamilyReadPermissions = {
+  SensitiveUserFamily.health: {'health:read', 'users:read_detail'},
+  SensitiveUserFamily.emergencyContacts: {
+    'emergency_contacts:read',
+    'users:read_detail',
+  },
+  SensitiveUserFamily.legalRepresentative: {
+    'legal_representative:read',
+    'users:read_detail',
+  },
+  SensitiveUserFamily.postRegistration: {
+    'post_registration:read',
+    'users:read_detail',
+  },
+};
+
+const Map<SensitiveUserFamily, Set<String>> _sensitiveFamilyUpdatePermissions =
+    {
+  SensitiveUserFamily.health: {'health:update', 'users:update'},
+  SensitiveUserFamily.emergencyContacts: {
+    'emergency_contacts:update',
+    'users:update',
+  },
+  SensitiveUserFamily.legalRepresentative: {
+    'legal_representative:update',
+    'users:update',
+  },
+  SensitiveUserFamily.postRegistration: {
+    'post_registration:update',
+    'users:update',
+  },
+};
+
 Set<String> _normalizePermissions(Iterable<dynamic> values) {
   return values
       .map((value) => value?.toString().trim().toLowerCase())
@@ -156,15 +196,41 @@ bool canViewAdministrativeCompletionForUser(
   required String targetUserId,
 }) {
   return isUserOwner(user, targetUserId) ||
-      hasAnyPermission(user, const {'users:read_detail', 'users:update'});
+      hasAnyPermission(user, {
+        ..._sensitiveFamilyReadPermissions[
+            SensitiveUserFamily.postRegistration]!,
+        ..._sensitiveFamilyUpdatePermissions[
+            SensitiveUserFamily.postRegistration]!,
+      });
 }
 
 bool canManageAdministrativeCompletionForUser(
   UserEntity? user, {
   required String targetUserId,
 }) {
+  return canUpdateSensitiveUserFamilyForUser(
+    user,
+    targetUserId: targetUserId,
+    family: SensitiveUserFamily.postRegistration,
+  );
+}
+
+bool canReadSensitiveUserFamilyForUser(
+  UserEntity? user, {
+  required String targetUserId,
+  required SensitiveUserFamily family,
+}) {
   return isUserOwner(user, targetUserId) ||
-      hasAnyPermission(user, const {'users:update'});
+      hasAnyPermission(user, _sensitiveFamilyReadPermissions[family]!);
+}
+
+bool canUpdateSensitiveUserFamilyForUser(
+  UserEntity? user, {
+  required String targetUserId,
+  required SensitiveUserFamily family,
+}) {
+  return isUserOwner(user, targetUserId) ||
+      hasAnyPermission(user, _sensitiveFamilyUpdatePermissions[family]!);
 }
 
 bool canAccessSensitiveUserDataForUser(

--- a/lib/features/post_registration/presentation/views/personal_info_step_view.dart
+++ b/lib/features/post_registration/presentation/views/personal_info_step_view.dart
@@ -8,6 +8,8 @@ import 'package:sacdia_app/core/theme/app_colors.dart';
 import 'package:sacdia_app/core/theme/sac_colors.dart';
 import 'package:sacdia_app/core/utils/responsive.dart';
 import 'package:sacdia_app/core/widgets/sac_card.dart';
+import 'package:sacdia_app/features/auth/domain/utils/authorization_utils.dart';
+import 'package:sacdia_app/features/auth/presentation/providers/auth_providers.dart';
 import '../providers/personal_info_providers.dart';
 import 'emergency_contacts_view.dart';
 import 'legal_representative_view.dart';
@@ -20,7 +22,16 @@ import 'diseases_selection_view.dart';
 /// date pickers limpios. Indicador de progreso de secciones completadas.
 /// Title uses responsive font size for small phones.
 class PersonalInfoStepView extends ConsumerStatefulWidget {
-  const PersonalInfoStepView({super.key});
+  const PersonalInfoStepView({
+    super.key,
+    required this.canReadSensitiveData,
+    required this.canManageAdministrativeCompletion,
+    required this.targetUserId,
+  });
+
+  final bool canReadSensitiveData;
+  final bool canManageAdministrativeCompletion;
+  final String targetUserId;
 
   @override
   ConsumerState<PersonalInfoStepView> createState() =>
@@ -30,25 +41,9 @@ class PersonalInfoStepView extends ConsumerStatefulWidget {
 class _PersonalInfoStepViewState extends ConsumerState<PersonalInfoStepView> {
   final _formKey = GlobalKey<FormState>();
 
-  int get _completedSections {
-    final formState = ref.read(personalInfoFormProvider);
-    final contacts = ref.read(emergencyContactsProvider);
-    int count = 0;
-
-    // Section 1: basic data
-    if (formState.gender != null && formState.birthdate != null) count++;
-    // Section 2: emergency contacts
-    if (contacts.hasValue && (contacts.value?.isNotEmpty ?? false)) count++;
-    // Section 3: medical info is optional, count if viewed
-    final allergies = ref.read(selectedAllergiesProvider);
-    final diseases = ref.read(selectedDiseasesProvider);
-    if (allergies.isNotEmpty || diseases.isNotEmpty) count++;
-
-    return count;
-  }
-
   @override
   Widget build(BuildContext context) {
+    final authUser = ref.watch(authNotifierProvider).valueOrNull;
     final formState = ref.watch(personalInfoFormProvider);
     final contactsAsync = ref.watch(emergencyContactsProvider);
     final legalRepAsync = ref.watch(legalRepresentativeProvider);
@@ -57,6 +52,21 @@ class _PersonalInfoStepViewState extends ConsumerState<PersonalInfoStepView> {
     final selectedAllergies = ref.watch(selectedAllergiesProvider);
     final selectedDiseases = ref.watch(selectedDiseasesProvider);
     final canComplete = ref.watch(canCompleteStep2Provider);
+    final canReadEmergencyContacts = canReadSensitiveUserFamilyForUser(
+      authUser,
+      targetUserId: widget.targetUserId,
+      family: SensitiveUserFamily.emergencyContacts,
+    );
+    final canReadLegalRepresentative = canReadSensitiveUserFamilyForUser(
+      authUser,
+      targetUserId: widget.targetUserId,
+      family: SensitiveUserFamily.legalRepresentative,
+    );
+    final canReadHealth = canReadSensitiveUserFamilyForUser(
+      authUser,
+      targetUserId: widget.targetUserId,
+      family: SensitiveUserFamily.health,
+    );
 
     // Responsive title style — smaller on very small phones
     final titleStyle = Responsive.isSmallPhone(context)
@@ -86,6 +96,36 @@ class _PersonalInfoStepViewState extends ConsumerState<PersonalInfoStepView> {
           ),
           const SizedBox(height: 24),
 
+          if (!widget.canReadSensitiveData &&
+              widget.canManageAdministrativeCompletion) ...[
+            SacCard(
+              backgroundColor: AppColors.accentLight,
+              borderColor: AppColors.accent.withValues(alpha: 0.3),
+              padding: const EdgeInsets.all(12),
+              child: Row(
+                children: [
+                  HugeIcon(
+                    icon: HugeIcons.strokeRoundedInformationCircle,
+                    size: 18,
+                    color: AppColors.accentDark,
+                  ),
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: Text(
+                      'Tu acceso actual solo permite completion administrativa mínima. Los datos sensibles del usuario no se muestran.',
+                      style: TextStyle(
+                        fontSize: 13,
+                        color: AppColors.accentDark,
+                        height: 1.3,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(height: 24),
+          ],
+
           // Progress indicator
           /*SacProgressBar(
             progress: _completedSections / 3,
@@ -94,161 +134,307 @@ class _PersonalInfoStepViewState extends ConsumerState<PersonalInfoStepView> {
           ),
           const SizedBox(height: 24), */
 
-          // === Section 1: Basic Data ===
-          _SectionHeader(
-            icon: HugeIcons.strokeRoundedUser,
-            title: 'Datos básicos',
-            isCompleted:
-                formState.gender != null && formState.birthdate != null,
-          ),
-          const SizedBox(height: 12),
-
-          // Gender chips
-          Text(
-            'Género',
-            style: Theme.of(context).textTheme.labelLarge?.copyWith(
-                  color: context.sac.textSecondary,
+          if (widget.canReadSensitiveData) ...[
+            // === Section 1: Basic Data ===
+            _SectionHeader(
+              icon: HugeIcons.strokeRoundedUser,
+              title: 'Datos básicos',
+              isCompleted:
+                  formState.gender != null && formState.birthdate != null,
+            ),
+            const SizedBox(height: 12),
+            Text(
+              'Género',
+              style: Theme.of(context).textTheme.labelLarge?.copyWith(
+                    color: context.sac.textSecondary,
+                  ),
+            ),
+            const SizedBox(height: 8),
+            Row(
+              children: [
+                _GenderChip(
+                  label: 'Masculino',
+                  icon: HugeIcons.strokeRoundedUser,
+                  isSelected: formState.gender == 'M',
+                  onTap: () {
+                    ref.read(personalInfoFormProvider.notifier).state =
+                        formState.copyWith(gender: 'M');
+                  },
                 ),
-          ),
-          const SizedBox(height: 8),
-          Row(
-            children: [
-              _GenderChip(
-                label: 'Masculino',
-                icon: HugeIcons.strokeRoundedUser,
-                isSelected: formState.gender == 'M',
-                onTap: () {
+                const SizedBox(width: 12),
+                _GenderChip(
+                  label: 'Femenino',
+                  icon: HugeIcons.strokeRoundedUser,
+                  isSelected: formState.gender == 'F',
+                  onTap: () {
+                    ref.read(personalInfoFormProvider.notifier).state =
+                        formState.copyWith(gender: 'F');
+                  },
+                ),
+              ],
+            ),
+            const SizedBox(height: 20),
+            _DatePickerCard(
+              label: 'Fecha de nacimiento',
+              icon: HugeIcons.strokeRoundedBirthdayCake,
+              date: formState.birthdate,
+              onTap: () => _selectBirthdate(context),
+            ),
+            const SizedBox(height: 16),
+            SacCard(
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+              child: SwitchListTile(
+                title: const Text(
+                  '¿Estás bautizado?',
+                  style: TextStyle(
+                    fontSize: 15,
+                    fontWeight: FontWeight.w500,
+                  ),
+                ),
+                value: formState.baptized,
+                activeTrackColor: AppColors.primaryLight,
+                thumbColor: WidgetStatePropertyAll(AppColors.primary),
+                contentPadding: EdgeInsets.zero,
+                onChanged: (value) {
                   ref.read(personalInfoFormProvider.notifier).state =
-                      formState.copyWith(gender: 'M');
+                      formState.copyWith(
+                    baptized: value,
+                    baptismDate: value ? formState.baptismDate : null,
+                  );
                 },
               ),
-              const SizedBox(width: 12),
-              _GenderChip(
-                label: 'Femenino',
-                icon: HugeIcons.strokeRoundedUser,
-                isSelected: formState.gender == 'F',
-                onTap: () {
-                  ref.read(personalInfoFormProvider.notifier).state =
-                      formState.copyWith(gender: 'F');
-                },
+            ),
+            if (formState.baptized) ...[
+              const SizedBox(height: 12),
+              _DatePickerCard(
+                label: 'Fecha de bautismo',
+                icon: HugeIcons.strokeRoundedBlood,
+                date: formState.baptismDate,
+                onTap: () => _selectBaptismDate(context),
               ),
             ],
-          ),
-          const SizedBox(height: 20),
+            const SizedBox(height: 28),
+          ],
 
-          // Birthdate
-          _DatePickerCard(
-            label: 'Fecha de nacimiento',
-            icon: HugeIcons.strokeRoundedBirthdayCake,
-            date: formState.birthdate,
-            onTap: () => _selectBirthdate(context),
-          ),
-          const SizedBox(height: 16),
-
-          // Baptized toggle
-          SacCard(
-            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-            child: SwitchListTile(
-              title: const Text(
-                '¿Estás bautizado?',
-                style: TextStyle(
-                  fontSize: 15,
-                  fontWeight: FontWeight.w500,
+          if (canReadEmergencyContacts) ...[
+            // === Section 2: Emergency Contacts ===
+            _SectionHeader(
+              icon: HugeIcons.strokeRoundedCall02,
+              title: 'Contactos de emergencia',
+              isCompleted: contactsAsync.hasValue &&
+                  (contactsAsync.value?.isNotEmpty ?? false),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              'Registra al menos un contacto de emergencia',
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                    color: context.sac.textTertiary,
+                  ),
+            ),
+            const SizedBox(height: 12),
+            contactsAsync.when(
+              loading: () => const Center(
+                child: Padding(
+                  padding: EdgeInsets.all(16),
+                  child: SacLoadingSmall(),
                 ),
               ),
-              value: formState.baptized,
-              activeTrackColor: AppColors.primaryLight,
-              thumbColor: WidgetStatePropertyAll(AppColors.primary),
-              contentPadding: EdgeInsets.zero,
-              onChanged: (value) {
-                ref.read(personalInfoFormProvider.notifier).state =
-                    formState.copyWith(
-                  baptized: value,
-                  baptismDate: value ? formState.baptismDate : null,
+              error: (error, _) => _ErrorCard(message: 'Error: $error'),
+              data: (contacts) => SacCard(
+                onTap: () => _navigateToEmergencyContacts(),
+                child: Row(
+                  children: [
+                    Container(
+                      width: 40,
+                      height: 40,
+                      decoration: BoxDecoration(
+                        color: contacts.isEmpty
+                            ? context.sac.surfaceVariant
+                            : AppColors.primaryLight,
+                        borderRadius: BorderRadius.circular(10),
+                      ),
+                      child: HugeIcon(
+                        icon: HugeIcons.strokeRoundedContactBook,
+                        size: 20,
+                        color: contacts.isEmpty
+                            ? context.sac.textTertiary
+                            : AppColors.primary,
+                      ),
+                    ),
+                    const SizedBox(width: 12),
+                    Expanded(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            contacts.isEmpty
+                                ? 'Sin contactos registrados'
+                                : '${contacts.length} contacto(s)',
+                            style: const TextStyle(
+                              fontSize: 15,
+                              fontWeight: FontWeight.w500,
+                            ),
+                          ),
+                          if (contacts.isEmpty)
+                            const Text(
+                              'Requerido: al menos 1',
+                              style: TextStyle(
+                                fontSize: 12,
+                                color: AppColors.accent,
+                              ),
+                            ),
+                        ],
+                      ),
+                    ),
+                    HugeIcon(
+                      icon: HugeIcons.strokeRoundedArrowRight01,
+                      color: context.sac.textTertiary,
+                    ),
+                  ],
+                ),
+              ),
+            ),
+            const SizedBox(height: 24),
+          ],
+
+          if (canReadLegalRepresentative)
+            requiresLegalRepAsync.when(
+              loading: () => const SizedBox.shrink(),
+              error: (_, __) => const SizedBox.shrink(),
+              data: (required) {
+                if (!required) return const SizedBox.shrink();
+
+                return Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    _SectionHeader(
+                      icon: HugeIcons.strokeRoundedUserGroup,
+                      title: 'Representante legal',
+                      isCompleted:
+                          legalRepAsync.hasValue && legalRepAsync.value != null,
+                    ),
+                    const SizedBox(height: 8),
+                    SacCard(
+                      backgroundColor: AppColors.accentLight,
+                      borderColor: AppColors.accent.withValues(alpha: 0.3),
+                      padding: const EdgeInsets.all(12),
+                      child: Row(
+                        children: [
+                          HugeIcon(
+                              icon: HugeIcons.strokeRoundedInformationCircle,
+                              size: 18,
+                              color: AppColors.accentDark),
+                          const SizedBox(width: 8),
+                          Expanded(
+                            child: Text(
+                              'Eres menor de 18 años, necesitas registrar un representante legal.',
+                              style: TextStyle(
+                                fontSize: 13,
+                                color: AppColors.accentDark,
+                                height: 1.3,
+                              ),
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                    const SizedBox(height: 12),
+                    legalRepAsync.when(
+                      loading: () => const Center(
+                        child: Padding(
+                          padding: EdgeInsets.all(16),
+                          child: SacLoadingSmall(),
+                        ),
+                      ),
+                      error: (error, _) => _ErrorCard(message: 'Error: $error'),
+                      data: (rep) => SacCard(
+                        onTap: () => _navigateToLegalRepresentative(),
+                        child: Row(
+                          children: [
+                            Container(
+                              width: 40,
+                              height: 40,
+                              decoration: BoxDecoration(
+                                color: rep != null
+                                    ? AppColors.primaryLight
+                                    : context.sac.surfaceVariant,
+                                borderRadius: BorderRadius.circular(10),
+                              ),
+                              child: HugeIcon(
+                                icon: HugeIcons.strokeRoundedUserGroup,
+                                size: 20,
+                                color: rep != null
+                                    ? AppColors.primary
+                                    : context.sac.textTertiary,
+                              ),
+                            ),
+                            const SizedBox(width: 12),
+                            Expanded(
+                              child: Text(
+                                rep != null
+                                    ? rep.fullName
+                                    : 'Sin representante registrado',
+                                style: const TextStyle(
+                                  fontSize: 15,
+                                  fontWeight: FontWeight.w500,
+                                ),
+                              ),
+                            ),
+                            HugeIcon(
+                              icon: HugeIcons.strokeRoundedArrowRight01,
+                              color: context.sac.textTertiary,
+                            ),
+                          ],
+                        ),
+                      ),
+                    ),
+                    const SizedBox(height: 24),
+                  ],
                 );
               },
             ),
-          ),
 
-          if (formState.baptized) ...[
+          if (canReadHealth) ...[
+            // === Section 3: Medical Info ===
+            _SectionHeader(
+              icon: HugeIcons.strokeRoundedFirstAidKit,
+              title: 'Información médica',
+              subtitle: 'Opcional',
+              isCompleted:
+                  selectedAllergies.isNotEmpty || selectedDiseases.isNotEmpty,
+            ),
             const SizedBox(height: 12),
-            _DatePickerCard(
-              label: 'Fecha de bautismo',
-              icon: HugeIcons.strokeRoundedBlood,
-              date: formState.baptismDate,
-              onTap: () => _selectBaptismDate(context),
-            ),
-          ],
-          const SizedBox(height: 28),
-
-          // === Section 2: Emergency Contacts ===
-          _SectionHeader(
-            icon: HugeIcons.strokeRoundedCall02,
-            title: 'Contactos de emergencia',
-            isCompleted: contactsAsync.hasValue &&
-                (contactsAsync.value?.isNotEmpty ?? false),
-          ),
-          const SizedBox(height: 8),
-          Text(
-            'Registra al menos un contacto de emergencia',
-            style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                  color: context.sac.textTertiary,
-                ),
-          ),
-          const SizedBox(height: 12),
-
-          contactsAsync.when(
-            loading: () => const Center(
-              child: Padding(
-                padding: EdgeInsets.all(16),
-                child: SacLoadingSmall(),
-              ),
-            ),
-            error: (error, _) => _ErrorCard(message: 'Error: $error'),
-            data: (contacts) => SacCard(
-              onTap: () => _navigateToEmergencyContacts(),
+            SacCard(
+              onTap: () => _navigateToAllergiesSelection(),
               child: Row(
                 children: [
                   Container(
                     width: 40,
                     height: 40,
                     decoration: BoxDecoration(
-                      color: contacts.isEmpty
-                          ? context.sac.surfaceVariant
-                          : AppColors.primaryLight,
+                      color: selectedAllergies.isNotEmpty
+                          ? AppColors.errorLight
+                          : context.sac.surfaceVariant,
                       borderRadius: BorderRadius.circular(10),
                     ),
                     child: HugeIcon(
-                      icon: HugeIcons.strokeRoundedContactBook,
+                      icon: HugeIcons.strokeRoundedBandage,
                       size: 20,
-                      color: contacts.isEmpty
-                          ? context.sac.textTertiary
-                          : AppColors.primary,
+                      color: selectedAllergies.isNotEmpty
+                          ? AppColors.error
+                          : context.sac.textTertiary,
                     ),
                   ),
                   const SizedBox(width: 12),
                   Expanded(
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Text(
-                          contacts.isEmpty
-                              ? 'Sin contactos registrados'
-                              : '${contacts.length} contacto(s)',
-                          style: const TextStyle(
-                            fontSize: 15,
-                            fontWeight: FontWeight.w500,
-                          ),
-                        ),
-                        if (contacts.isEmpty)
-                          const Text(
-                            'Requerido: al menos 1',
-                            style: TextStyle(
-                              fontSize: 12,
-                              color: AppColors.accent,
-                            ),
-                          ),
-                      ],
+                    child: Text(
+                      selectedAllergies.isEmpty
+                          ? 'Alergias'
+                          : '${selectedAllergies.length} alergia(s)',
+                      style: const TextStyle(
+                        fontSize: 15,
+                        fontWeight: FontWeight.w500,
+                      ),
                     ),
                   ),
                   HugeIcon(
@@ -258,204 +444,52 @@ class _PersonalInfoStepViewState extends ConsumerState<PersonalInfoStepView> {
                 ],
               ),
             ),
-          ),
-          const SizedBox(height: 24),
-
-          // === Legal Representative (conditional) ===
-          requiresLegalRepAsync.when(
-            loading: () => const SizedBox.shrink(),
-            error: (_, __) => const SizedBox.shrink(),
-            data: (required) {
-              if (!required) return const SizedBox.shrink();
-
-              return Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
+            const SizedBox(height: 12),
+            SacCard(
+              onTap: () => _navigateToDiseasesSelection(),
+              child: Row(
                 children: [
-                  _SectionHeader(
-                    icon: HugeIcons.strokeRoundedUserGroup,
-                    title: 'Representante legal',
-                    isCompleted:
-                        legalRepAsync.hasValue && legalRepAsync.value != null,
-                  ),
-                  const SizedBox(height: 8),
-                  SacCard(
-                    backgroundColor: AppColors.accentLight,
-                    borderColor: AppColors.accent.withValues(alpha: 0.3),
-                    padding: const EdgeInsets.all(12),
-                    child: Row(
-                      children: [
-                        HugeIcon(
-                            icon: HugeIcons.strokeRoundedInformationCircle,
-                            size: 18,
-                            color: AppColors.accentDark),
-                        const SizedBox(width: 8),
-                        Expanded(
-                          child: Text(
-                            'Eres menor de 18 años, necesitas registrar un representante legal.',
-                            style: TextStyle(
-                              fontSize: 13,
-                              color: AppColors.accentDark,
-                              height: 1.3,
-                            ),
-                          ),
-                        ),
-                      ],
+                  Container(
+                    width: 40,
+                    height: 40,
+                    decoration: BoxDecoration(
+                      color: selectedDiseases.isNotEmpty
+                          ? AppColors.accentLight
+                          : context.sac.surfaceVariant,
+                      borderRadius: BorderRadius.circular(10),
+                    ),
+                    child: HugeIcon(
+                      icon: HugeIcons.strokeRoundedStethoscope,
+                      size: 20,
+                      color: selectedDiseases.isNotEmpty
+                          ? AppColors.accent
+                          : context.sac.textTertiary,
                     ),
                   ),
-                  const SizedBox(height: 12),
-                  legalRepAsync.when(
-                    loading: () => const Center(
-                      child: Padding(
-                        padding: EdgeInsets.all(16),
-                        child: SacLoadingSmall(),
-                      ),
-                    ),
-                    error: (error, _) => _ErrorCard(message: 'Error: $error'),
-                    data: (rep) => SacCard(
-                      onTap: () => _navigateToLegalRepresentative(),
-                      child: Row(
-                        children: [
-                          Container(
-                            width: 40,
-                            height: 40,
-                            decoration: BoxDecoration(
-                              color: rep != null
-                                  ? AppColors.primaryLight
-                                  : context.sac.surfaceVariant,
-                              borderRadius: BorderRadius.circular(10),
-                            ),
-                            child: HugeIcon(
-                              icon: HugeIcons.strokeRoundedUserGroup,
-                              size: 20,
-                              color: rep != null
-                                  ? AppColors.primary
-                                  : context.sac.textTertiary,
-                            ),
-                          ),
-                          const SizedBox(width: 12),
-                          Expanded(
-                            child: Text(
-                              rep != null
-                                  ? rep.fullName
-                                  : 'Sin representante registrado',
-                              style: const TextStyle(
-                                fontSize: 15,
-                                fontWeight: FontWeight.w500,
-                              ),
-                            ),
-                          ),
-                          HugeIcon(
-                            icon: HugeIcons.strokeRoundedArrowRight01,
-                            color: context.sac.textTertiary,
-                          ),
-                        ],
+                  const SizedBox(width: 12),
+                  Expanded(
+                    child: Text(
+                      selectedDiseases.isEmpty
+                          ? 'Enfermedades'
+                          : '${selectedDiseases.length} enfermedad(es)',
+                      style: const TextStyle(
+                        fontSize: 15,
+                        fontWeight: FontWeight.w500,
                       ),
                     ),
                   ),
-                  const SizedBox(height: 24),
+                  HugeIcon(
+                    icon: HugeIcons.strokeRoundedArrowRight01,
+                    color: context.sac.textTertiary,
+                  ),
                 ],
-              );
-            },
-          ),
-
-          // === Section 3: Medical Info ===
-          _SectionHeader(
-            icon: HugeIcons.strokeRoundedFirstAidKit,
-            title: 'Información médica',
-            subtitle: 'Opcional',
-            isCompleted:
-                selectedAllergies.isNotEmpty || selectedDiseases.isNotEmpty,
-          ),
-          const SizedBox(height: 12),
-
-          // Allergies
-          SacCard(
-            onTap: () => _navigateToAllergiesSelection(),
-            child: Row(
-              children: [
-                Container(
-                  width: 40,
-                  height: 40,
-                  decoration: BoxDecoration(
-                    color: selectedAllergies.isNotEmpty
-                        ? AppColors.errorLight
-                        : context.sac.surfaceVariant,
-                    borderRadius: BorderRadius.circular(10),
-                  ),
-                  child: HugeIcon(
-                    icon: HugeIcons.strokeRoundedBandage,
-                    size: 20,
-                    color: selectedAllergies.isNotEmpty
-                        ? AppColors.error
-                        : context.sac.textTertiary,
-                  ),
-                ),
-                const SizedBox(width: 12),
-                Expanded(
-                  child: Text(
-                    selectedAllergies.isEmpty
-                        ? 'Alergias'
-                        : '${selectedAllergies.length} alergia(s)',
-                    style: const TextStyle(
-                      fontSize: 15,
-                      fontWeight: FontWeight.w500,
-                    ),
-                  ),
-                ),
-                HugeIcon(
-                  icon: HugeIcons.strokeRoundedArrowRight01,
-                  color: context.sac.textTertiary,
-                ),
-              ],
+              ),
             ),
-          ),
-          const SizedBox(height: 12),
-
-          // Diseases
-          SacCard(
-            onTap: () => _navigateToDiseasesSelection(),
-            child: Row(
-              children: [
-                Container(
-                  width: 40,
-                  height: 40,
-                  decoration: BoxDecoration(
-                    color: selectedDiseases.isNotEmpty
-                        ? AppColors.accentLight
-                        : context.sac.surfaceVariant,
-                    borderRadius: BorderRadius.circular(10),
-                  ),
-                  child: HugeIcon(
-                    icon: HugeIcons.strokeRoundedStethoscope,
-                    size: 20,
-                    color: selectedDiseases.isNotEmpty
-                        ? AppColors.accent
-                        : context.sac.textTertiary,
-                  ),
-                ),
-                const SizedBox(width: 12),
-                Expanded(
-                  child: Text(
-                    selectedDiseases.isEmpty
-                        ? 'Enfermedades'
-                        : '${selectedDiseases.length} enfermedad(es)',
-                    style: const TextStyle(
-                      fontSize: 15,
-                      fontWeight: FontWeight.w500,
-                    ),
-                  ),
-                ),
-                HugeIcon(
-                  icon: HugeIcons.strokeRoundedArrowRight01,
-                  color: context.sac.textTertiary,
-                ),
-              ],
-            ),
-          ),
-          const SizedBox(height: 24),
+            const SizedBox(height: 24),
+          ],
 
           // Warning if incomplete
-          if (!canComplete)
+          if (widget.canReadSensitiveData && !canComplete)
             SacCard(
               backgroundColor: AppColors.accentLight,
               borderColor: AppColors.accent.withValues(alpha: 0.3),
@@ -495,7 +529,7 @@ class _PersonalInfoStepViewState extends ConsumerState<PersonalInfoStepView> {
     final picked = await showDatePicker(
       context: context,
       initialDate: initialDate,
-      firstDate: minDate, 
+      firstDate: minDate,
       lastDate: maxDate,
       helpText: 'Selecciona tu fecha de nacimiento',
       cancelText: 'Cancelar',
@@ -651,9 +685,8 @@ class _GenderChip extends StatelessWidget {
               buildIcon(
                 icon,
                 size: 20,
-                color: isSelected
-                    ? AppColors.primary
-                    : context.sac.textSecondary,
+                color:
+                    isSelected ? AppColors.primary : context.sac.textSecondary,
               ),
               const SizedBox(width: 8),
               Text(
@@ -706,9 +739,8 @@ class _DatePickerCard extends StatelessWidget {
             child: buildIcon(
               icon,
               size: 20,
-              color: date != null
-                  ? AppColors.primary
-                  : context.sac.textTertiary,
+              color:
+                  date != null ? AppColors.primary : context.sac.textTertiary,
             ),
           ),
           const SizedBox(width: 12),

--- a/lib/features/post_registration/presentation/views/post_registration_shell.dart
+++ b/lib/features/post_registration/presentation/views/post_registration_shell.dart
@@ -6,6 +6,8 @@ import 'package:sacdia_app/core/config/route_names.dart';
 import 'package:sacdia_app/core/theme/app_colors.dart';
 import 'package:sacdia_app/core/theme/sac_colors.dart';
 import 'package:sacdia_app/core/utils/responsive.dart';
+import 'package:sacdia_app/features/auth/domain/entities/user_entity.dart';
+import 'package:sacdia_app/features/auth/domain/utils/authorization_utils.dart';
 import '../../../auth/presentation/providers/auth_providers.dart';
 import '../providers/post_registration_providers.dart';
 import '../widgets/bottom_navigation_buttons.dart';
@@ -15,6 +17,25 @@ import 'personal_info_step_view.dart';
 import 'photo_step_view.dart';
 import '../providers/club_selection_providers.dart';
 import '../providers/personal_info_providers.dart';
+
+bool canReadSensitiveStep2Data(String targetUserId, UserEntity? user) {
+  return canAccessSensitiveUserDataForUser(user, targetUserId: targetUserId) ||
+      canReadSensitiveUserFamilyForUser(
+        user,
+        targetUserId: targetUserId,
+        family: SensitiveUserFamily.emergencyContacts,
+      ) ||
+      canReadSensitiveUserFamilyForUser(
+        user,
+        targetUserId: targetUserId,
+        family: SensitiveUserFamily.legalRepresentative,
+      ) ||
+      canReadSensitiveUserFamilyForUser(
+        user,
+        targetUserId: targetUserId,
+        family: SensitiveUserFamily.health,
+      );
+}
 
 /// Shell del post-registro - Estilo "Scout Vibrante"
 ///
@@ -118,9 +139,21 @@ class _PostRegistrationShellState extends ConsumerState<PostRegistrationShell> {
   }
 
   Future<void> _completeStep2() async {
+    final authState = ref.read(authNotifierProvider);
+    final user = authState.valueOrNull;
+    final userId = user?.id;
+    if (userId == null) return;
+
+    final canReadSensitiveData = canReadSensitiveStep2Data(userId, user);
+
     try {
-      final saveInfo = ref.read(savePersonalInfoProvider);
-      await saveInfo();
+      if (canReadSensitiveData) {
+        final saveInfo = ref.read(savePersonalInfoProvider);
+        await saveInfo();
+      } else {
+        final dataSource = ref.read(personalInfoDataSourceProvider);
+        await dataSource.completeStep2(userId);
+      }
       if (mounted) _goToStep(3);
     } catch (e) {
       if (!mounted) return;
@@ -215,9 +248,18 @@ class _PostRegistrationShellState extends ConsumerState<PostRegistrationShell> {
   @override
   Widget build(BuildContext context) {
     final currentStep = ref.watch(currentStepProvider);
+    final authUser = ref.watch(authNotifierProvider).valueOrNull;
     final selectedPhoto = ref.watch(selectedPhotoPathProvider);
     final isUploading = ref.watch(isUploadingPhotoProvider);
     final hPad = Responsive.horizontalPadding(context);
+    final targetUserId = authUser?.id ?? '';
+    final canReadStep2SensitiveData =
+        canReadSensitiveStep2Data(targetUserId, authUser);
+    final canManageStep2AdministrativeCompletion =
+        canManageAdministrativeCompletionForUser(
+      authUser,
+      targetUserId: targetUserId,
+    );
 
     bool canContinue = false;
     switch (currentStep) {
@@ -225,7 +267,9 @@ class _PostRegistrationShellState extends ConsumerState<PostRegistrationShell> {
         canContinue = selectedPhoto != null && !isUploading;
         break;
       case 2:
-        canContinue = ref.watch(canCompleteStep2Provider);
+        canContinue = canReadStep2SensitiveData
+            ? ref.watch(canCompleteStep2Provider)
+            : canManageStep2AdministrativeCompletion;
         break;
       case 3:
         final canComplete3 = ref.watch(canCompleteStep3Provider);
@@ -309,10 +353,15 @@ class _PostRegistrationShellState extends ConsumerState<PostRegistrationShell> {
               child: PageView(
                 controller: _pageController,
                 physics: const NeverScrollableScrollPhysics(),
-                children: const [
-                  PhotoStepView(),
-                  PersonalInfoStepView(),
-                  ClubSelectionStepView(),
+                children: [
+                  const PhotoStepView(),
+                  PersonalInfoStepView(
+                    canReadSensitiveData: canReadStep2SensitiveData,
+                    canManageAdministrativeCompletion:
+                        canManageStep2AdministrativeCompletion,
+                    targetUserId: targetUserId,
+                  ),
+                  const ClubSelectionStepView(),
                 ],
               ),
             ),

--- a/lib/features/seguros/presentation/providers/seguros_providers.dart
+++ b/lib/features/seguros/presentation/providers/seguros_providers.dart
@@ -62,7 +62,6 @@ final canManageSegurosProvider = FutureProvider.autoDispose<bool>((ref) async {
   return canByPermissionOrLegacyRole(
     authState,
     requiredPermissions: const {
-      'users:update',
       'club_roles:assign',
     },
     legacyRoles: _segurosEditorRoles,

--- a/test/features/auth/domain/utils/authorization_utils_test.dart
+++ b/test/features/auth/domain/utils/authorization_utils_test.dart
@@ -99,5 +99,79 @@ void main() {
         isTrue,
       );
     });
+
+    test('allows fine-grained sensitive family reads with legacy fallback', () {
+      final fineGrained = buildUser(
+        id: 'actor',
+        permissions: const ['health:read', 'emergency_contacts:read'],
+      );
+      final legacy = buildUser(
+        id: 'actor',
+        permissions: const ['users:read_detail'],
+      );
+
+      expect(
+        canReadSensitiveUserFamilyForUser(
+          fineGrained,
+          targetUserId: 'target',
+          family: SensitiveUserFamily.health,
+        ),
+        isTrue,
+      );
+      expect(
+        canReadSensitiveUserFamilyForUser(
+          fineGrained,
+          targetUserId: 'target',
+          family: SensitiveUserFamily.emergencyContacts,
+        ),
+        isTrue,
+      );
+      expect(
+        canReadSensitiveUserFamilyForUser(
+          legacy,
+          targetUserId: 'target',
+          family: SensitiveUserFamily.legalRepresentative,
+        ),
+        isTrue,
+      );
+    });
+
+    test(
+        'allows fine-grained updates without treating users:update as sensitive read',
+        () {
+      final updater = buildUser(
+        id: 'actor',
+        permissions: const ['users:update'],
+      );
+      final fineGrained = buildUser(
+        id: 'actor',
+        permissions: const ['legal_representative:update'],
+      );
+
+      expect(
+        canUpdateSensitiveUserFamilyForUser(
+          updater,
+          targetUserId: 'target',
+          family: SensitiveUserFamily.postRegistration,
+        ),
+        isTrue,
+      );
+      expect(
+        canReadSensitiveUserFamilyForUser(
+          updater,
+          targetUserId: 'target',
+          family: SensitiveUserFamily.postRegistration,
+        ),
+        isFalse,
+      );
+      expect(
+        canUpdateSensitiveUserFamilyForUser(
+          fineGrained,
+          targetUserId: 'target',
+          family: SensitiveUserFamily.legalRepresentative,
+        ),
+        isTrue,
+      );
+    });
   });
 }

--- a/test/features/auth/domain/utils/authorization_utils_test.dart
+++ b/test/features/auth/domain/utils/authorization_utils_test.dart
@@ -1,0 +1,103 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sacdia_app/features/auth/domain/entities/authorization_snapshot.dart';
+import 'package:sacdia_app/features/auth/domain/entities/user_entity.dart';
+import 'package:sacdia_app/features/auth/domain/utils/authorization_utils.dart';
+
+UserEntity buildUser({
+  required String id,
+  List<String> permissions = const [],
+  List<AuthorizationGrant> globalGrants = const [],
+  List<AuthorizationGrant> clubAssignments = const [],
+}) {
+  return UserEntity(
+    id: id,
+    email: '$id@example.com',
+    authorization: AuthorizationSnapshot(
+      effectivePermissions: permissions,
+      globalGrants: globalGrants,
+      clubAssignments: clubAssignments,
+    ),
+  );
+}
+
+void main() {
+  group('authorization utils', () {
+    test('uses canonical permissions from authorization snapshot', () {
+      final user = buildUser(
+        id: 'actor',
+        permissions: const ['Users:Read_Detail', 'users:update'],
+      );
+
+      expect(
+        extractUserPermissions(user),
+        {'users:read_detail', 'users:update'},
+      );
+    });
+
+    test('uses resolved role names from authorization grants', () {
+      final user = buildUser(
+        id: 'actor',
+        clubAssignments: const [
+          AuthorizationGrant(roleName: 'Director'),
+          AuthorizationGrant(roleName: 'Secretary'),
+        ],
+      );
+
+      expect(extractUserRoles(user), {'director', 'secretary'});
+    });
+
+    test(
+        'allows third-party administrative completion with explicit global access',
+        () {
+      final user = buildUser(
+        id: 'actor',
+        permissions: const ['users:update'],
+      );
+
+      expect(
+        canViewAdministrativeCompletionForUser(
+          user,
+          targetUserId: 'target',
+        ),
+        isTrue,
+      );
+      expect(
+        canManageAdministrativeCompletionForUser(
+          user,
+          targetUserId: 'target',
+        ),
+        isTrue,
+      );
+    });
+
+    test('does not treat generic users:update as sensitive data access', () {
+      final user = buildUser(
+        id: 'actor',
+        permissions: const ['users:update'],
+      );
+
+      expect(
+        canAccessSensitiveUserDataForUser(user, targetUserId: 'target'),
+        isFalse,
+      );
+    });
+
+    test('allows sensitive data access only for owner or users:read_detail',
+        () {
+      final reader = buildUser(
+        id: 'actor',
+        permissions: const ['users:read_detail'],
+      );
+      final owner = buildUser(id: 'target');
+
+      expect(
+        canAccessSensitiveUserDataForUser(reader, targetUserId: 'target'),
+        isTrue,
+      );
+      expect(
+        canAccessSensitiveUserDataForUser(owner, targetUserId: 'target'),
+        isTrue,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- align mobile authorization utilities with fine-grained sensitive user families and legacy fallback semantics
- separate administrative post-registration completion from sensitive user data access in the post-registration flow
- update mobile post-registration views to respect pruned sensitive payloads coming from backend

## Test Plan
- `flutter test test/features/auth/domain/utils/authorization_utils_test.dart`
- `flutter analyze lib/features/auth/domain/utils/authorization_utils.dart lib/features/post_registration/presentation/views/personal_info_step_view.dart lib/features/post_registration/presentation/views/post_registration_shell.dart`