### PR TITLE
Release: Dashboard Wiring + OAuth + Units + Insurance

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -18,7 +18,7 @@
         <activity
             android:name=".MainActivity"
             android:exported="true"
-            android:launchMode="singleTop"
+            android:launchMode="singleTask"
             android:taskAffinity=""
             android:theme="@style/LaunchTheme"
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"
@@ -35,6 +35,16 @@
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>
+            </intent-filter>
+            <!-- Deep link para OAuth callbacks: io.sacdia.app://auth/callback -->
+            <intent-filter android:autoVerify="false">
+                <action android:name="android.intent.action.VIEW"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+                <category android:name="android.intent.category.BROWSABLE"/>
+                <data
+                    android:scheme="io.sacdia.app"
+                    android:host="auth"
+                    android:pathPrefix="/callback"/>
             </intent-filter>
         </activity>
         <!-- Don't delete the meta-data below.

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -65,6 +65,21 @@
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>
 	<string>Main</string>
+	<!-- Habilita deep links via Flutter (requerido por supabase_flutter para OAuth callbacks) -->
+	<key>FlutterDeepLinkingEnabled</key>
+	<true/>
+	<!-- URL scheme para OAuth callbacks: io.sacdia.app://auth/callback -->
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>io.sacdia.app</string>
+			</array>
+		</dict>
+	</array>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>

--- a/lib/features/auth/data/datasources/auth_remote_data_source.dart
+++ b/lib/features/auth/data/datasources/auth_remote_data_source.dart
@@ -55,6 +55,15 @@ abstract class AuthRemoteDataSource {
   /// Cambia el contexto activo de autorización del usuario.
   /// Llama a PATCH /auth/me/context con el assignment_id indicado.
   Future<void> switchContext(String assignmentId);
+
+  /// Intercambia el [supabaseAccessToken] (recibido en el deep link OAuth) por
+  /// el JWT interno de SACDIA.
+  ///
+  /// Llama a `GET /auth/oauth/callback?access_token=<token>` en el backend,
+  /// que valida el token de Supabase y devuelve las credenciales de SACDIA.
+  /// Internamente invoca [_saveToken] para persistir la sesión y emitir
+  /// el evento correspondiente en [authStateChanges].
+  Future<UserModel> handleOAuthCallback(String supabaseAccessToken);
 }
 
 /// Implementación de la fuente de datos remota con Dio para API personalizada
@@ -663,6 +672,71 @@ class AuthRemoteDataSourceImpl implements AuthRemoteDataSource {
       throw AuthException(
         message: 'Error al iniciar sesión con Apple. Intenta de nuevo.',
       );
+    }
+  }
+
+  // ── OAuth Callback ────────────────────────────────────────────────────────────
+  //
+  // Llamado desde AuthNotifier cuando Supabase dispara onAuthStateChange con
+  // evento signedIn después de un flujo OAuth.  El backend valida el access
+  // token de Supabase y devuelve las credenciales internas de SACDIA.
+
+  @override
+  Future<UserModel> handleOAuthCallback(String supabaseAccessToken) async {
+    try {
+      AppLogger.i('Procesando OAuth callback con backend SACDIA', tag: _tag);
+
+      final response = await _dio.get(
+        '$_baseUrl/auth/oauth/callback',
+        queryParameters: {'access_token': supabaseAccessToken},
+      );
+
+      if (response.statusCode != 200 && response.statusCode != 201) {
+        throw AuthException(
+          message: response.data?['message'] ?? 'Error en OAuth callback',
+        );
+      }
+
+      final responseData = response.data['data'] as Map<String, dynamic>?;
+      if (responseData == null) {
+        throw AuthException(message: 'Respuesta del servidor inválida');
+      }
+
+      final token = responseData['accessToken'] as String?;
+      if (token == null) {
+        throw AuthException(message: 'No se recibió token de autenticación');
+      }
+
+      await _saveToken(
+        token,
+        refreshToken: responseData['refreshToken'] as String?,
+        expiresAt: responseData['expiresAt'] as int?,
+        tokenType: responseData['tokenType'] as String?,
+      );
+
+      final userData = responseData['user'] as Map<String, dynamic>?;
+      final userId = userData?['id'] as String?;
+      if (userId == null) {
+        throw AuthException(message: 'No se recibió ID de usuario');
+      }
+
+      final needsPostRegistration =
+          responseData['needsPostRegistration'] as bool? ?? true;
+
+      AppLogger.i('OAuth callback procesado exitosamente', tag: _tag);
+      return UserModel(
+        id: userId,
+        email: userData?['email'] as String? ?? '',
+        name: userData?['name'] as String? ?? '',
+        postRegisterComplete: !needsPostRegistration,
+      );
+    } catch (e) {
+      AppLogger.e('Error en OAuth callback', tag: _tag, error: e);
+      if (e is DioException) {
+        throw AuthException(message: e.message ?? 'Error de conexión');
+      }
+      if (e is AuthException) rethrow;
+      throw AuthException(message: e.toString());
     }
   }
 

--- a/lib/features/auth/data/repositories/auth_repository_impl.dart
+++ b/lib/features/auth/data/repositories/auth_repository_impl.dart
@@ -168,6 +168,26 @@ class AuthRepositoryImpl implements AuthRepository {
   }
 
   @override
+  Future<Either<Failure, UserEntity>> handleOAuthCallback(
+    String supabaseAccessToken,
+  ) async {
+    if (await networkInfo.isConnected) {
+      try {
+        final user = await remoteDataSource.handleOAuthCallback(
+          supabaseAccessToken,
+        );
+        return Right(user);
+      } on core_exceptions.AuthException catch (e) {
+        return Left(AuthFailure(message: e.message, code: e.code));
+      } catch (e) {
+        return Left(ServerFailure(message: e.toString()));
+      }
+    } else {
+      return Left(NetworkFailure(message: 'No hay conexión a internet'));
+    }
+  }
+
+  @override
   Future<bool> hasLocalToken() async {
     return remoteDataSource.hasLocalToken();
   }

--- a/lib/features/auth/domain/repositories/auth_repository.dart
+++ b/lib/features/auth/domain/repositories/auth_repository.dart
@@ -48,4 +48,14 @@ abstract class AuthRepository {
 
   /// Cambia el contexto activo de autorización del usuario.
   Future<Either<Failure, void>> switchContext(String assignmentId);
+
+  /// Intercambia el access_token de Supabase (recibido por deep link OAuth)
+  /// por el JWT interno de SACDIA y persiste la sesión.
+  ///
+  /// Llamar cuando Supabase dispara [onAuthStateChange] con evento signedIn
+  /// después de un flujo OAuth. El backend en `/auth/oauth/callback` valida
+  /// el token de Supabase y devuelve el JWT de SACDIA.
+  Future<Either<Failure, UserEntity>> handleOAuthCallback(
+    String supabaseAccessToken,
+  );
 }

--- a/lib/features/auth/presentation/providers/auth_providers.dart
+++ b/lib/features/auth/presentation/providers/auth_providers.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:supabase_flutter/supabase_flutter.dart' as supabase;
 
 import '../../../../core/errors/failures.dart';
 import '../../../../core/network/network_info.dart';
@@ -95,6 +96,53 @@ class AuthNotifier extends AsyncNotifier<UserEntity?> {
   @override
   Future<UserEntity?> build() async {
     final repository = ref.read(authRepositoryProvider);
+
+    // ── Supabase onAuthStateChange → OAuth callback handler ───────────────────
+    //
+    // supabase_flutter ≥ 2.x con FlutterDeepLinkingEnabled=true (iOS) y el
+    // intent-filter correcto (Android) recibe automáticamente el deep link
+    // `io.sacdia.app://auth/callback`, llama a getSessionFromUrl() internamente
+    // y dispara este stream con evento signedIn.
+    //
+    // Cuando eso ocurre, intercambiamos el access_token de Supabase por el JWT
+    // interno de SACDIA usando el endpoint /auth/oauth/callback del backend.
+    //
+    // ref.onDispose cancela la suscripción si el notifier es destruido.
+    final supabaseAuthSub = supabase.Supabase.instance.client.auth
+        .onAuthStateChange
+        .listen((authState) async {
+      if (authState.event == supabase.AuthChangeEvent.signedIn) {
+        final accessToken = authState.session?.accessToken;
+        if (accessToken == null) return;
+
+        // Evitar procesar si ya tenemos una sesión SACDIA válida
+        // (login por email/password también dispara signedIn).
+        // Solo actuar si el estado actual es null (post-OAuth redirect).
+        if (state.valueOrNull != null) return;
+
+        AppLogger.i('Supabase signedIn detectado — procesando OAuth callback',
+            tag: _tag);
+
+        final result = await repository.handleOAuthCallback(accessToken);
+        result.fold(
+          (failure) {
+            AppLogger.e(
+              'Error al procesar OAuth callback: ${failure.message}',
+              tag: _tag,
+            );
+            state = AsyncValue.error(failure.message, StackTrace.current);
+          },
+          (user) {
+            AppLogger.i('OAuth completado: ${user.email}', tag: _tag);
+            ref.read(isUserLoggedOutProvider.notifier).state = false;
+            _cacheUser(user);
+            state = AsyncValue.data(user);
+          },
+        );
+      }
+    });
+
+    ref.onDispose(supabaseAuthSub.cancel);
 
     AppLogger.i('Verificando token local', tag: _tag);
     final hasToken = await repository.hasLocalToken();

--- a/lib/features/dashboard/data/datasources/dashboard_remote_data_source.dart
+++ b/lib/features/dashboard/data/datasources/dashboard_remote_data_source.dart
@@ -1,62 +1,89 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+
 import '../../../../core/errors/exceptions.dart';
 import '../../../../core/utils/app_logger.dart';
 import '../models/dashboard_summary_model.dart';
 
 /// Interfaz para la fuente de datos remota del dashboard
 abstract class DashboardRemoteDataSource {
-  /// Obtiene los datos del dashboard para un usuario
-  Future<DashboardSummaryModel> getDashboardData(
-    String userId, {
-    Map<String, dynamic>? userMetadata,
-  });
+  /// Obtiene el resumen del dashboard del usuario autenticado
+  Future<DashboardSummaryModel> getDashboardSummary();
 }
 
 /// Implementación de la fuente de datos remota del dashboard
+///
+/// Endpoint: GET /api/v1/dashboard/summary
 class DashboardRemoteDataSourceImpl implements DashboardRemoteDataSource {
+  final Dio _dio;
+  final String _baseUrl;
+  final FlutterSecureStorage _secureStorage;
+
   static const _tag = 'DashboardDS';
 
-  const DashboardRemoteDataSourceImpl();
+  DashboardRemoteDataSourceImpl({
+    required Dio dio,
+    required String baseUrl,
+  })  : _dio = dio,
+        _baseUrl = baseUrl,
+        _secureStorage = const FlutterSecureStorage();
+
+  Future<String> _getAuthToken() async {
+    final token = await _secureStorage.read(key: 'auth_token');
+    if (token == null) throw AuthException(message: 'No hay sesión activa');
+    return token;
+  }
+
+  Options _authOptions(String token) =>
+      Options(headers: {'Authorization': 'Bearer $token'});
 
   @override
-  Future<DashboardSummaryModel> getDashboardData(
-    String userId, {
-    Map<String, dynamic>? userMetadata,
-  }) async {
+  Future<DashboardSummaryModel> getDashboardSummary() async {
     try {
-      final userData = userMetadata ?? {};
+      final token = await _getAuthToken();
+      final response = await _dio.get(
+        '$_baseUrl/dashboard/summary',
+        options: _authOptions(token),
+      );
 
-      final firstName = (userData['name'] as String?) ?? '';
-      final paternalLn = (userData['paternal_last_name'] as String?) ?? '';
-      final maternalLn = (userData['maternal_last_name'] as String?) ?? '';
-      final fullName = [firstName, paternalLn, maternalLn]
-          .where((s) => s.isNotEmpty)
-          .join(' ');
+      if (response.statusCode == 200 || response.statusCode == 201) {
+        final body = response.data;
+        final json = body is Map<String, dynamic>
+            ? (body.containsKey('data')
+                ? body['data'] as Map<String, dynamic>
+                : body)
+            : body as Map<String, dynamic>;
+        return DashboardSummaryModel.fromJson(json);
+      }
 
-      final rawRoles = userData['roles'] as List<dynamic>?;
-      final firstRole = rawRoles?.isNotEmpty == true
-          ? rawRoles!.first as String?
-          : null;
-
-      final clubData = userData['club'] as Map<String, dynamic>?;
-
-      final dashboardData = {
-        'user_name': fullName.isNotEmpty ? fullName : 'Usuario',
-        'user_avatar': userData['user_image'] as String?,
-        'club_name': clubData?['club_name'] as String?,
-        'club_type': clubData?['club_type'] as String?,
-        'user_role': firstRole,
-        'current_class_name': null,
-        'class_progress': 0.0,
-        'honors_completed': 0,
-        'honors_in_progress': 0,
-        'upcoming_activities': <Map<String, dynamic>>[],
-      };
-
-      return DashboardSummaryModel.fromJson(dashboardData);
+      throw ServerException(
+        message: 'Error al obtener el resumen del dashboard',
+        code: response.statusCode,
+      );
     } catch (e) {
-      if (e is AuthException || e is ServerException) rethrow;
-      AppLogger.e('Error inesperado en dashboard', tag: _tag, error: e);
-      throw ServerException(message: e.toString());
+      AppLogger.e('Error en getDashboardSummary', tag: _tag, error: e);
+      _rethrow(e);
     }
+  }
+
+  // ── Helpers ───────────────────────────────────────────────────────────────────
+
+  Never _rethrow(Object e) {
+    if (e is DioException) {
+      final msg = _extractDioMessage(e);
+      throw ServerException(message: msg, code: e.response?.statusCode);
+    }
+    if (e is ServerException || e is AuthException) throw e;
+    throw ServerException(message: e.toString());
+  }
+
+  String _extractDioMessage(DioException e) {
+    try {
+      final data = e.response?.data;
+      if (data is Map) {
+        return (data['message'] ?? e.message ?? 'Error de conexión').toString();
+      }
+    } catch (_) {}
+    return e.message ?? 'Error de conexión';
   }
 }

--- a/lib/features/dashboard/data/repositories/dashboard_repository_impl.dart
+++ b/lib/features/dashboard/data/repositories/dashboard_repository_impl.dart
@@ -18,16 +18,10 @@ class DashboardRepositoryImpl implements DashboardRepository {
   });
 
   @override
-  Future<Either<Failure, DashboardSummary>> getDashboardData(
-    String userId, {
-    Map<String, dynamic>? userMetadata,
-  }) async {
+  Future<Either<Failure, DashboardSummary>> getDashboardSummary() async {
     if (await networkInfo.isConnected) {
       try {
-        final dashboardData = await remoteDataSource.getDashboardData(
-          userId,
-          userMetadata: userMetadata,
-        );
+        final dashboardData = await remoteDataSource.getDashboardSummary();
         return Right(dashboardData);
       } on AuthException catch (e) {
         return Left(AuthFailure(message: e.message, code: e.code));

--- a/lib/features/dashboard/domain/repositories/dashboard_repository.dart
+++ b/lib/features/dashboard/domain/repositories/dashboard_repository.dart
@@ -5,9 +5,6 @@ import '../entities/dashboard_summary.dart';
 
 /// Interfaz del repositorio de dashboard
 abstract class DashboardRepository {
-  /// Obtiene el resumen del dashboard para un usuario
-  Future<Either<Failure, DashboardSummary>> getDashboardData(
-    String userId, {
-    Map<String, dynamic>? userMetadata,
-  });
+  /// Obtiene el resumen del dashboard del usuario autenticado
+  Future<Either<Failure, DashboardSummary>> getDashboardSummary();
 }

--- a/lib/features/dashboard/domain/usecases/get_dashboard_data.dart
+++ b/lib/features/dashboard/domain/usecases/get_dashboard_data.dart
@@ -5,28 +5,14 @@ import '../../../../core/usecases/usecase.dart';
 import '../entities/dashboard_summary.dart';
 import '../repositories/dashboard_repository.dart';
 
-/// Parámetros para obtener datos del dashboard
-class GetDashboardDataParams {
-  final String userId;
-  final Map<String, dynamic>? userMetadata;
-
-  const GetDashboardDataParams({
-    required this.userId,
-    this.userMetadata,
-  });
-}
-
-/// Caso de uso para obtener los datos del dashboard
-class GetDashboardData implements UseCase<DashboardSummary, GetDashboardDataParams> {
+/// Caso de uso para obtener el resumen del dashboard del usuario autenticado
+class GetDashboardSummary implements UseCase<DashboardSummary, NoParams> {
   final DashboardRepository repository;
 
-  GetDashboardData(this.repository);
+  GetDashboardSummary(this.repository);
 
   @override
-  Future<Either<Failure, DashboardSummary>> call(GetDashboardDataParams params) async {
-    return await repository.getDashboardData(
-      params.userId,
-      userMetadata: params.userMetadata,
-    );
+  Future<Either<Failure, DashboardSummary>> call(NoParams params) async {
+    return await repository.getDashboardSummary();
   }
 }

--- a/lib/features/dashboard/presentation/providers/dashboard_providers.dart
+++ b/lib/features/dashboard/presentation/providers/dashboard_providers.dart
@@ -1,5 +1,7 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../../../core/usecases/usecase.dart';
+import '../../../../providers/dio_provider.dart';
 import '../../../auth/presentation/providers/auth_providers.dart';
 import '../../data/datasources/dashboard_remote_data_source.dart';
 import '../../data/repositories/dashboard_repository_impl.dart';
@@ -9,43 +11,40 @@ import '../../domain/usecases/get_dashboard_data.dart';
 
 /// Provider para la fuente de datos remota del dashboard
 final dashboardRemoteDataSourceProvider = Provider<DashboardRemoteDataSource>((ref) {
-  return const DashboardRemoteDataSourceImpl();
+  return DashboardRemoteDataSourceImpl(
+    dio: ref.read(dioProvider),
+    baseUrl: ref.read(apiBaseUrlProvider),
+  );
 });
 
 /// Provider para el repositorio del dashboard
 final dashboardRepositoryProvider = Provider<DashboardRepository>((ref) {
-  final networkInfo = ref.read(networkInfoProvider);
-  final remoteDataSource = ref.read(dashboardRemoteDataSourceProvider);
-
   return DashboardRepositoryImpl(
-    remoteDataSource: remoteDataSource,
-    networkInfo: networkInfo,
+    remoteDataSource: ref.read(dashboardRemoteDataSourceProvider),
+    networkInfo: ref.read(networkInfoProvider),
   );
 });
 
-/// Provider para el caso de uso de obtener datos del dashboard
-final getDashboardDataProvider = Provider<GetDashboardData>((ref) {
-  return GetDashboardData(ref.read(dashboardRepositoryProvider));
+/// Provider para el caso de uso de obtener el resumen del dashboard
+final getDashboardSummaryProvider = Provider<GetDashboardSummary>((ref) {
+  return GetDashboardSummary(ref.read(dashboardRepositoryProvider));
 });
 
 /// Notifier para manejar los datos del dashboard
 class DashboardNotifier extends AsyncNotifier<DashboardSummary?> {
   @override
   Future<DashboardSummary?> build() async {
-    // Solo reaccionar a cambios en el ID del usuario (evita cascadas por cambios de metadata).
+    // Reaccionar a cambios en la sesión: si el usuario se desloguea, limpiar.
     final userId = await ref.watch(
       authNotifierProvider.selectAsync((user) => user?.id),
     );
     if (userId == null) return null;
 
-    // Leer el usuario completo sin suscripción para obtener metadata.
-    final user = await ref.read(authNotifierProvider.future);
+    return _fetch();
+  }
 
-    // Obtener los datos del dashboard
-    final result = await ref.read(getDashboardDataProvider)(
-      GetDashboardDataParams(userId: user!.id, userMetadata: user.metadata),
-    );
-
+  Future<DashboardSummary?> _fetch() async {
+    final result = await ref.read(getDashboardSummaryProvider)(const NoParams());
     return result.fold(
       (failure) => null,
       (dashboard) => dashboard,
@@ -56,19 +55,7 @@ class DashboardNotifier extends AsyncNotifier<DashboardSummary?> {
   Future<void> refresh() async {
     state = const AsyncValue.loading();
 
-    final user = await ref.read(authNotifierProvider.future);
-
-    if (user == null) {
-      state = AsyncValue.error(
-        'No hay usuario autenticado',
-        StackTrace.current,
-      );
-      return;
-    }
-
-    final result = await ref.read(getDashboardDataProvider)(
-      GetDashboardDataParams(userId: user.id, userMetadata: user.metadata),
-    );
+    final result = await ref.read(getDashboardSummaryProvider)(const NoParams());
 
     state = result.fold(
       (failure) => AsyncValue.error(failure.message, StackTrace.current),


### PR DESCRIPTION
## Summary
- Dashboard home screen wired a API real (reemplaza hardcoded null/0/[])
- OAuth Google/Apple: deep link config (Info.plist + AndroidManifest), callback exchange con backend
- Units feature: stack completo Clean Architecture conectado a backend real
- Insurance expiring alerts wired
- Loading polish integrado

## Test plan
- [ ] `flutter analyze` clean
- [ ] `flutter test` passing
- [ ] Home screen muestra datos reales del dashboard
- [ ] Units screens cargan desde API
- [ ] OAuth buttons visibles (funcional post-config Supabase)