### PR TITLE
feat(rankings): 8.4-A mobile — Flutter Clean Architecture + 2 screens + nav wiring

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -2760,7 +2760,9 @@
       "grouped_class": "Group Class",
       "insurance": "Club Insurance",
       "inventory": "Inventory",
-      "resources": "Resources"
+      "resources": "Resources",
+      "my_ranking": "My ranking",
+      "section_ranking": "Section ranking"
     },
     "stats": {
       "honors_completed": "Honors completed",

--- a/assets/translations/es.json
+++ b/assets/translations/es.json
@@ -2760,7 +2760,9 @@
       "grouped_class": "Clase Agrupada",
       "insurance": "Seguros del Club",
       "inventory": "Inventario",
-      "resources": "Recursos"
+      "resources": "Recursos",
+      "my_ranking": "Mi ranking",
+      "section_ranking": "Ranking de sección"
     },
     "stats": {
       "honors_completed": "Esp. completadas",

--- a/assets/translations/fr.json
+++ b/assets/translations/fr.json
@@ -2760,7 +2760,9 @@
       "grouped_class": "Classe groupée",
       "insurance": "Assurances du club",
       "inventory": "Inventaire",
-      "resources": "Ressources"
+      "resources": "Ressources",
+      "my_ranking": "Mon classement",
+      "section_ranking": "Classement de section"
     },
     "stats": {
       "honors_completed": "Spéc. terminées",

--- a/assets/translations/pt-BR.json
+++ b/assets/translations/pt-BR.json
@@ -2760,7 +2760,9 @@
       "grouped_class": "Aula em Grupo",
       "insurance": "Seguros do Clube",
       "inventory": "Inventário",
-      "resources": "Recursos"
+      "resources": "Recursos",
+      "my_ranking": "Meu ranking",
+      "section_ranking": "Ranking da seção"
     },
     "stats": {
       "honors_completed": "Esp. concluídas",

--- a/lib/core/config/route_names.dart
+++ b/lib/core/config/route_names.dart
@@ -160,4 +160,11 @@ class RouteNames {
       '/camporee/$camporeeId/member/$memberId/payments';
   static String camporeeEnrollClubPath(int camporeeId) =>
       '/camporee/$camporeeId/enroll-club';
+
+  // Rankings
+  static const String homeMyRanking = '/home/my-ranking';
+  static const String sectionRanking = '/section-ranking/:sectionId';
+
+  static String sectionRankingPath(int sectionId) =>
+      '/section-ranking/$sectionId';
 }

--- a/lib/core/config/router.dart
+++ b/lib/core/config/router.dart
@@ -53,6 +53,8 @@ import 'package:sacdia_app/features/support/presentation/views/support_view.dart
 import 'package:sacdia_app/features/support/presentation/views/faq_view.dart';
 import 'package:sacdia_app/features/support/presentation/views/contact_view.dart';
 import 'package:sacdia_app/features/support/presentation/views/report_problem_view.dart';
+import 'package:sacdia_app/features/rankings/presentation/screens/my_ranking_screen.dart';
+import 'package:sacdia_app/features/rankings/presentation/screens/section_ranking_screen.dart';
 
 import '../../features/auth/domain/entities/authorization_snapshot.dart';
 import '../../features/auth/domain/entities/user_entity.dart';
@@ -508,6 +510,20 @@ final routerProvider = Provider<GoRouter>((ref) {
               ),
             ],
           ),
+
+          // ── Branch 17: Mi Ranking (quick-access, no nav bar) ─────────────
+          StatefulShellBranch(
+            routes: [
+              GoRoute(
+                path: RouteNames.homeMyRanking,
+                pageBuilder: (context, state) => _fadeThroughBuild(
+                  context,
+                  state,
+                  const MyRankingScreen(),
+                ),
+              ),
+            ],
+          ),
         ],
       ),
 
@@ -926,6 +942,30 @@ final routerProvider = Provider<GoRouter>((ref) {
           state,
           const AchievementsView(),
         ),
+      ),
+
+      // Ranking de sección — drill-down fuera del shell (push).
+      // Recibe el sectionId como path param para evitar dependencia de contexto.
+      GoRoute(
+        path: RouteNames.sectionRanking,
+        pageBuilder: (context, state) {
+          final sectionIdStr = state.pathParameters['sectionId'];
+          final sectionId = int.tryParse(sectionIdStr ?? '');
+          if (sectionId == null) {
+            return _sharedAxisBuild(
+              context,
+              state,
+              const Scaffold(
+                body: Center(child: Text('Sección inválida')),
+              ),
+            );
+          }
+          return _sharedAxisBuild(
+            context,
+            state,
+            SectionRankingScreen(sectionId: sectionId),
+          );
+        },
       ),
 
       // Soporte / Ayuda — hub principal

--- a/lib/core/constants/api_endpoints.dart
+++ b/lib/core/constants/api_endpoints.dart
@@ -100,4 +100,8 @@ class ApiEndpoints {
 
   // ── QR ────────────────────────────────────────────────────────────────────
   static const String qr = '/qr';
+
+  // ── Rankings ─────────────────────────────────────────────────────────────
+  static const String memberRankings = '/member-rankings';
+  static const String sectionRankings = '/section-rankings';
 }

--- a/lib/core/errors/failures.dart
+++ b/lib/core/errors/failures.dart
@@ -2,7 +2,7 @@ import 'package:easy_localization/easy_localization.dart';
 import 'package:equatable/equatable.dart';
 
 /// Clase base para todos los fallos en la aplicación
-abstract class Failure extends Equatable {
+abstract class Failure extends Equatable implements Exception {
   final String message;
   final int? code;
   final StackTrace? stackTrace;

--- a/lib/features/dashboard/presentation/widgets/quick_access_grid.dart
+++ b/lib/features/dashboard/presentation/widgets/quick_access_grid.dart
@@ -8,13 +8,23 @@ import 'package:sacdia_app/core/theme/app_colors.dart';
 import 'package:sacdia_app/core/theme/sac_colors.dart';
 import 'package:sacdia_app/features/auth/domain/utils/authorization_utils.dart';
 import 'package:sacdia_app/features/auth/presentation/providers/auth_providers.dart';
+import 'package:sacdia_app/features/members/presentation/providers/members_providers.dart';
 
 class _QuickAccessItemConfig {
   /// Translation key resolved at render time via tr(labelKey).
   final String labelKey;
   final List<List<dynamic>> icon;
   final Color? color;
+
+  /// Static route path. Use this for routes that do not depend on runtime
+  /// context. For dynamic routes, leave empty and provide [routeResolver].
   final String route;
+
+  /// Optional resolver for routes that need runtime data (e.g. sectionId from
+  /// clubContextProvider). Called at render time with a [WidgetRef]. Return
+  /// null to hide the card when context data is unavailable.
+  final String? Function(WidgetRef ref)? routeResolver;
+
   final Set<String> requiredPermissions;
 
   /// Canonical role names to gate against when the item is not permission-based.
@@ -27,13 +37,15 @@ class _QuickAccessItemConfig {
     required this.labelKey,
     required this.icon,
     this.color,
-    required this.route,
+    this.route = '',
+    this.routeResolver,
     this.requiredPermissions = const {},
     this.requiredRoles = const {},
   });
 }
 
-const List<_QuickAccessItemConfig> _quickAccessItemsConfig = [
+// ignore: prefer_const_declarations
+final List<_QuickAccessItemConfig> _quickAccessItemsConfig = [
   // Coordination hub — gated by GLOBAL role only. The concept "is the user a
   // coordinator / admin" does not map to a single permission, because club
   // directors also hold operational permissions like `investiture:validate`;
@@ -117,6 +129,28 @@ const List<_QuickAccessItemConfig> _quickAccessItemsConfig = [
     route: RouteNames.homeResources,
     requiredPermissions: {'folders:read'},
   ),
+  // Mi ranking — universal (no permission gate, visible to every member).
+  _QuickAccessItemConfig(
+    labelKey: 'dashboard.quick_access.my_ranking',
+    icon: HugeIcons.strokeRoundedRanking,
+    color: AppColors.accent,
+    route: RouteNames.homeMyRanking,
+  ),
+  // Ranking de sección — gated by units:update (counselor+). Route is
+  // resolved at render time because it requires the active sectionId from
+  // clubContextProvider. Card is hidden when context is unavailable.
+  _QuickAccessItemConfig(
+    labelKey: 'dashboard.quick_access.section_ranking',
+    icon: HugeIcons.strokeRoundedAward01,
+    color: AppColors.primary,
+    routeResolver: (ref) {
+      final ctxAsync = ref.watch(clubContextProvider);
+      final sectionId = ctxAsync.valueOrNull?.sectionId;
+      if (sectionId == null) return null;
+      return RouteNames.sectionRankingPath(sectionId);
+    },
+    requiredPermissions: {'units:update'},
+  ),
 ];
 
 /// Grid 2xN de acceso rápido a los módulos principales del sistema.
@@ -165,6 +199,13 @@ class QuickAccessGrid extends ConsumerWidget {
         return true;
       }
       return false;
+    }).where((item) {
+      // For items with a dynamic routeResolver, hide the card when the
+      // resolved route is null (context data not yet available or missing).
+      if (item.routeResolver != null) {
+        return item.routeResolver!(ref) != null;
+      }
+      return true;
     }).toList();
 
     if (filteredItems.isEmpty) {
@@ -196,7 +237,11 @@ class QuickAccessGrid extends ConsumerWidget {
           itemCount: filteredItems.length,
           itemBuilder: (context, index) {
             final item = filteredItems[index];
-            return _QuickAccessTile(item: item);
+            final resolvedRoute =
+                item.routeResolver != null ? item.routeResolver!(ref) : item.route;
+            // resolvedRoute is guaranteed non-null here: items with null
+            // resolution were already filtered out above.
+            return _QuickAccessTile(item: item, resolvedRoute: resolvedRoute!);
           },
         ),
       ],
@@ -257,10 +302,13 @@ class _QuickAccessSkeleton extends StatelessWidget {
 class _QuickAccessTile extends StatelessWidget {
   final _QuickAccessItemConfig item;
 
+  /// Pre-resolved navigation path (static route or resolved dynamic route).
+  final String resolvedRoute;
+
   // Shared BorderRadius to avoid repeated allocations on every build.
   static final _kTileRadius = BorderRadius.circular(16);
 
-  const _QuickAccessTile({required this.item});
+  const _QuickAccessTile({required this.item, required this.resolvedRoute});
 
   @override
   Widget build(BuildContext context) {
@@ -272,7 +320,7 @@ class _QuickAccessTile extends StatelessWidget {
       borderRadius: _kTileRadius,
       child: InkWell(
         borderRadius: _kTileRadius,
-        onTap: () => context.push(item.route),
+        onTap: () => context.push(resolvedRoute),
         child: Container(
           decoration: BoxDecoration(
             borderRadius: _kTileRadius,

--- a/lib/features/rankings/data/datasources/rankings_remote_data_source.dart
+++ b/lib/features/rankings/data/datasources/rankings_remote_data_source.dart
@@ -1,0 +1,250 @@
+import 'package:dio/dio.dart';
+import 'package:easy_localization/easy_localization.dart';
+
+import '../../../../core/constants/api_endpoints.dart';
+import '../../../../core/errors/exceptions.dart';
+import '../../../../core/utils/app_logger.dart';
+import '../models/member_ranking_dto.dart';
+import '../models/section_ranking_dto.dart';
+
+/// Typed signal thrown when backend responds 403 MEMBER_RANKING_HIDDEN.
+/// The repository catches this and maps it to [Right(null)] — graceful empty state.
+class MemberRankingHiddenException extends AppException {
+  MemberRankingHiddenException()
+      : super(
+          message: 'member_rankings.visibility_hidden',
+          code: 403,
+        );
+}
+
+/// Interface for the rankings remote data source.
+abstract class RankingsRemoteDataSource {
+  /// `GET /member-rankings/me?year_id=[yearId]`
+  ///
+  /// Throws [MemberRankingHiddenException] when visibility_mode = hidden.
+  /// Throws [AuthException] on other 403s.
+  /// Throws [ServerException] on other errors.
+  Future<MyRankingResponseDto> getMyRanking(
+    int yearId, {
+    CancelToken? cancelToken,
+  });
+
+  /// `GET /section-rankings?year_id=[yearId]&club_id=[clubId]`
+  ///
+  /// Returns the paginated `data` array.
+  Future<List<SectionRankingDto>> getSectionRankings({
+    required int yearId,
+    int? clubId,
+    int page = 1,
+    int limit = 20,
+    CancelToken? cancelToken,
+  });
+
+  /// `GET /section-rankings/:sectionId/members?year_id=[yearId]`
+  Future<List<SectionMemberDto>> getSectionMembers(
+    int sectionId,
+    int yearId, {
+    CancelToken? cancelToken,
+  });
+}
+
+/// Implementation of [RankingsRemoteDataSource] using [Dio].
+class RankingsRemoteDataSourceImpl implements RankingsRemoteDataSource {
+  final Dio _dio;
+  final String _baseUrl;
+
+  static const _tag = 'RankingsDS';
+
+  RankingsRemoteDataSourceImpl({
+    required Dio dio,
+    required String baseUrl,
+  })  : _dio = dio,
+        _baseUrl = baseUrl;
+
+  // ── Helpers ──────────────────────────────────────────────────────────────────
+
+  String _extractErrorCode(DioException e) {
+    try {
+      final data = e.response?.data;
+      if (data is Map) {
+        // Backend sends { code: 'MEMBER_RANKING_HIDDEN', message: '...' }
+        final code = data['code'];
+        if (code is String) return code;
+      }
+    } catch (_) {}
+    return '';
+  }
+
+  String _extractDioMessage(DioException e) {
+    try {
+      final data = e.response?.data;
+      if (data is Map) {
+        final msg = data['message'];
+        if (msg is List) return msg.join(', ');
+        return (msg ?? e.message ?? tr('common.error_network')).toString();
+      }
+    } catch (e) {
+      AppLogger.w('Error al parsear respuesta de error', tag: _tag, error: e);
+    }
+    return e.message ?? tr('common.error_network');
+  }
+
+  Never _rethrow(Object e) {
+    if (e is DioException) {
+      final statusCode = e.response?.statusCode;
+
+      if (statusCode == 401) {
+        // Expired token / not authenticated → AuthException so repo maps to Left(AuthFailure)
+        throw AuthException(
+          message: _extractDioMessage(e),
+          code: 401,
+        );
+      }
+
+      if (statusCode == 403) {
+        final code = _extractErrorCode(e);
+        if (code == 'MEMBER_RANKING_HIDDEN') {
+          throw MemberRankingHiddenException();
+        }
+        // Other 403 → AuthException so repo maps to Left(AuthFailure)
+        throw AuthException(
+          message: _extractDioMessage(e),
+          code: statusCode,
+        );
+      }
+
+      // Mid-flight network errors (timeout, connection drop) — no response
+      if (e.type == DioExceptionType.connectionError ||
+          e.type == DioExceptionType.connectionTimeout ||
+          e.type == DioExceptionType.receiveTimeout ||
+          e.type == DioExceptionType.sendTimeout) {
+        throw ServerException(message: tr('common.error_network'), code: null);
+      }
+
+      final msg = _extractDioMessage(e);
+      throw ServerException(message: msg, code: statusCode);
+    }
+    if (e is MemberRankingHiddenException ||
+        e is ServerException ||
+        e is AuthException) {
+      throw e;
+    }
+    throw ServerException(message: e.toString());
+  }
+
+  // ── GET /member-rankings/me ───────────────────────────────────────────────────
+
+  @override
+  Future<MyRankingResponseDto> getMyRanking(
+    int yearId, {
+    CancelToken? cancelToken,
+  }) async {
+    try {
+      final response = await _dio.get(
+        '$_baseUrl${ApiEndpoints.memberRankings}/me',
+        queryParameters: {'year_id': yearId},
+        cancelToken: cancelToken,
+      );
+
+      if (response.statusCode == 200) {
+        final data = response.data;
+        final json = data is Map && data.containsKey('data')
+            ? data['data'] as Map<String, dynamic>
+            : data as Map<String, dynamic>;
+        return MyRankingResponseDto.fromJson(json);
+      }
+
+      throw ServerException(
+        message: tr('member_rankings.errors.get_my_ranking'),
+        code: response.statusCode,
+      );
+    } catch (e) {
+      if (e is DioException && e.type == DioExceptionType.cancel) rethrow;
+      AppLogger.e('Error en getMyRanking', tag: _tag, error: e);
+      _rethrow(e);
+    }
+  }
+
+  // ── GET /section-rankings ─────────────────────────────────────────────────────
+
+  @override
+  Future<List<SectionRankingDto>> getSectionRankings({
+    required int yearId,
+    int? clubId,
+    int page = 1,
+    int limit = 20,
+    CancelToken? cancelToken,
+  }) async {
+    try {
+      final queryParams = <String, dynamic>{
+        'year_id': yearId,
+        'page': page,
+        'limit': limit,
+      };
+      if (clubId != null) queryParams['club_id'] = clubId;
+
+      final response = await _dio.get(
+        '$_baseUrl${ApiEndpoints.sectionRankings}',
+        queryParameters: queryParams,
+        cancelToken: cancelToken,
+      );
+
+      if (response.statusCode == 200) {
+        final body = response.data;
+        // Backend returns { data: [...], total, page, limit }
+        final rawList = body is Map
+            ? (body['data'] as List<dynamic>? ?? [])
+            : (body as List<dynamic>? ?? []);
+        return rawList
+            .map((e) =>
+                SectionRankingDto.fromJson(e as Map<String, dynamic>))
+            .toList();
+      }
+
+      throw ServerException(
+        message: tr('section_rankings.errors.get_rankings'),
+        code: response.statusCode,
+      );
+    } catch (e) {
+      if (e is DioException && e.type == DioExceptionType.cancel) rethrow;
+      AppLogger.e('Error en getSectionRankings', tag: _tag, error: e);
+      _rethrow(e);
+    }
+  }
+
+  // ── GET /section-rankings/:sectionId/members ──────────────────────────────────
+
+  @override
+  Future<List<SectionMemberDto>> getSectionMembers(
+    int sectionId,
+    int yearId, {
+    CancelToken? cancelToken,
+  }) async {
+    try {
+      final response = await _dio.get(
+        '$_baseUrl${ApiEndpoints.sectionRankings}/$sectionId/members',
+        queryParameters: {'year_id': yearId},
+        cancelToken: cancelToken,
+      );
+
+      if (response.statusCode == 200) {
+        final body = response.data;
+        // Backend returns a plain array (MemberRankingResponseDto[])
+        final rawList = body as List<dynamic>? ?? <dynamic>[];
+        return rawList
+            .map((e) =>
+                SectionMemberDto.fromJson(e as Map<String, dynamic>))
+            .toList();
+      }
+
+      throw ServerException(
+        message: tr('section_rankings.errors.get_members'),
+        code: response.statusCode,
+      );
+    } catch (e) {
+      if (e is DioException && e.type == DioExceptionType.cancel) rethrow;
+      AppLogger.e('Error en getSectionMembers', tag: _tag, error: e);
+      _rethrow(e);
+    }
+  }
+}

--- a/lib/features/rankings/data/models/member_ranking_dto.dart
+++ b/lib/features/rankings/data/models/member_ranking_dto.dart
@@ -1,0 +1,176 @@
+import '../../../../core/utils/json_helpers.dart';
+import '../../domain/entities/member_ranking.dart';
+
+/// DTO for an award category embedded in ranking responses.
+class AwardedCategoryDto {
+  final String id;
+  final String name;
+  final String? icon;
+  final double minPct;
+  final double maxPct;
+
+  const AwardedCategoryDto({
+    required this.id,
+    required this.name,
+    this.icon,
+    required this.minPct,
+    required this.maxPct,
+  });
+
+  factory AwardedCategoryDto.fromJson(Map<String, dynamic> json) {
+    return AwardedCategoryDto(
+      id: safeString(json['id']),
+      name: safeString(json['name']),
+      icon: safeStringOrNull(json['icon']),
+      minPct: (json['min_pct'] as num?)?.toDouble() ?? 0.0,
+      maxPct: (json['max_pct'] as num?)?.toDouble() ?? 0.0,
+    );
+  }
+
+  AwardCategory toEntity() {
+    return AwardCategory(
+      id: id,
+      name: name,
+      icon: icon,
+      minPct: minPct,
+      maxPct: maxPct,
+    );
+  }
+}
+
+/// DTO for a single member ranking row — mirrors [MemberRankingResponseDto].
+class MemberRankingDto {
+  final int enrollmentId;
+  final String userId;
+  final String memberName;
+  final int? clubSectionId;
+  final String? sectionName;
+  final double? classScorePct;
+  final double? investitureScorePct;
+  final double? camporeeScorePct;
+  final double? compositeScorePct;
+  final int? rankPosition;
+  final AwardedCategoryDto? awardedCategory;
+  final DateTime? compositeCalculatedAt;
+
+  const MemberRankingDto({
+    required this.enrollmentId,
+    required this.userId,
+    required this.memberName,
+    this.clubSectionId,
+    this.sectionName,
+    this.classScorePct,
+    this.investitureScorePct,
+    this.camporeeScorePct,
+    this.compositeScorePct,
+    this.rankPosition,
+    this.awardedCategory,
+    this.compositeCalculatedAt,
+  });
+
+  factory MemberRankingDto.fromJson(Map<String, dynamic> json) {
+    return MemberRankingDto(
+      enrollmentId: safeInt(json['enrollment_id']),
+      userId: safeString(json['user_id']),
+      memberName: safeString(json['member_name']),
+      clubSectionId: safeIntOrNull(json['club_section_id']),
+      sectionName: safeStringOrNull(json['section_name']),
+      classScorePct: (json['class_score_pct'] as num?)?.toDouble(),
+      investitureScorePct:
+          (json['investiture_score_pct'] as num?)?.toDouble(),
+      camporeeScorePct: (json['camporee_score_pct'] as num?)?.toDouble(),
+      compositeScorePct: (json['composite_score_pct'] as num?)?.toDouble(),
+      rankPosition: safeIntOrNull(json['rank_position']),
+      awardedCategory: json['awarded_category'] != null
+          ? AwardedCategoryDto.fromJson(
+              json['awarded_category'] as Map<String, dynamic>)
+          : null,
+      compositeCalculatedAt: json['composite_calculated_at'] != null
+          ? DateTime.tryParse(safeString(json['composite_calculated_at']))
+          : null,
+    );
+  }
+
+  MemberRanking toEntity() {
+    return MemberRanking(
+      enrollmentId: enrollmentId,
+      userId: userId,
+      memberName: memberName,
+      clubSectionId: clubSectionId,
+      sectionName: sectionName,
+      classScorePct: classScorePct,
+      investitureScorePct: investitureScorePct,
+      camporeeScorePct: camporeeScorePct,
+      compositeScorePct: compositeScorePct,
+      rankPosition: rankPosition,
+      awardedCategory: awardedCategory?.toEntity(),
+      compositeCalculatedAt: compositeCalculatedAt,
+    );
+  }
+}
+
+/// DTO for an anonymized top-N peer entry — mirrors [AnonymizedTopNEntryDto].
+class AnonymizedTopNEntryDto {
+  /// Backend sends privacy-safe label: "Miembro #N".
+  final String memberName;
+  final double? compositeScorePct;
+  final int? rankPosition;
+
+  const AnonymizedTopNEntryDto({
+    required this.memberName,
+    this.compositeScorePct,
+    this.rankPosition,
+  });
+
+  factory AnonymizedTopNEntryDto.fromJson(Map<String, dynamic> json) {
+    return AnonymizedTopNEntryDto(
+      memberName: safeString(json['member_name']),
+      compositeScorePct: (json['composite_score_pct'] as num?)?.toDouble(),
+      rankPosition: safeIntOrNull(json['rank_position']),
+    );
+  }
+
+  AnonymizedTopNEntry toEntity() {
+    return AnonymizedTopNEntry(
+      memberName: memberName,
+      compositeScorePct: compositeScorePct,
+      rankPosition: rankPosition,
+    );
+  }
+}
+
+/// DTO for `GET /member-rankings/me` response — mirrors [MemberMyRankingDto].
+class MyRankingResponseDto {
+  final MemberRankingDto? member;
+  final String visibilityMode;
+  final List<AnonymizedTopNEntryDto>? topN;
+
+  const MyRankingResponseDto({
+    required this.member,
+    required this.visibilityMode,
+    this.topN,
+  });
+
+  factory MyRankingResponseDto.fromJson(Map<String, dynamic> json) {
+    final rawTopN = json['top_n'] as List<dynamic>?;
+    return MyRankingResponseDto(
+      member: json['member'] != null
+          ? MemberRankingDto.fromJson(json['member'] as Map<String, dynamic>)
+          : null,
+      visibilityMode: safeString(json['visibility_mode'], 'hidden'),
+      topN: rawTopN
+          ?.map((e) =>
+              AnonymizedTopNEntryDto.fromJson(e as Map<String, dynamic>))
+          .toList(),
+    );
+  }
+
+  MyRankingView toEntity() {
+    return MyRankingView(
+      member: member?.toEntity(),
+      visibilityMode:
+          MyRankingVisibilityMode.fromString(visibilityMode),
+      topN: topN?.map((e) => e.toEntity()).toList(),
+    );
+  }
+}

--- a/lib/features/rankings/data/models/section_ranking_dto.dart
+++ b/lib/features/rankings/data/models/section_ranking_dto.dart
@@ -1,0 +1,58 @@
+import '../../../../core/utils/json_helpers.dart';
+import '../../domain/entities/section_ranking.dart';
+import 'member_ranking_dto.dart';
+
+/// DTO for a section ranking row — mirrors [SectionRankingResponseDto].
+class SectionRankingDto {
+  final int clubSectionId;
+  final String sectionName;
+  final double? compositeScorePct;
+  final int? rankPosition;
+  final int activeEnrollmentCount;
+  final AwardedCategoryDto? awardedCategory;
+  final DateTime? compositeCalculatedAt;
+
+  const SectionRankingDto({
+    required this.clubSectionId,
+    required this.sectionName,
+    this.compositeScorePct,
+    this.rankPosition,
+    required this.activeEnrollmentCount,
+    this.awardedCategory,
+    this.compositeCalculatedAt,
+  });
+
+  factory SectionRankingDto.fromJson(Map<String, dynamic> json) {
+    return SectionRankingDto(
+      clubSectionId: safeInt(json['club_section_id']),
+      sectionName: safeString(json['section_name']),
+      compositeScorePct: (json['composite_score_pct'] as num?)?.toDouble(),
+      rankPosition: safeIntOrNull(json['rank_position']),
+      activeEnrollmentCount: safeInt(json['active_enrollment_count']),
+      awardedCategory: json['awarded_category'] != null
+          ? AwardedCategoryDto.fromJson(
+              json['awarded_category'] as Map<String, dynamic>)
+          : null,
+      compositeCalculatedAt: json['composite_calculated_at'] != null
+          ? DateTime.tryParse(safeString(json['composite_calculated_at']))
+          : null,
+    );
+  }
+
+  SectionRanking toEntity() {
+    return SectionRanking(
+      clubSectionId: clubSectionId,
+      sectionName: sectionName,
+      compositeScorePct: compositeScorePct,
+      rankPosition: rankPosition,
+      activeEnrollmentCount: activeEnrollmentCount,
+      awardedCategory: awardedCategory?.toEntity(),
+      compositeCalculatedAt: compositeCalculatedAt,
+    );
+  }
+}
+
+/// DTO for a member within a section drill-down.
+/// Reuses [MemberRankingDto] since the backend returns [MemberRankingResponseDto]
+/// for both `GET /section-rankings/:id/members` and `GET /member-rankings`.
+typedef SectionMemberDto = MemberRankingDto;

--- a/lib/features/rankings/data/repositories/member_rankings_repository_impl.dart
+++ b/lib/features/rankings/data/repositories/member_rankings_repository_impl.dart
@@ -1,0 +1,63 @@
+import 'package:dartz/dartz.dart';
+import 'package:dio/dio.dart';
+
+import '../../../../core/errors/exceptions.dart';
+import '../../../../core/errors/failures.dart';
+import '../../../../core/network/network_info.dart';
+import '../../domain/entities/member_ranking.dart';
+import '../../domain/repositories/member_rankings_repository.dart';
+import '../datasources/rankings_remote_data_source.dart';
+
+/// Concrete implementation of [MemberRankingsRepository].
+class MemberRankingsRepositoryImpl implements MemberRankingsRepository {
+  final RankingsRemoteDataSource remoteDataSource;
+  final NetworkInfo networkInfo;
+
+  MemberRankingsRepositoryImpl({
+    required this.remoteDataSource,
+    required this.networkInfo,
+  });
+
+  // ── Failure helpers ───────────────────────────────────────────────────────────
+
+  Left<Failure, T> _serverFailure<T>(ServerException e) =>
+      Left(ServerFailure(message: e.message, code: e.code));
+
+  Left<Failure, T> _authFailure<T>(AuthException e) =>
+      Left(AuthFailure(message: e.message, code: e.code));
+
+  Left<Failure, T> _unexpectedFailure<T>(Object e) =>
+      Left(UnexpectedFailure(message: e.toString()));
+
+  // ── MemberRankingsRepository ──────────────────────────────────────────────────
+
+  @override
+  Future<Either<Failure, MyRankingView?>> getMyRanking(
+    int yearId, {
+    CancelToken? cancelToken,
+  }) async {
+    // Check connectivity; return NetworkFailure when offline.
+    if (!await networkInfo.isConnected) {
+      return const Left(
+        NetworkFailure(message: 'Sin conexión a internet'),
+      );
+    }
+
+    try {
+      final dto = await remoteDataSource.getMyRanking(
+        yearId,
+        cancelToken: cancelToken,
+      );
+      return Right(dto.toEntity());
+    } on MemberRankingHiddenException {
+      // Visibility = hidden → graceful empty state (not an error).
+      return const Right(null);
+    } on ServerException catch (e) {
+      return _serverFailure(e);
+    } on AuthException catch (e) {
+      return _authFailure(e);
+    } catch (e) {
+      return _unexpectedFailure(e);
+    }
+  }
+}

--- a/lib/features/rankings/data/repositories/section_rankings_repository_impl.dart
+++ b/lib/features/rankings/data/repositories/section_rankings_repository_impl.dart
@@ -1,0 +1,89 @@
+import 'package:dartz/dartz.dart';
+import 'package:dio/dio.dart';
+
+import '../../../../core/errors/exceptions.dart';
+import '../../../../core/errors/failures.dart';
+import '../../../../core/network/network_info.dart';
+import '../../domain/entities/section_ranking.dart';
+import '../../domain/repositories/section_rankings_repository.dart';
+import '../datasources/rankings_remote_data_source.dart';
+
+/// Concrete implementation of [SectionRankingsRepository].
+class SectionRankingsRepositoryImpl implements SectionRankingsRepository {
+  final RankingsRemoteDataSource remoteDataSource;
+  final NetworkInfo networkInfo;
+
+  SectionRankingsRepositoryImpl({
+    required this.remoteDataSource,
+    required this.networkInfo,
+  });
+
+  // ── Failure helpers ───────────────────────────────────────────────────────────
+
+  Left<Failure, T> _serverFailure<T>(ServerException e) =>
+      Left(ServerFailure(message: e.message, code: e.code));
+
+  Left<Failure, T> _authFailure<T>(AuthException e) =>
+      Left(AuthFailure(message: e.message, code: e.code));
+
+  Left<Failure, T> _unexpectedFailure<T>(Object e) =>
+      Left(UnexpectedFailure(message: e.toString()));
+
+  // ── SectionRankingsRepository ─────────────────────────────────────────────────
+
+  @override
+  Future<Either<Failure, List<SectionRanking>>> getSectionRankings({
+    required int yearId,
+    int? clubId,
+    int page = 1,
+    int limit = 20,
+    CancelToken? cancelToken,
+  }) async {
+    if (!await networkInfo.isConnected) {
+      return const Left(NetworkFailure(message: 'Sin conexión a internet'));
+    }
+
+    try {
+      final dtos = await remoteDataSource.getSectionRankings(
+        yearId: yearId,
+        clubId: clubId,
+        page: page,
+        limit: limit,
+        cancelToken: cancelToken,
+      );
+      return Right(dtos.map((d) => d.toEntity()).toList());
+    } on ServerException catch (e) {
+      return _serverFailure(e);
+    } on AuthException catch (e) {
+      return _authFailure(e);
+    } catch (e) {
+      return _unexpectedFailure(e);
+    }
+  }
+
+  @override
+  Future<Either<Failure, List<SectionMember>>> getSectionMembers(
+    int sectionId,
+    int yearId, {
+    CancelToken? cancelToken,
+  }) async {
+    if (!await networkInfo.isConnected) {
+      return const Left(NetworkFailure(message: 'Sin conexión a internet'));
+    }
+
+    try {
+      final dtos = await remoteDataSource.getSectionMembers(
+        sectionId,
+        yearId,
+        cancelToken: cancelToken,
+      );
+      return Right(dtos.map((d) => d.toEntity()).toList());
+    } on ServerException catch (e) {
+      return _serverFailure(e);
+    } on AuthException catch (e) {
+      return _authFailure(e);
+    } catch (e) {
+      return _unexpectedFailure(e);
+    }
+  }
+}

--- a/lib/features/rankings/domain/entities/member_ranking.dart
+++ b/lib/features/rankings/domain/entities/member_ranking.dart
@@ -1,0 +1,121 @@
+import 'package:equatable/equatable.dart';
+
+/// Visibility mode for member rankings — mirrors backend VisibilityMode type.
+enum MyRankingVisibilityMode {
+  hidden,
+  selfOnly,
+  selfAndTopN;
+
+  static MyRankingVisibilityMode fromString(String raw) {
+    switch (raw) {
+      case 'self_only':
+        return MyRankingVisibilityMode.selfOnly;
+      case 'self_and_top_n':
+        return MyRankingVisibilityMode.selfAndTopN;
+      default:
+        return MyRankingVisibilityMode.hidden;
+    }
+  }
+}
+
+/// Domain entity for an award category assigned to a ranking row.
+class AwardCategory extends Equatable {
+  final String id;
+  final String name;
+  final String? icon;
+  final double minPct;
+  final double maxPct;
+
+  const AwardCategory({
+    required this.id,
+    required this.name,
+    this.icon,
+    required this.minPct,
+    required this.maxPct,
+  });
+
+  @override
+  List<Object?> get props => [id, name, icon, minPct, maxPct];
+}
+
+/// Domain entity for a single member ranking row.
+class MemberRanking extends Equatable {
+  final int enrollmentId;
+  final String userId;
+  final String memberName;
+  final int? clubSectionId;
+  final String? sectionName;
+  final double? classScorePct;
+  final double? investitureScorePct;
+  final double? camporeeScorePct;
+  final double? compositeScorePct;
+  final int? rankPosition;
+  final AwardCategory? awardedCategory;
+  final DateTime? compositeCalculatedAt;
+
+  const MemberRanking({
+    required this.enrollmentId,
+    required this.userId,
+    required this.memberName,
+    this.clubSectionId,
+    this.sectionName,
+    this.classScorePct,
+    this.investitureScorePct,
+    this.camporeeScorePct,
+    this.compositeScorePct,
+    this.rankPosition,
+    this.awardedCategory,
+    this.compositeCalculatedAt,
+  });
+
+  @override
+  List<Object?> get props => [
+        enrollmentId,
+        userId,
+        memberName,
+        clubSectionId,
+        sectionName,
+        classScorePct,
+        investitureScorePct,
+        camporeeScorePct,
+        compositeScorePct,
+        rankPosition,
+        awardedCategory,
+        compositeCalculatedAt,
+      ];
+}
+
+/// Anonymized top-N peer entry visible when visibility_mode = self_and_top_n.
+class AnonymizedTopNEntry extends Equatable {
+  /// Backend sends "Miembro #N" (privacy-safe label).
+  final String memberName;
+  final double? compositeScorePct;
+  final int? rankPosition;
+
+  const AnonymizedTopNEntry({
+    required this.memberName,
+    this.compositeScorePct,
+    this.rankPosition,
+  });
+
+  @override
+  List<Object?> get props => [memberName, compositeScorePct, rankPosition];
+}
+
+/// Aggregate view returned for `GET /member-rankings/me`.
+/// Bundles the member's own row + optional top-N + visibility mode.
+/// [member] is null when the score hasn't been calculated yet.
+class MyRankingView extends Equatable {
+  final MemberRanking? member;
+  final MyRankingVisibilityMode visibilityMode;
+  final List<AnonymizedTopNEntry>? topN;
+
+  const MyRankingView({
+    required this.member,
+    required this.visibilityMode,
+    this.topN,
+  });
+
+  @override
+  List<Object?> get props => [member, visibilityMode, topN];
+}

--- a/lib/features/rankings/domain/entities/section_ranking.dart
+++ b/lib/features/rankings/domain/entities/section_ranking.dart
@@ -1,0 +1,39 @@
+import 'package:equatable/equatable.dart';
+
+import 'member_ranking.dart';
+
+/// Domain entity for a section ranking row.
+class SectionRanking extends Equatable {
+  final int clubSectionId;
+  final String sectionName;
+  final double? compositeScorePct;
+  final int? rankPosition;
+  final int activeEnrollmentCount;
+  final AwardCategory? awardedCategory;
+  final DateTime? compositeCalculatedAt;
+
+  const SectionRanking({
+    required this.clubSectionId,
+    required this.sectionName,
+    this.compositeScorePct,
+    this.rankPosition,
+    required this.activeEnrollmentCount,
+    this.awardedCategory,
+    this.compositeCalculatedAt,
+  });
+
+  @override
+  List<Object?> get props => [
+        clubSectionId,
+        sectionName,
+        compositeScorePct,
+        rankPosition,
+        activeEnrollmentCount,
+        awardedCategory,
+        compositeCalculatedAt,
+      ];
+}
+
+/// Domain entity for a member inside a section ranking drill-down.
+/// Reuses [MemberRanking] — director sees real names (RBAC enforced server-side).
+typedef SectionMember = MemberRanking;

--- a/lib/features/rankings/domain/repositories/member_rankings_repository.dart
+++ b/lib/features/rankings/domain/repositories/member_rankings_repository.dart
@@ -1,0 +1,18 @@
+import 'package:dartz/dartz.dart';
+import 'package:dio/dio.dart';
+
+import '../../../../core/errors/failures.dart';
+import '../entities/member_ranking.dart';
+
+/// Abstract repository for member rankings domain operations.
+abstract class MemberRankingsRepository {
+  /// Returns the calling member's own ranking for [yearId].
+  ///
+  /// - 200 OK → [Right<MyRankingView>] (member may be null when uncalculated)
+  /// - 403 MEMBER_RANKING_HIDDEN → [Right(null)] (graceful empty state)
+  /// - Other 403 / 4xx / 5xx → [Left<Failure>]
+  Future<Either<Failure, MyRankingView?>> getMyRanking(
+    int yearId, {
+    CancelToken? cancelToken,
+  });
+}

--- a/lib/features/rankings/domain/repositories/section_rankings_repository.dart
+++ b/lib/features/rankings/domain/repositories/section_rankings_repository.dart
@@ -1,0 +1,26 @@
+import 'package:dartz/dartz.dart';
+import 'package:dio/dio.dart';
+
+import '../../../../core/errors/failures.dart';
+import '../entities/section_ranking.dart';
+
+/// Abstract repository for section rankings domain operations.
+abstract class SectionRankingsRepository {
+  /// Returns a paginated list of section rankings for [yearId].
+  ///
+  /// [clubId] is optional — backend filters by RBAC scope when omitted.
+  Future<Either<Failure, List<SectionRanking>>> getSectionRankings({
+    required int yearId,
+    int? clubId,
+    int page = 1,
+    int limit = 20,
+    CancelToken? cancelToken,
+  });
+
+  /// Returns members ranked within a specific section for [yearId].
+  Future<Either<Failure, List<SectionMember>>> getSectionMembers(
+    int sectionId,
+    int yearId, {
+    CancelToken? cancelToken,
+  });
+}

--- a/lib/features/rankings/presentation/providers/my_ranking_provider.dart
+++ b/lib/features/rankings/presentation/providers/my_ranking_provider.dart
@@ -1,0 +1,56 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../../core/constants/app_constants.dart';
+import '../../../../providers/dio_provider.dart';
+import '../../../auth/presentation/providers/auth_providers.dart';
+import '../../data/datasources/rankings_remote_data_source.dart';
+import '../../data/repositories/member_rankings_repository_impl.dart';
+import '../../domain/entities/member_ranking.dart';
+import '../../domain/repositories/member_rankings_repository.dart';
+
+// ── Infrastructure providers ──────────────────────────────────────────────────
+
+/// Provider for the shared rankings remote data source.
+/// Both member and section repository providers read from this single instance.
+final rankingsRemoteDataSourceProvider =
+    Provider<RankingsRemoteDataSource>((ref) {
+  return RankingsRemoteDataSourceImpl(
+    dio: ref.read(dioProvider),
+    baseUrl: AppConstants.baseUrl,
+  );
+});
+
+/// Provider for the member rankings repository.
+final memberRankingsRepositoryProvider =
+    Provider<MemberRankingsRepository>((ref) {
+  return MemberRankingsRepositoryImpl(
+    remoteDataSource: ref.read(rankingsRemoteDataSourceProvider),
+    networkInfo: ref.read(networkInfoProvider),
+  );
+});
+
+// ── Data provider ─────────────────────────────────────────────────────────────
+
+/// Fetches the calling member's own ranking for a given [yearId].
+///
+/// Returns:
+/// - [AsyncValue.data(MyRankingView)] — ranking available
+/// - [AsyncValue.data(null)] — visibility = hidden (empty state, NOT error)
+/// - [AsyncValue.error(Failure)] — auth or network error
+final myRankingProvider =
+    FutureProvider.autoDispose.family<MyRankingView?, int>(
+        (ref, yearId) async {
+  ref.keepAlive();
+  final cancelToken = CancelToken();
+  ref.onDispose(() => cancelToken.cancel());
+
+  final repo = ref.watch(memberRankingsRepositoryProvider);
+  final result =
+      await repo.getMyRanking(yearId, cancelToken: cancelToken);
+
+  return result.fold(
+    (failure) => throw failure,
+    (data) => data, // null when hidden, MyRankingView when available
+  );
+});

--- a/lib/features/rankings/presentation/providers/section_ranking_provider.dart
+++ b/lib/features/rankings/presentation/providers/section_ranking_provider.dart
@@ -1,0 +1,77 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../auth/presentation/providers/auth_providers.dart';
+import '../../data/repositories/section_rankings_repository_impl.dart';
+import '../../domain/entities/section_ranking.dart';
+import '../../domain/repositories/section_rankings_repository.dart';
+import 'my_ranking_provider.dart';
+
+// ── Param types ───────────────────────────────────────────────────────────────
+
+/// Parameter record for [sectionRankingsProvider].
+/// Using a Dart record ensures structural equality for provider family keying.
+typedef SectionRankingsParams = ({int yearId, int? clubId});
+
+/// Parameter record for [sectionMembersProvider].
+typedef SectionMembersParams = ({int sectionId, int yearId});
+
+// ── Infrastructure provider ───────────────────────────────────────────────────
+
+/// Provider for the section rankings repository.
+/// Reads the shared [rankingsRemoteDataSourceProvider] defined in my_ranking_provider.
+final sectionRankingsRepositoryProvider =
+    Provider<SectionRankingsRepository>((ref) {
+  return SectionRankingsRepositoryImpl(
+    remoteDataSource: ref.read(rankingsRemoteDataSourceProvider),
+    networkInfo: ref.read(networkInfoProvider),
+  );
+});
+
+// ── Data providers ────────────────────────────────────────────────────────────
+
+/// Fetches paginated section rankings.
+///
+/// [params.clubId] is optional — backend applies RBAC scope filter when null.
+final sectionRankingsProvider = FutureProvider.autoDispose
+    .family<List<SectionRanking>, SectionRankingsParams>(
+        (ref, params) async {
+  ref.keepAlive();
+  final cancelToken = CancelToken();
+  ref.onDispose(() => cancelToken.cancel());
+
+  final repo = ref.watch(sectionRankingsRepositoryProvider);
+  final result = await repo.getSectionRankings(
+    yearId: params.yearId,
+    clubId: params.clubId,
+    cancelToken: cancelToken,
+  );
+
+  return result.fold(
+    (failure) => throw failure,
+    (sections) => sections,
+  );
+});
+
+/// Fetches members ranked within a specific section.
+///
+/// Director sees real names (RBAC enforced server-side).
+final sectionMembersProvider = FutureProvider.autoDispose
+    .family<List<SectionMember>, SectionMembersParams>(
+        (ref, params) async {
+  ref.keepAlive();
+  final cancelToken = CancelToken();
+  ref.onDispose(() => cancelToken.cancel());
+
+  final repo = ref.watch(sectionRankingsRepositoryProvider);
+  final result = await repo.getSectionMembers(
+    params.sectionId,
+    params.yearId,
+    cancelToken: cancelToken,
+  );
+
+  return result.fold(
+    (failure) => throw failure,
+    (members) => members,
+  );
+});

--- a/lib/features/rankings/presentation/screens/my_ranking_screen.dart
+++ b/lib/features/rankings/presentation/screens/my_ranking_screen.dart
@@ -1,0 +1,243 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:hugeicons/hugeicons.dart';
+
+import '../../../../core/theme/sac_colors.dart';
+import '../../../../providers/catalogs_provider.dart';
+import '../../domain/entities/member_ranking.dart';
+import '../providers/my_ranking_provider.dart';
+import '../widgets/ranking_empty_state.dart';
+import '../widgets/ranking_hero_card.dart';
+import '../widgets/ranking_skeleton.dart';
+import '../widgets/signal_score_row.dart';
+import '../widgets/top_n_section.dart';
+
+/// Pantalla principal de ranking individual del miembro.
+///
+/// Flujo:
+/// 1. Resuelve el año eclesiástico activo via [currentEcclesiasticalYearProvider].
+/// 2. Con el yearId, observa [myRankingProvider] para obtener [MyRankingView?].
+/// 3. null → visibility=hidden → [RankingEmptyState.hidden].
+/// 4. Datos → layout completo con hero card, señales y top-N condicional.
+///
+/// Navegación: accesible via Navigator.push directo hasta que Task 26+
+/// integre ambas pantallas en el nav principal.
+class MyRankingScreen extends ConsumerWidget {
+  const MyRankingScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final yearAsync = ref.watch(currentEcclesiasticalYearProvider);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Mi ranking'),
+      ),
+      body: yearAsync.when(
+        data: (year) {
+          if (year == null) {
+            return const RankingEmptyState(reason: RankingEmptyReason.noData);
+          }
+          return _RankingBody(
+            yearId: year.ecclesiasticalYearId,
+            yearLabel: year.name,
+          );
+        },
+        loading: () => RankingSkeleton.myRanking(),
+        error: (_, __) => RankingEmptyState(
+          reason: RankingEmptyReason.networkError,
+          onRetry: () => ref.invalidate(currentEcclesiasticalYearProvider),
+        ),
+      ),
+    );
+  }
+}
+
+/// Cuerpo principal que ya tiene el yearId resuelto.
+class _RankingBody extends ConsumerWidget {
+  final int yearId;
+  final String yearLabel;
+
+  const _RankingBody({required this.yearId, required this.yearLabel});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final myRankingAsync = ref.watch(myRankingProvider(yearId));
+
+    return RefreshIndicator(
+      onRefresh: () async => ref.invalidate(myRankingProvider(yearId)),
+      child: myRankingAsync.when(
+        data: (view) {
+          // null = visibility=hidden → silenciar con mensaje calmo.
+          if (view == null) {
+            return const SingleChildScrollView(
+              // ScrollView necesario para que RefreshIndicator funcione.
+              physics: AlwaysScrollableScrollPhysics(),
+              child: SizedBox(
+                height: 500,
+                child: RankingEmptyState(reason: RankingEmptyReason.hidden),
+              ),
+            );
+          }
+
+          // Sin datos de member (score aún no calculado).
+          if (view.member == null) {
+            return const SingleChildScrollView(
+              physics: AlwaysScrollableScrollPhysics(),
+              child: SizedBox(
+                height: 500,
+                child: RankingEmptyState(reason: RankingEmptyReason.noData),
+              ),
+            );
+          }
+
+          final ranking = view.member!;
+
+          return CustomScrollView(
+            physics: const AlwaysScrollableScrollPhysics(),
+            slivers: [
+              // Hero card con puntaje compuesto.
+              SliverToBoxAdapter(
+                child: RankingHeroCard(
+                  compositeScore: ranking.compositeScorePct,
+                  rankPosition: ranking.rankPosition,
+                  totalInSection: _resolveTotalInSection(view),
+                  awardedCategoryName: ranking.awardedCategory?.name,
+                  awardedCategoryTierId: ranking.awardedCategory?.id,
+                  sectionName: ranking.sectionName,
+                  ecclesiasticalYearLabel: yearLabel,
+                ),
+              ),
+
+              // Fila de señales.
+              SliverPadding(
+                padding: EdgeInsets.zero,
+                sliver: SliverToBoxAdapter(
+                  child: SignalScoreRow(
+                    classScore: ranking.classScorePct,
+                    investitureScore: ranking.investitureScorePct,
+                    camporeeScore: ranking.camporeeScorePct,
+                  ),
+                ),
+              ),
+
+              // Nudge contextual basado en la señal más baja.
+              SliverToBoxAdapter(
+                child: _ContextualNudge(ranking: ranking),
+              ),
+
+              // Top-N (solo si visibility = selfAndTopN y topN no está vacío).
+              if (view.visibilityMode ==
+                      MyRankingVisibilityMode.selfAndTopN &&
+                  view.topN != null &&
+                  view.topN!.isNotEmpty)
+                SliverToBoxAdapter(
+                  child: TopNSection(
+                    entries: view.topN!,
+                    userOwnRankPosition: ranking.rankPosition,
+                    userOwnComposite: ranking.compositeScorePct,
+                  ),
+                ),
+
+              // Espacio inferior para la última fila no quede pegada al borde.
+              const SliverPadding(
+                  padding: EdgeInsets.only(bottom: 32)),
+            ],
+          );
+        },
+        loading: () => RankingSkeleton.myRanking(),
+        error: (_, __) => RankingEmptyState(
+          reason: RankingEmptyReason.networkError,
+          onRetry: () => ref.invalidate(myRankingProvider(yearId)),
+        ),
+      ),
+    );
+  }
+
+  /// Resuelve el total de miembros en la sección a partir del top-N si
+  /// está disponible. Fallback: null (la hero card omite la línea de rank).
+  int? _resolveTotalInSection(MyRankingView view) {
+    if (view.topN == null || view.topN!.isEmpty) return null;
+    // El top-N no expone el total directamente; lo inferimos del último
+    // rankPosition del listado si el backend lo envía ordenado.
+    // Si el usuario está fuera del top-N, su propio rank es el indicador.
+    final member = view.member;
+    if (member?.rankPosition != null && view.topN!.isNotEmpty) {
+      // Devolvemos null para no mostrar un total incorrecto. El backend
+      // debería enviar total_in_section en una versión futura del contrato.
+      return null;
+    }
+    return null;
+  }
+
+}
+
+// ── Nudge contextual ────────────────────────────────────────────────────────
+
+/// Muestra una línea de motivación derivada de la señal con puntaje más bajo.
+///
+/// Oculto si todas las señales son null.
+class _ContextualNudge extends StatelessWidget {
+  final MemberRanking ranking;
+
+  const _ContextualNudge({required this.ranking});
+
+  /// Devuelve el mensaje correspondiente a la señal con menor puntaje no-null.
+  String? _nudgeMessage() {
+    final scores = <String, double?>{
+      'class': ranking.classScorePct,
+      'investiture': ranking.investitureScorePct,
+      'camporee': ranking.camporeeScorePct,
+    };
+
+    // Filtramos solo los que tienen valor.
+    final available = scores.entries
+        .where((e) => e.value != null)
+        .toList()
+      ..sort((a, b) => a.value!.compareTo(b.value!));
+
+    if (available.isEmpty) return null;
+
+    switch (available.first.key) {
+      case 'class':
+        return 'Completá tus próximas lecciones de clase para mejorar tu puntaje.';
+      case 'investiture':
+        return 'Trabajá en los requisitos de tu próxima investidura.';
+      case 'camporee':
+        return 'Participá en los próximos camporees para sumar puntos.';
+      default:
+        return null;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final message = _nudgeMessage();
+    if (message == null) return const SizedBox.shrink();
+
+    final c = context.sac;
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          HugeIcon(
+            icon: HugeIcons.strokeRoundedArrowRight01,
+            size: 12,
+            color: c.textSecondary,
+          ),
+          const SizedBox(width: 4),
+          Expanded(
+            child: Text(
+              message,
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                    color: c.textSecondary,
+                  ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/rankings/presentation/screens/section_ranking_screen.dart
+++ b/lib/features/rankings/presentation/screens/section_ranking_screen.dart
@@ -1,0 +1,168 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../../providers/catalogs_provider.dart';
+import '../../../members/presentation/providers/members_providers.dart';
+import '../providers/section_ranking_provider.dart';
+import '../widgets/member_ranking_list_tile.dart';
+import '../widgets/ranking_empty_state.dart';
+import '../widgets/ranking_skeleton.dart';
+
+// ── Role helpers ──────────────────────────────────────────────────────────────
+
+/// Roles autorizados a ver el ranking de sección.
+///
+/// Equivalente al conjunto de [_kManagementRoles] de units_list_view.dart
+/// más 'counselor' — los counselors son responsables de su unidad y
+/// necesitan visibilidad del ranking para hacer seguimiento.
+const _kSectionRankingRoles = [
+  'director',
+  'sub_director',
+  'secretario',
+  'secretario_tesorero',
+  'counselor',
+];
+
+bool _canViewSectionRanking(String? role) {
+  if (role == null) return false;
+  return _kSectionRankingRoles.contains(role.trim().toLowerCase());
+}
+
+// ── Screen ────────────────────────────────────────────────────────────────────
+
+/// Pantalla de ranking de miembros dentro de una sección específica.
+///
+/// Flujo:
+/// 1. Resuelve el año eclesiástico activo via [currentEcclesiasticalYearProvider].
+/// 2. Valida el rol del usuario via [clubContextProvider] (RBAC client-side).
+/// 3. Observa [sectionMembersProvider] con (sectionId, yearId).
+/// 4. Renderiza lista de [MemberRankingListTile] con pull-to-refresh.
+///
+/// Navegación: accesible via `Navigator.push(context, MaterialPageRoute(...))`
+/// hasta que una tarea futura integre la pantalla en el nav principal.
+class SectionRankingScreen extends ConsumerWidget {
+  const SectionRankingScreen({super.key, required this.sectionId});
+
+  /// ID de la sección cuyo ranking se muestra.
+  final int sectionId;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final yearAsync = ref.watch(currentEcclesiasticalYearProvider);
+    final ctxAsync = ref.watch(clubContextProvider);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Text(
+              'Ranking de sección',
+              style: TextStyle(fontSize: 17, fontWeight: FontWeight.w600),
+            ),
+            // Subtítulo: se sobreescribe con el yearLabel cuando está disponible.
+            // Mientras carga, muestra el texto base.
+            yearAsync.maybeWhen(
+              data: (year) => Text(
+                year != null
+                    ? 'Registro de progreso — ${year.name}'
+                    : 'Registro de progreso',
+                style: const TextStyle(
+                  fontSize: 12,
+                  fontWeight: FontWeight.w400,
+                ),
+              ),
+              orElse: () => const Text(
+                'Registro de progreso',
+                style: TextStyle(
+                  fontSize: 12,
+                  fontWeight: FontWeight.w400,
+                ),
+              ),
+            ),
+          ],
+        ),
+        toolbarHeight: 60,
+      ),
+      body: yearAsync.when(
+        data: (year) {
+          if (year == null) {
+            return const RankingEmptyState(reason: RankingEmptyReason.noData);
+          }
+
+          // RBAC gate: validar rol antes de mostrar datos.
+          // ctxAsync puede estar loading → usamos valueOrNull para no bloquear.
+          final ctx = ctxAsync.valueOrNull;
+          if (ctx == null || !_canViewSectionRanking(ctx.roleName)) {
+            // ctx == null puede ser transitorio (aún cargando) o definitivo
+            // (sin grant activo). Cuando ctxAsync aún está cargando,
+            // mostramos el skeleton — evita un flash de "sin datos".
+            if (ctxAsync.isLoading) {
+              return RankingSkeleton.sectionList();
+            }
+            return const RankingEmptyState(
+                reason: RankingEmptyReason.unauthorized);
+          }
+
+          return _buildList(context, ref, year.ecclesiasticalYearId);
+        },
+        loading: () => RankingSkeleton.sectionList(),
+        error: (_, __) => RankingEmptyState(
+          reason: RankingEmptyReason.networkError,
+          onRetry: () => ref.invalidate(currentEcclesiasticalYearProvider),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildList(BuildContext context, WidgetRef ref, int yearId) {
+    final params = (sectionId: sectionId, yearId: yearId);
+    final membersAsync = ref.watch(sectionMembersProvider(params));
+
+    return RefreshIndicator(
+      onRefresh: () async => ref.invalidate(sectionMembersProvider(params)),
+      child: membersAsync.when(
+        data: (members) {
+          if (members.isEmpty) {
+            return const SingleChildScrollView(
+              // ScrollView necesario para que RefreshIndicator funcione.
+              physics: AlwaysScrollableScrollPhysics(),
+              child: SizedBox(
+                height: 500,
+                child: RankingEmptyState(
+                    reason: RankingEmptyReason.noSectionMembers),
+              ),
+            );
+          }
+
+          return ListView.separated(
+            physics: const AlwaysScrollableScrollPhysics(),
+            itemCount: members.length,
+            separatorBuilder: (_, __) => const Divider(
+              indent: 60, // 16 outer-padding + 32 rank-col + 12 gap
+              height: 1,
+            ),
+            itemBuilder: (_, i) {
+              final m = members[i];
+              return MemberRankingListTile(
+                key: ValueKey(m.enrollmentId),
+                rankPosition: m.rankPosition ?? (i + 1),
+                memberName: m.memberName,
+                sectionName: m.sectionName,
+                compositeScore: m.compositeScorePct,
+                awardedCategoryName: m.awardedCategory?.name,
+                awardedCategoryTierId: m.awardedCategory?.id,
+              );
+            },
+          );
+        },
+        loading: () => RankingSkeleton.sectionList(),
+        error: (_, __) => RankingEmptyState(
+          reason: RankingEmptyReason.networkError,
+          onRetry: () => ref.invalidate(sectionMembersProvider(params)),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/rankings/presentation/widgets/member_ranking_list_tile.dart
+++ b/lib/features/rankings/presentation/widgets/member_ranking_list_tile.dart
@@ -1,0 +1,214 @@
+import 'package:flutter/material.dart';
+
+import '../../../../core/theme/app_colors.dart';
+import '../../../../core/theme/sac_colors.dart';
+
+/// Fila de ranking de un miembro dentro de su sección.
+///
+/// Layout:
+/// ```
+/// [rank 32dp]  [nombre + sección opcional]     [score badge]
+/// ```
+///
+/// Reglas visuales (según spec Task 26 / ui-ux-designer locked):
+/// - Top 3: posición en `headlineSmall` 18px w700 `sac.text`.
+/// - Resto:  posición en `titleSmall`   14px w500 `sac.textTertiary`.
+/// - Score badge: 48×24dp, border-radius 6, bg = tier @ 12%, border = tier @ 40%.
+/// - Sin score → bg = borderLight, text = textSecondary, guión "—".
+///
+/// NO usa [ListTile] nativo — el padding/height de ListTile no respeta el
+/// mínimo de 56dp sin comprometer la especificación visual.
+class MemberRankingListTile extends StatelessWidget {
+  /// Posición 1-based del miembro en el ranking.
+  final int rankPosition;
+
+  /// Nombre real del miembro (vista de director — server-side RBAC).
+  final String memberName;
+
+  /// Nombre de la sección (opcional — solo se muestra si no es null).
+  final String? sectionName;
+
+  /// Puntaje compuesto 0-100 con un decimal. Null si aún no calculado.
+  final double? compositeScore;
+
+  /// Nombre de la categoría premiada (e.g. "Oro", "Plata"). Null si no asignada.
+  final String? awardedCategoryName;
+
+  /// ID UUID de la categoría — se usa para resolver el color del tier.
+  /// Neutro cuando null (sin tier asignado todavía).
+  final String? awardedCategoryTierId;
+
+  const MemberRankingListTile({
+    super.key,
+    required this.rankPosition,
+    required this.memberName,
+    this.sectionName,
+    this.compositeScore,
+    this.awardedCategoryName,
+    this.awardedCategoryTierId,
+  });
+
+  /// Resuelve el color del tier para el score badge.
+  ///
+  /// Mismo enfoque que [RankingHeroCard._tierColor()]: la capa de dominio
+  /// no expone un campo `tier` tipado todavía — se usa el color de acento
+  /// cuando hay categoría y neutro cuando no.
+  Color _tierColor() {
+    if (awardedCategoryTierId == null) {
+      // Sin tier: color neutro que NO colisione con AppColors.accent
+      // (el accent se reserva para énfasis de puntaje compuesto en hero card).
+      return AppColors.secondary; // verde SACDIA — neutral, no compite
+    }
+    // Mientras el backend no exponga un campo `tier` en AwardCategory,
+    // usamos el color de acento como fallback para cualquier categoría presente.
+    return AppColors.accent;
+  }
+
+  /// Formatea el puntaje con 1 decimal fijo para alineación de columna.
+  // always 1 decimal — list column alignment vs single-value emphasis
+  String _formatScore(double score) {
+    return score.toStringAsFixed(1);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final c = context.sac;
+    final tierColor = _tierColor();
+    final isTop3 = rankPosition <= 3;
+
+    // Label de accesibilidad completo para VoiceOver/TalkBack.
+    final semanticsLabel = [
+      'Posición $rankPosition',
+      memberName,
+      if (sectionName != null) 'sección $sectionName',
+      compositeScore != null
+          ? 'puntaje ${_formatScore(compositeScore!)}'
+          : 'puntaje no disponible',
+      if (awardedCategoryName != null) 'categoría $awardedCategoryName',
+    ].join(', ');
+
+    return Semantics(
+      label: semanticsLabel,
+      child: Container(
+        constraints: const BoxConstraints(minHeight: 56),
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            // ── Columna de posición ────────────────────────────────────
+            SizedBox(
+              width: 32,
+              child: Text(
+                '#$rankPosition',
+                textAlign: TextAlign.center,
+                style: isTop3
+                    ? (Theme.of(context).textTheme.headlineSmall?.copyWith(
+                              fontSize: 18,
+                              fontWeight: FontWeight.w700,
+                              color: c.text,
+                            ) ??
+                          const TextStyle(
+                              fontSize: 18, fontWeight: FontWeight.w700))
+                    : (Theme.of(context).textTheme.titleSmall?.copyWith(
+                              fontSize: 14,
+                              fontWeight: FontWeight.w500,
+                              color: c.textTertiary,
+                            ) ??
+                          const TextStyle(
+                              fontSize: 14, fontWeight: FontWeight.w500)),
+              ),
+            ),
+
+            const SizedBox(width: 12),
+
+            // ── Columna central: nombre + sección ─────────────────────
+            Expanded(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    memberName,
+                    style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                          fontWeight: FontWeight.w500,
+                          color: c.text,
+                        ),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                  if (sectionName != null) ...[
+                    const SizedBox(height: 2),
+                    Text(
+                      sectionName!,
+                      style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                            color: c.textTertiary,
+                          ),
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ],
+                ],
+              ),
+            ),
+
+            const SizedBox(width: 8),
+
+            // ── Score badge ───────────────────────────────────────────
+            _ScoreBadge(
+              score: compositeScore,
+              tierColor: tierColor,
+              formatScore: _formatScore,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+// ── Score badge ───────────────────────────────────────────────────────────────
+
+class _ScoreBadge extends StatelessWidget {
+  final double? score;
+  final Color tierColor;
+  final String Function(double) formatScore;
+
+  const _ScoreBadge({
+    required this.score,
+    required this.tierColor,
+    required this.formatScore,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final c = context.sac;
+    final hasScore = score != null;
+
+    final bgColor =
+        hasScore ? tierColor.withValues(alpha: 0.12) : c.borderLight;
+    final borderColor =
+        hasScore ? tierColor.withValues(alpha: 0.40) : c.borderLight;
+    final textColor = hasScore ? tierColor : c.textSecondary;
+    final label = hasScore ? formatScore(score!) : '—';
+
+    return Container(
+      width: 48,
+      height: 24,
+      decoration: BoxDecoration(
+        color: bgColor,
+        borderRadius: BorderRadius.circular(6),
+        border: Border.all(color: borderColor, width: 1),
+      ),
+      alignment: Alignment.center,
+      child: Text(
+        label,
+        style: Theme.of(context).textTheme.labelSmall?.copyWith(
+              fontWeight: FontWeight.w700,
+              color: textColor,
+            ),
+        overflow: TextOverflow.ellipsis,
+        maxLines: 1,
+      ),
+    );
+  }
+}

--- a/lib/features/rankings/presentation/widgets/ranking_empty_state.dart
+++ b/lib/features/rankings/presentation/widgets/ranking_empty_state.dart
@@ -1,0 +1,132 @@
+import 'package:flutter/material.dart';
+import 'package:hugeicons/hugeicons.dart';
+
+import '../../../../core/theme/sac_colors.dart';
+import '../../../../core/utils/icon_helper.dart';
+
+/// Razones por las que el ranking no se puede mostrar.
+enum RankingEmptyReason {
+  /// Visibilidad configurada como "oculto" por el director.
+  hidden,
+
+  /// Datos aún no calculados.
+  noData,
+
+  /// Error de red al cargar el ranking.
+  networkError,
+
+  /// Sección sin miembros suficientes para calcular rankings.
+  noSectionMembers,
+}
+
+/// Estado vacío genérico para el ranking, dirigido por [RankingEmptyReason].
+///
+/// Reutilizable por Task 25 (MyRankingScreen) y Task 26 (SectionRankingScreen).
+class RankingEmptyState extends StatelessWidget {
+  final RankingEmptyReason reason;
+
+  /// Callback solo usado para [RankingEmptyReason.networkError].
+  final VoidCallback? onRetry;
+
+  const RankingEmptyState({
+    super.key,
+    required this.reason,
+    this.onRetry,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final c = context.sac;
+    final config = _configFor(reason);
+
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(32),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          crossAxisAlignment: CrossAxisAlignment.center,
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            HugeIcon(
+              icon: config.icon,
+              size: 64,
+              color: c.textTertiary,
+            ),
+            const SizedBox(height: 20),
+            Text(
+              config.title,
+              style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                    color: c.text,
+                    fontWeight: FontWeight.w600,
+                  ),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 8),
+            Text(
+              config.body,
+              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                    color: c.textSecondary,
+                  ),
+              textAlign: TextAlign.center,
+            ),
+            if (reason == RankingEmptyReason.networkError &&
+                onRetry != null) ...[
+              const SizedBox(height: 24),
+              ElevatedButton(
+                onPressed: onRetry,
+                style: ElevatedButton.styleFrom(
+                  minimumSize: const Size(88, 44),
+                ),
+                child: const Text('Reintentar'),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+
+  _EmptyConfig _configFor(RankingEmptyReason reason) {
+    switch (reason) {
+      case RankingEmptyReason.hidden:
+        return _EmptyConfig(
+          icon: HugeIcons.strokeRoundedViewOff,
+          title: 'Ranking no disponible',
+          body:
+              'Tu director puede activar la visibilidad del ranking cuando esté listo.',
+        );
+      case RankingEmptyReason.noData:
+        return _EmptyConfig(
+          icon: HugeIcons.strokeRoundedClock01,
+          title: 'Aún no hay datos',
+          body:
+              'Tu ranking se calcula automáticamente. Volvé a revisar más tarde.',
+        );
+      case RankingEmptyReason.networkError:
+        return _EmptyConfig(
+          icon: HugeIcons.strokeRoundedWifiDisconnected01,
+          title: 'Sin conexión',
+          body: 'No pudimos cargar tu ranking.',
+        );
+      case RankingEmptyReason.noSectionMembers:
+        return _EmptyConfig(
+          icon: HugeIcons.strokeRoundedUserSearch01,
+          title: 'Todavía no hay rankings',
+          body:
+              'Los rankings se calculan automáticamente cada 24 hs. Las clases y camporees del año ya deben estar registrados.',
+        );
+    }
+  }
+}
+
+class _EmptyConfig {
+  final HugeIconData icon;
+  final String title;
+  final String body;
+
+  const _EmptyConfig({
+    required this.icon,
+    required this.title,
+    required this.body,
+  });
+}

--- a/lib/features/rankings/presentation/widgets/ranking_empty_state.dart
+++ b/lib/features/rankings/presentation/widgets/ranking_empty_state.dart
@@ -17,6 +17,9 @@ enum RankingEmptyReason {
 
   /// Sección sin miembros suficientes para calcular rankings.
   noSectionMembers,
+
+  /// Usuario sin permisos para ver el ranking de esta sección (RBAC).
+  unauthorized,
 }
 
 /// Estado vacío genérico para el ranking, dirigido por [RankingEmptyReason].
@@ -114,6 +117,13 @@ class RankingEmptyState extends StatelessWidget {
           title: 'Todavía no hay rankings',
           body:
               'Los rankings se calculan automáticamente cada 24 hs. Las clases y camporees del año ya deben estar registrados.',
+        );
+      case RankingEmptyReason.unauthorized:
+        return _EmptyConfig(
+          icon: HugeIcons.strokeRoundedShieldKey,
+          title: 'Acceso restringido',
+          body:
+              'No tenés permisos para ver el ranking de esta sección. Consultá con tu director.',
         );
     }
   }

--- a/lib/features/rankings/presentation/widgets/ranking_hero_card.dart
+++ b/lib/features/rankings/presentation/widgets/ranking_hero_card.dart
@@ -1,0 +1,220 @@
+import 'package:flutter/material.dart';
+
+import '../../../../core/theme/app_colors.dart';
+import '../../../../core/theme/app_theme.dart';
+
+/// Hero card con fondo oscuro (#1A1A1A) que muestra el puntaje compuesto del
+/// miembro como ancla visual principal.
+///
+/// Reglas de renderizado:
+/// - composite + rank presentes → layout completo.
+/// - composite presente + rank null → compuesto + sub-label, sin línea de rank.
+/// - ambos null → "Ranking pendiente" sin filas de datos.
+class RankingHeroCard extends StatelessWidget {
+  final double? compositeScore;
+  final int? rankPosition;
+  final int? totalInSection;
+  final String? awardedCategoryName;
+  final String? awardedCategoryTierId;
+  final String? sectionName;
+  final String ecclesiasticalYearLabel;
+
+  const RankingHeroCard({
+    super.key,
+    this.compositeScore,
+    this.rankPosition,
+    this.totalInSection,
+    this.awardedCategoryName,
+    this.awardedCategoryTierId,
+    this.sectionName,
+    required this.ecclesiasticalYearLabel,
+  });
+
+  /// Resuelve el color del tier a partir del ID de categoría.
+  /// Usa la misma función [achievementTierColor] que el resto de la app.
+  Color _tierColor() {
+    if (awardedCategoryTierId == null) {
+      // TODO(rankings): replace with domain tier field when AwardCategory exposes it via Task 24 entity update
+      return AppColors.darkBorder;
+    }
+    // Mapeamos el UUID a un tier heurístico por nombre convencional.
+    // Los UUIDs reales los maneja el backend; esta función es un fallback
+    // hasta que la capa de dominio exponga un campo `tier` en AwardCategory.
+    return AppColors.accent;
+  }
+
+  /// Formatea el puntaje: 1 decimal cuando la parte fraccionaria != 0.
+  String _formatScore(double score) {
+    if (score == score.truncateToDouble()) {
+      return score.toStringAsFixed(0);
+    }
+    return score.toStringAsFixed(1);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final tierColor = _tierColor();
+    final hasComposite = compositeScore != null;
+    final hasRank = rankPosition != null;
+
+    final rankLine = hasRank
+        ? (totalInSection != null
+            ? '#$rankPosition de $totalInSection'
+            : '#$rankPosition')
+        : null;
+
+    final semanticLabel = [
+      hasComposite
+          ? 'Tu puntaje compuesto es ${_formatScore(compositeScore!)}'
+          : 'Ranking pendiente',
+      if (rankLine != null) 'posición $rankLine',
+      if (awardedCategoryName != null) 'categoría $awardedCategoryName',
+    ].join(', ');
+
+    return Semantics(
+      label: semanticLabel,
+      child: Container(
+        constraints: const BoxConstraints(minHeight: 120),
+        margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+        decoration: BoxDecoration(
+          color: AppColors.darkSurface,
+          borderRadius: BorderRadius.circular(AppTheme.radiusMD),
+        ),
+        child: ClipRRect(
+          borderRadius: BorderRadius.circular(AppTheme.radiusMD),
+          child: IntrinsicHeight(
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                // Barra de acento lateral de 4px con color del tier.
+                Container(width: 4, color: tierColor),
+
+                // Contenido principal.
+                Expanded(
+                  child: Padding(
+                    padding: const EdgeInsets.all(20),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        // Fila superior: pill de categoría + año eclesiástico.
+                        Row(
+                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                          children: [
+                            if (awardedCategoryName != null)
+                              _CategoryPill(
+                                name: awardedCategoryName!,
+                                color: tierColor,
+                              )
+                            else
+                              const SizedBox.shrink(),
+                            Text(
+                              ecclesiasticalYearLabel,
+                              style: Theme.of(context)
+                                  .textTheme
+                                  .labelSmall
+                                  ?.copyWith(
+                                    color: Colors.white
+                                        .withValues(alpha: 0.6),
+                                  ),
+                            ),
+                          ],
+                        ),
+
+                        const SizedBox(height: 12),
+
+                        // Puntaje compuesto o mensaje pendiente.
+                        if (hasComposite) ...[
+                          Text(
+                            _formatScore(compositeScore!),
+                            style: Theme.of(context)
+                                .textTheme
+                                .displayLarge
+                                ?.copyWith(
+                                  color: AppColors.accent,
+                                  fontWeight: FontWeight.w700,
+                                  fontSize: 32,
+                                ),
+                          ),
+                          const SizedBox(height: 2),
+                          Text(
+                            'Puntaje compuesto',
+                            style: Theme.of(context)
+                                .textTheme
+                                .bodySmall
+                                ?.copyWith(
+                                  color: Colors.white.withValues(alpha: 0.6),
+                                  fontSize: 12,
+                                ),
+                          ),
+                        ] else ...[
+                          Text(
+                            'Ranking pendiente',
+                            style: Theme.of(context)
+                                .textTheme
+                                .bodyMedium
+                                ?.copyWith(
+                                  color: Colors.white.withValues(alpha: 0.6),
+                                ),
+                          ),
+                        ],
+
+                        // Línea de posición (solo si rankPosition != null).
+                        if (hasRank) ...[
+                          const SizedBox(height: 8),
+                          Text(
+                            '$rankLine'
+                            '${sectionName != null ? ' · Sección: $sectionName' : ''}',
+                            style: Theme.of(context)
+                                .textTheme
+                                .bodyMedium
+                                ?.copyWith(
+                                  color: Colors.white.withValues(alpha: 0.85),
+                                  fontSize: 14,
+                                ),
+                          ),
+                        ],
+                      ],
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Pill pequeña con el nombre de la categoría premiada.
+class _CategoryPill extends StatelessWidget {
+  final String name;
+  final Color color;
+
+  const _CategoryPill({required this.name, required this.color});
+
+  @override
+  Widget build(BuildContext context) {
+    return ConstrainedBox(
+      constraints: const BoxConstraints(maxWidth: 80),
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 3),
+        decoration: BoxDecoration(
+          color: color,
+          borderRadius: BorderRadius.circular(12),
+        ),
+        child: Text(
+          name.toUpperCase(),
+          style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                color: Colors.white,
+                fontWeight: FontWeight.w600,
+                fontSize: 10,
+              ),
+          overflow: TextOverflow.ellipsis,
+          maxLines: 1,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/rankings/presentation/widgets/ranking_skeleton.dart
+++ b/lib/features/rankings/presentation/widgets/ranking_skeleton.dart
@@ -1,0 +1,232 @@
+import 'package:flutter/material.dart';
+
+import '../../../../core/theme/app_colors.dart';
+import '../../../../core/theme/app_theme.dart';
+
+/// Skeleton de contenido para pantallas de ranking.
+///
+/// Dos constructores de fábrica:
+/// - [RankingSkeleton.myRanking] — layout de MyRankingScreen.
+/// - [RankingSkeleton.sectionList] — lista de sección.
+///
+/// Usa animación de opacidad simple para el efecto shimmer.
+/// Respeta `MediaQuery.disableAnimations` para usuarios con
+/// `prefers-reduced-motion` activado en el dispositivo.
+class RankingSkeleton extends StatefulWidget {
+  final _SkeletonMode _mode;
+  final int _rowCount;
+
+  const RankingSkeleton._({
+    required _SkeletonMode mode,
+    int rowCount = 8,
+  })  : _mode = mode,
+        _rowCount = rowCount;
+
+  /// Skeleton con la forma de la pantalla "Mi Ranking":
+  /// card hero oscura → 3 mini-cards → 8 filas de top-N.
+  factory RankingSkeleton.myRanking() =>
+      const RankingSkeleton._(mode: _SkeletonMode.myRanking);
+
+  /// Skeleton con la forma de una lista de sección.
+  factory RankingSkeleton.sectionList({int count = 8}) =>
+      RankingSkeleton._(mode: _SkeletonMode.sectionList, rowCount: count);
+
+  @override
+  State<RankingSkeleton> createState() => _RankingSkeletonState();
+}
+
+enum _SkeletonMode { myRanking, sectionList }
+
+class _RankingSkeletonState extends State<RankingSkeleton>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller;
+  late final Animation<double> _opacity;
+
+  @override
+  void initState() {
+    super.initState();
+
+    _controller = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 900),
+    );
+
+    _opacity = Tween<double>(begin: 0.4, end: 0.9).animate(
+      CurvedAnimation(parent: _controller, curve: Curves.easeInOut),
+    );
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    final reduceMotion =
+        MediaQuery.maybeOf(context)?.disableAnimations ?? false;
+    if (!reduceMotion && !_controller.isAnimating) {
+      _controller.repeat(reverse: true);
+    }
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedBuilder(
+      animation: _opacity,
+      builder: (context, _) {
+        return Opacity(
+          opacity: _opacity.value,
+          child: _buildContent(),
+        );
+      },
+    );
+  }
+
+  Widget _buildContent() {
+    switch (widget._mode) {
+      case _SkeletonMode.myRanking:
+        return _buildMyRankingSkeleton();
+      case _SkeletonMode.sectionList:
+        return _buildSectionListSkeleton();
+    }
+  }
+
+  Widget _buildMyRankingSkeleton() {
+    return SingleChildScrollView(
+      physics: const NeverScrollableScrollPhysics(),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const SizedBox(height: 8),
+
+            // Hero card oscura ~120dp.
+            _ShimmerBox(
+              height: 120,
+              color: AppColors.darkSurfaceVariant,
+              borderRadius: AppTheme.radiusMD,
+            ),
+
+            const SizedBox(height: 12),
+
+            // 3 mini-cards horizontales.
+            Row(
+              children: [
+                Expanded(
+                    child: _ShimmerBox(
+                        height: 80, borderRadius: AppTheme.radiusMD)),
+                const SizedBox(width: 8),
+                Expanded(
+                    child: _ShimmerBox(
+                        height: 80, borderRadius: AppTheme.radiusMD)),
+                const SizedBox(width: 8),
+                Expanded(
+                    child: _ShimmerBox(
+                        height: 80, borderRadius: AppTheme.radiusMD)),
+              ],
+            ),
+
+            const SizedBox(height: 20),
+
+            // Línea de nudge.
+            _ShimmerBox(height: 14, borderRadius: 4, widthFactor: 0.65),
+
+            const SizedBox(height: 20),
+
+            // Título "Tu sección".
+            _ShimmerBox(height: 12, borderRadius: 4, widthFactor: 0.3),
+
+            const SizedBox(height: 12),
+
+            // Filas del top-N.
+            ...List.generate(
+              8,
+              (i) => Padding(
+                padding: const EdgeInsets.only(bottom: 8),
+                child: _SectionRowSkeleton(),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildSectionListSkeleton() {
+    return ListView.builder(
+      physics: const NeverScrollableScrollPhysics(),
+      itemCount: widget._rowCount,
+      itemBuilder: (_, __) => Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+        child: _SectionRowSkeleton(),
+      ),
+    );
+  }
+}
+
+/// Caja de shimmer con forma rectangular.
+class _ShimmerBox extends StatelessWidget {
+  final double height;
+  final Color? color;
+  final double borderRadius;
+  final double widthFactor;
+
+  const _ShimmerBox({
+    required this.height,
+    this.color,
+    this.borderRadius = 8,
+    this.widthFactor = 1.0,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return FractionallySizedBox(
+      widthFactor: widthFactor,
+      child: Container(
+        height: height,
+        decoration: BoxDecoration(
+          color: color ?? AppColors.lightSurfaceVariant,
+          borderRadius: BorderRadius.circular(borderRadius),
+        ),
+      ),
+    );
+  }
+}
+
+/// Fila de skeleton para el listado de sección: circulo 32dp + 2 barras.
+class _SectionRowSkeleton extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        // Círculo izquierdo (posición / avatar).
+        Container(
+          width: 32,
+          height: 32,
+          decoration: const BoxDecoration(
+            color: AppColors.lightSurfaceVariant,
+            shape: BoxShape.circle,
+          ),
+        ),
+        const SizedBox(width: 12),
+
+        // Barra central (nombre).
+        Expanded(
+          child: _ShimmerBox(height: 12, borderRadius: 4),
+        ),
+        const SizedBox(width: 12),
+
+        // Barra derecha (puntaje badge) — ancho fijo 48dp para evitar
+        // excepción de eje horizontal no acotado con FractionallySizedBox.
+        SizedBox(
+          width: 48,
+          child: _ShimmerBox(height: 24, borderRadius: 8),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/rankings/presentation/widgets/ranking_skeleton.dart
+++ b/lib/features/rankings/presentation/widgets/ranking_skeleton.dart
@@ -61,8 +61,15 @@ class _RankingSkeletonState extends State<RankingSkeleton>
     super.didChangeDependencies();
     final reduceMotion =
         MediaQuery.maybeOf(context)?.disableAnimations ?? false;
-    if (!reduceMotion && !_controller.isAnimating) {
-      _controller.repeat(reverse: true);
+    if (reduceMotion) {
+      if (_controller.isAnimating) {
+        _controller.stop();
+        _controller.value = 0.9; // settle to high-opacity end state
+      }
+    } else {
+      if (!_controller.isAnimating) {
+        _controller.repeat(reverse: true);
+      }
     }
   }
 

--- a/lib/features/rankings/presentation/widgets/signal_score_row.dart
+++ b/lib/features/rankings/presentation/widgets/signal_score_row.dart
@@ -1,0 +1,119 @@
+import 'package:flutter/material.dart';
+import 'package:hugeicons/hugeicons.dart';
+
+import '../../../../core/theme/app_colors.dart';
+import '../../../../core/theme/sac_colors.dart';
+import '../../../../core/utils/icon_helper.dart';
+import '../../../../core/widgets/sac_card.dart';
+
+/// Fila con tres tarjetas de señal: Clase, Investidura y Camporees.
+///
+/// Cada tarjeta muestra el icono, el puntaje (o "—" si es null) y la etiqueta.
+/// Sin onTap — solo display (OD-1 bloqueado).
+class SignalScoreRow extends StatelessWidget {
+  final double? classScore;
+  final double? investitureScore;
+  final double? camporeeScore;
+
+  const SignalScoreRow({
+    super.key,
+    this.classScore,
+    this.investitureScore,
+    this.camporeeScore,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+      child: Row(
+        children: [
+          Expanded(
+            child: _SignalScoreCard(
+              icon: HugeIcons.strokeRoundedBook01,
+              score: classScore,
+              label: 'Clase',
+            ),
+          ),
+          const SizedBox(width: 8),
+          Expanded(
+            child: _SignalScoreCard(
+              icon: HugeIcons.strokeRoundedMedal01,
+              score: investitureScore,
+              label: 'Investidura',
+            ),
+          ),
+          const SizedBox(width: 8),
+          Expanded(
+            child: _SignalScoreCard(
+              icon: HugeIcons.strokeRoundedCampfire,
+              score: camporeeScore,
+              label: 'Camporees',
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Tarjeta individual de señal. Privada a este archivo.
+class _SignalScoreCard extends StatelessWidget {
+  final HugeIconData icon;
+  final double? score;
+  final String label;
+
+  const _SignalScoreCard({
+    required this.icon,
+    this.score,
+    required this.label,
+  });
+
+  /// Formatea el puntaje: 1 decimal cuando fraccionario != 0.
+  String _formatScore(double value) {
+    if (value == value.truncateToDouble()) return value.toStringAsFixed(0);
+    return value.toStringAsFixed(1);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final c = context.sac;
+    final hasScore = score != null;
+    final iconColor = hasScore ? AppColors.primary : c.textTertiary;
+
+    return SacCard(
+      padding: const EdgeInsets.symmetric(vertical: 12, horizontal: 8),
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(minHeight: 80),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            HugeIcon(icon: icon, size: 24, color: iconColor),
+            const SizedBox(height: 6),
+            Text(
+              hasScore ? _formatScore(score!) : '—',
+              style: Theme.of(context).textTheme.headlineSmall?.copyWith(
+                    fontSize: 18,
+                    fontWeight: FontWeight.w700,
+                    color: hasScore ? c.text : c.textTertiary,
+                  ),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 2),
+            Text(
+              label,
+              style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                    fontSize: 10,
+                    fontWeight: FontWeight.w500,
+                    color: c.textTertiary,
+                  ),
+              textAlign: TextAlign.center,
+              overflow: TextOverflow.ellipsis,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/rankings/presentation/widgets/top_n_section.dart
+++ b/lib/features/rankings/presentation/widgets/top_n_section.dart
@@ -1,0 +1,188 @@
+import 'package:flutter/material.dart';
+
+import '../../../../core/theme/app_colors.dart';
+import '../../../../core/theme/sac_colors.dart';
+import '../../domain/entities/member_ranking.dart';
+
+/// Sección que muestra el top-N anonimizado de la sección del miembro.
+///
+/// Solo se renderiza cuando [entries] no está vacío. Si el usuario no está
+/// en el top-N visible, se agrega una fila inferior con su posición.
+///
+/// Los nombres ya vienen anonimizados desde el backend como "Miembro #N";
+/// este widget los renderiza tal cual, sin transformación adicional.
+class TopNSection extends StatelessWidget {
+  final List<AnonymizedTopNEntry> entries;
+  final int? userOwnRankPosition;
+  final double? userOwnComposite;
+
+  const TopNSection({
+    super.key,
+    required this.entries,
+    this.userOwnRankPosition,
+    this.userOwnComposite,
+  });
+
+  /// Formatea el puntaje compuesto para el badge lateral.
+  String _formatScore(double value) {
+    if (value == value.truncateToDouble()) return value.toStringAsFixed(0);
+    return value.toStringAsFixed(1);
+  }
+
+  /// Determina si el usuario NO aparece ya en el top-N.
+  bool get _userBelowTopN {
+    if (userOwnRankPosition == null) return false;
+    if (entries.isEmpty) return false;
+    final lastTopN = entries
+        .map((e) => e.rankPosition)
+        .whereType<int>()
+        .fold<int?>(null, (prev, r) => prev == null || r > prev ? r : prev);
+    if (lastTopN == null) return false;
+    return userOwnRankPosition! > lastTopN;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (entries.isEmpty) return const SizedBox.shrink();
+
+    final c = context.sac;
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Tu sección',
+            style: Theme.of(context).textTheme.labelMedium?.copyWith(
+                  color: c.textSecondary,
+                ),
+          ),
+          const SizedBox(height: 6),
+          Divider(color: c.borderLight, height: 1),
+          const SizedBox(height: 4),
+
+          // Filas del top-N.
+          ...entries.map((entry) => _TopNRow(
+                entry: entry,
+                isCurrentUser: _isCurrentUserEntry(entry),
+                formatScore: _formatScore,
+              )),
+
+          // Pie de página con posición del usuario fuera del top-N.
+          if (_userBelowTopN) ...[
+            Divider(color: c.borderLight, height: 1),
+            const SizedBox(height: 6),
+            Text(
+              'Tu posición en la sección: #$userOwnRankPosition',
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                    color: c.textSecondary,
+                  ),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+
+  /// Identifica si esta entrada corresponde al usuario actual comparando
+  /// la posición. La lógica exacta depende del caller que pase ambos datos.
+  bool _isCurrentUserEntry(AnonymizedTopNEntry entry) {
+    if (userOwnRankPosition == null) return false;
+    return entry.rankPosition == userOwnRankPosition;
+  }
+}
+
+/// Fila individual del top-N.
+class _TopNRow extends StatelessWidget {
+  final AnonymizedTopNEntry entry;
+  final bool isCurrentUser;
+  final String Function(double) formatScore;
+
+  const _TopNRow({
+    required this.entry,
+    required this.isCurrentUser,
+    required this.formatScore,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final c = context.sac;
+
+    return Container(
+      margin: const EdgeInsets.symmetric(vertical: 2),
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 6),
+      decoration: BoxDecoration(
+        color: isCurrentUser ? AppColors.primarySurface : Colors.transparent,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Row(
+        children: [
+          // Posición: 24dp fijo, bodySmall w600 textTertiary.
+          SizedBox(
+            width: 24,
+            child: Text(
+              entry.rankPosition != null ? '#${entry.rankPosition}' : '—',
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                    fontWeight: FontWeight.w600,
+                    color: c.textTertiary,
+                  ),
+            ),
+          ),
+          const SizedBox(width: 8),
+
+          // Nombre anonimizado.
+          Expanded(
+            child: Text(
+              entry.memberName,
+              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                    color: c.text,
+                  ),
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
+          const SizedBox(width: 8),
+
+          // Badge de puntaje compuesto.
+          if (entry.compositeScorePct != null)
+            _CompositeBadge(
+              score: entry.compositeScorePct!,
+              formatScore: formatScore,
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Badge rectangular con el puntaje compuesto de cada miembro del top-N.
+class _CompositeBadge extends StatelessWidget {
+  final double score;
+  final String Function(double) formatScore;
+
+  const _CompositeBadge({required this.score, required this.formatScore});
+
+  @override
+  Widget build(BuildContext context) {
+    // Color del badge: accent con 15% de opacidad; texto accent.
+    const tierColor = AppColors.accent;
+
+    return Container(
+      width: 48,
+      height: 24,
+      alignment: Alignment.center,
+      decoration: BoxDecoration(
+        color: tierColor.withValues(alpha: 0.15),
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Text(
+        formatScore(score),
+        style: Theme.of(context).textTheme.labelSmall?.copyWith(
+              fontWeight: FontWeight.w600,
+              color: tierColor,
+              fontSize: 11,
+            ),
+      ),
+    );
+  }
+}

--- a/test/features/rankings/data/repositories/member_rankings_repository_impl_test.dart
+++ b/test/features/rankings/data/repositories/member_rankings_repository_impl_test.dart
@@ -1,0 +1,221 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:sacdia_app/core/errors/exceptions.dart';
+import 'package:sacdia_app/core/errors/failures.dart';
+import 'package:sacdia_app/core/network/network_info.dart';
+import 'package:sacdia_app/features/rankings/data/datasources/rankings_remote_data_source.dart';
+import 'package:sacdia_app/features/rankings/data/models/member_ranking_dto.dart';
+import 'package:sacdia_app/features/rankings/data/models/section_ranking_dto.dart';
+import 'package:sacdia_app/features/rankings/data/repositories/member_rankings_repository_impl.dart';
+import 'package:sacdia_app/features/rankings/domain/entities/member_ranking.dart';
+
+// ── Stubs ─────────────────────────────────────────────────────────────────────
+
+class _StubDataSource implements RankingsRemoteDataSource {
+  /// Set before each test case — [MyRankingResponseDto], [Exception], or
+  /// [MemberRankingHiddenException].
+  Object? getMyRankingResult;
+
+  @override
+  Future<MyRankingResponseDto> getMyRanking(
+    int yearId, {
+    cancelToken,
+  }) async {
+    final r = getMyRankingResult;
+    if (r is Exception) throw r;
+    return r as MyRankingResponseDto;
+  }
+
+  @override
+  Future<List<SectionRankingDto>> getSectionRankings({
+    required int yearId,
+    int? clubId,
+    int page = 1,
+    int limit = 20,
+    cancelToken,
+  }) =>
+      throw UnimplementedError();
+
+  @override
+  Future<List<SectionMemberDto>> getSectionMembers(
+    int sectionId,
+    int yearId, {
+    cancelToken,
+  }) =>
+      throw UnimplementedError();
+}
+
+class _AlwaysConnected implements NetworkInfo {
+  @override
+  Future<bool> get isConnected async => true;
+}
+
+class _NeverConnected implements NetworkInfo {
+  @override
+  Future<bool> get isConnected async => false;
+}
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+MyRankingResponseDto _myRankingDto({
+  String visibilityMode = 'self_only',
+  bool includeMember = true,
+}) {
+  return MyRankingResponseDto(
+    member: includeMember
+        ? const MemberRankingDto(
+            enrollmentId: 42,
+            userId: 'user-abc',
+            memberName: 'Juan Perez',
+            compositeScorePct: 75.5,
+            rankPosition: 3,
+          )
+        : null,
+    visibilityMode: visibilityMode,
+    topN: visibilityMode == 'self_and_top_n'
+        ? [
+            const AnonymizedTopNEntryDto(
+              memberName: 'Miembro #1',
+              compositeScorePct: 95.0,
+              rankPosition: 1,
+            ),
+          ]
+        : null,
+  );
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+void main() {
+  late _StubDataSource dataSource;
+  late MemberRankingsRepositoryImpl repository;
+
+  setUp(() {
+    dataSource = _StubDataSource();
+    repository = MemberRankingsRepositoryImpl(
+      remoteDataSource: dataSource,
+      networkInfo: _AlwaysConnected(),
+    );
+  });
+
+  group('MemberRankingsRepositoryImpl.getMyRanking', () {
+    // ── Case 1: 200 OK ────────────────────────────────────────────────────────
+
+    test('returns Right(MyRankingView) on success', () async {
+      dataSource.getMyRankingResult = _myRankingDto();
+
+      final result = await repository.getMyRanking(5);
+
+      expect(result.isRight(), isTrue);
+      result.fold(
+        (_) => fail('Expected Right'),
+        (view) {
+          expect(view, isNotNull);
+          expect(view!.member?.enrollmentId, 42);
+          expect(view.member?.memberName, 'Juan Perez');
+          expect(view.member?.compositeScorePct, 75.5);
+          expect(view.member?.rankPosition, 3);
+          expect(view.visibilityMode, MyRankingVisibilityMode.selfOnly);
+        },
+      );
+    });
+
+    // ── Case 2: 200 OK with top_n ─────────────────────────────────────────────
+
+    test('maps top_n entries correctly when visibility=self_and_top_n',
+        () async {
+      dataSource.getMyRankingResult =
+          _myRankingDto(visibilityMode: 'self_and_top_n');
+
+      final result = await repository.getMyRanking(5);
+
+      expect(result.isRight(), isTrue);
+      result.fold(
+        (_) => fail('Expected Right'),
+        (view) {
+          expect(view!.visibilityMode,
+              MyRankingVisibilityMode.selfAndTopN);
+          expect(view.topN, isNotNull);
+          expect(view.topN!, hasLength(1));
+          expect(view.topN!.first.memberName, 'Miembro #1');
+          expect(view.topN!.first.compositeScorePct, 95.0);
+          expect(view.topN!.first.rankPosition, 1);
+        },
+      );
+    });
+
+    // ── Case 3: 403 MEMBER_RANKING_HIDDEN → Right(null) ───────────────────────
+
+    test(
+        'returns Right(null) when datasource throws MemberRankingHiddenException',
+        () async {
+      dataSource.getMyRankingResult = MemberRankingHiddenException();
+
+      final result = await repository.getMyRanking(5);
+
+      expect(result.isRight(), isTrue);
+      result.fold(
+        (_) => fail('Expected Right(null)'),
+        (view) => expect(view, isNull),
+      );
+    });
+
+    // ── Case 4: Other 403 (MEMBER_RANKING_SCOPE_DENIED) → Left(AuthFailure) ──
+
+    test('returns Left(AuthFailure) when datasource throws AuthException',
+        () async {
+      dataSource.getMyRankingResult = AuthException(
+        message: 'MEMBER_RANKING_SCOPE_DENIED',
+        code: 403,
+      );
+
+      final result = await repository.getMyRanking(5);
+
+      expect(result.isLeft(), isTrue);
+      result.fold(
+        (failure) {
+          expect(failure, isA<AuthFailure>());
+          expect(failure.code, 403);
+        },
+        (_) => fail('Expected Left'),
+      );
+    });
+
+    // ── Case 5: 500 → Left(ServerFailure) ────────────────────────────────────
+
+    test('returns Left(ServerFailure) when datasource throws ServerException',
+        () async {
+      dataSource.getMyRankingResult =
+          ServerException(message: 'Internal Server Error', code: 500);
+
+      final result = await repository.getMyRanking(5);
+
+      expect(result.isLeft(), isTrue);
+      result.fold(
+        (failure) {
+          expect(failure, isA<ServerFailure>());
+          expect((failure as ServerFailure).message, 'Internal Server Error');
+          expect(failure.code, 500);
+        },
+        (_) => fail('Expected Left'),
+      );
+    });
+
+    // ── Case 6: No internet → Left(NetworkFailure) ────────────────────────────
+
+    test('returns Left(NetworkFailure) when device is offline', () async {
+      final offlineRepo = MemberRankingsRepositoryImpl(
+        remoteDataSource: dataSource,
+        networkInfo: _NeverConnected(),
+      );
+
+      final result = await offlineRepo.getMyRanking(5);
+
+      expect(result.isLeft(), isTrue);
+      result.fold(
+        (failure) => expect(failure, isA<NetworkFailure>()),
+        (_) => fail('Expected Left'),
+      );
+    });
+  });
+}

--- a/test/features/rankings/data/repositories/section_rankings_repository_impl_test.dart
+++ b/test/features/rankings/data/repositories/section_rankings_repository_impl_test.dart
@@ -1,0 +1,248 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:sacdia_app/core/errors/exceptions.dart';
+import 'package:sacdia_app/core/errors/failures.dart';
+import 'package:sacdia_app/core/network/network_info.dart';
+import 'package:sacdia_app/features/rankings/data/datasources/rankings_remote_data_source.dart';
+import 'package:sacdia_app/features/rankings/data/models/member_ranking_dto.dart';
+import 'package:sacdia_app/features/rankings/data/models/section_ranking_dto.dart';
+import 'package:sacdia_app/features/rankings/data/repositories/section_rankings_repository_impl.dart';
+
+// ── Stubs ─────────────────────────────────────────────────────────────────────
+
+class _StubDataSource implements RankingsRemoteDataSource {
+  Object? getSectionRankingsResult;
+  Object? getSectionMembersResult;
+
+  @override
+  Future<MyRankingResponseDto> getMyRanking(
+    int yearId, {
+    cancelToken,
+  }) =>
+      throw UnimplementedError();
+
+  @override
+  Future<List<SectionRankingDto>> getSectionRankings({
+    required int yearId,
+    int? clubId,
+    int page = 1,
+    int limit = 20,
+    cancelToken,
+  }) async {
+    final r = getSectionRankingsResult;
+    if (r is Exception) throw r;
+    return r as List<SectionRankingDto>;
+  }
+
+  @override
+  Future<List<SectionMemberDto>> getSectionMembers(
+    int sectionId,
+    int yearId, {
+    cancelToken,
+  }) async {
+    final r = getSectionMembersResult;
+    if (r is Exception) throw r;
+    return r as List<SectionMemberDto>;
+  }
+}
+
+class _AlwaysConnected implements NetworkInfo {
+  @override
+  Future<bool> get isConnected async => true;
+}
+
+class _NeverConnected implements NetworkInfo {
+  @override
+  Future<bool> get isConnected async => false;
+}
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+SectionRankingDto _sectionDto({
+  int clubSectionId = 10,
+  String sectionName = 'Sección A',
+  double? compositeScorePct = 80.0,
+  int? rankPosition = 1,
+  int activeEnrollmentCount = 12,
+}) {
+  return SectionRankingDto(
+    clubSectionId: clubSectionId,
+    sectionName: sectionName,
+    compositeScorePct: compositeScorePct,
+    rankPosition: rankPosition,
+    activeEnrollmentCount: activeEnrollmentCount,
+  );
+}
+
+SectionMemberDto _memberDto({
+  int enrollmentId = 1,
+  String userId = 'user-xyz',
+  String memberName = 'Maria Lopez',
+  double? compositeScorePct = 90.0,
+  int? rankPosition = 1,
+}) {
+  return SectionMemberDto(
+    enrollmentId: enrollmentId,
+    userId: userId,
+    memberName: memberName,
+    compositeScorePct: compositeScorePct,
+    rankPosition: rankPosition,
+  );
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+void main() {
+  late _StubDataSource dataSource;
+  late SectionRankingsRepositoryImpl repository;
+
+  setUp(() {
+    dataSource = _StubDataSource();
+    repository = SectionRankingsRepositoryImpl(
+      remoteDataSource: dataSource,
+      networkInfo: _AlwaysConnected(),
+    );
+  });
+
+  // ── getSectionRankings ────────────────────────────────────────────────────────
+
+  group('SectionRankingsRepositoryImpl.getSectionRankings', () {
+    test('returns Right(List<SectionRanking>) on 200 OK', () async {
+      dataSource.getSectionRankingsResult = [
+        _sectionDto(),
+        _sectionDto(
+          clubSectionId: 11,
+          sectionName: 'Sección B',
+          compositeScorePct: 70.0,
+          rankPosition: 2,
+        ),
+      ];
+
+      final result = await repository.getSectionRankings(yearId: 5);
+
+      expect(result.isRight(), isTrue);
+      result.fold(
+        (_) => fail('Expected Right'),
+        (sections) {
+          expect(sections, hasLength(2));
+          expect(sections.first.clubSectionId, 10);
+          expect(sections.first.sectionName, 'Sección A');
+          expect(sections.first.compositeScorePct, 80.0);
+          expect(sections.first.rankPosition, 1);
+          expect(sections.first.activeEnrollmentCount, 12);
+        },
+      );
+    });
+
+    test('returns Left(AuthFailure) when datasource throws AuthException',
+        () async {
+      dataSource.getSectionRankingsResult = AuthException(
+        message: 'MEMBER_RANKING_SCOPE_DENIED',
+        code: 403,
+      );
+
+      final result = await repository.getSectionRankings(yearId: 5);
+
+      expect(result.isLeft(), isTrue);
+      result.fold(
+        (failure) {
+          expect(failure, isA<AuthFailure>());
+          expect(failure.code, 403);
+        },
+        (_) => fail('Expected Left'),
+      );
+    });
+
+    test('returns Left(NetworkFailure) when offline', () async {
+      final offlineRepo = SectionRankingsRepositoryImpl(
+        remoteDataSource: dataSource,
+        networkInfo: _NeverConnected(),
+      );
+
+      final result = await offlineRepo.getSectionRankings(yearId: 5);
+
+      expect(result.isLeft(), isTrue);
+      result.fold(
+        (failure) => expect(failure, isA<NetworkFailure>()),
+        (_) => fail('Expected Left'),
+      );
+    });
+  });
+
+  // ── getSectionMembers ─────────────────────────────────────────────────────────
+
+  group('SectionRankingsRepositoryImpl.getSectionMembers', () {
+    test('returns Right(List<SectionMember>) on 200 OK', () async {
+      dataSource.getSectionMembersResult = [
+        _memberDto(),
+        _memberDto(
+          enrollmentId: 2,
+          userId: 'user-abc',
+          memberName: 'Pedro Ramirez',
+          compositeScorePct: 85.0,
+          rankPosition: 2,
+        ),
+      ];
+
+      final result = await repository.getSectionMembers(10, 5);
+
+      expect(result.isRight(), isTrue);
+      result.fold(
+        (_) => fail('Expected Right'),
+        (members) {
+          expect(members, hasLength(2));
+          final first = members.first;
+          expect(first.enrollmentId, 1);
+          expect(first.memberName, 'Maria Lopez');
+          expect(first.compositeScorePct, 90.0);
+          expect(first.rankPosition, 1);
+        },
+      );
+    });
+
+    test('returns Left(ServerFailure) when datasource throws ServerException',
+        () async {
+      dataSource.getSectionMembersResult = ServerException(
+        message: 'Not Found',
+        code: 404,
+      );
+
+      final result = await repository.getSectionMembers(10, 5);
+
+      expect(result.isLeft(), isTrue);
+      result.fold(
+        (failure) {
+          expect(failure, isA<ServerFailure>());
+          expect(failure.code, 404);
+        },
+        (_) => fail('Expected Left'),
+      );
+    });
+
+    test('maps SectionMember entity fields from DTO correctly', () async {
+      dataSource.getSectionMembersResult = [
+        _memberDto(
+          enrollmentId: 99,
+          userId: 'user-999',
+          memberName: 'Ana Torres',
+          compositeScorePct: 77.3,
+          rankPosition: 5,
+        ),
+      ];
+
+      final result = await repository.getSectionMembers(10, 5);
+
+      result.fold(
+        (_) => fail('Expected Right'),
+        (members) {
+          final m = members.first;
+          expect(m.enrollmentId, 99);
+          expect(m.userId, 'user-999');
+          expect(m.memberName, 'Ana Torres');
+          expect(m.compositeScorePct, 77.3);
+          expect(m.rankPosition, 5);
+        },
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Plan 8.4-A Phase 4 mobile shipping. Full Clean Architecture data layer + 2 screens with "Cuaderno de Campo + Dark Anchor" visual direction + dashboard quick-access nav wiring.

**Tasks 24-26 + nav wiring follow-up shipped.**

## Architecture

### Data layer (Task 24)
- `lib/features/rankings/domain/entities/{member_ranking,section_ranking}.dart` — entities + `MyRankingView` (composite + topN + visibilityMode enum) + `AnonymizedTopNEntry` + `AwardCategory`
- `lib/features/rankings/data/models/*` — DTOs with snake_case verbatim + toEntity()
- `lib/features/rankings/data/datasources/rankings_remote_data_source.dart` — Dio + CancelToken + typed `MemberRankingHiddenException` for visibility=hidden → Right(null) UX flow
- `lib/features/rankings/data/repositories/*_impl.dart` — Either<Failure, T> via dartz, follows annual_folders pattern
- Riverpod 2.6.1: `myRankingProvider.family<MyRankingView?, int yearId>`, `sectionRankingsProvider`, `sectionMembersProvider` with `ref.keepAlive()` + CancelToken lifecycle
- 12/12 unit tests GREEN (mockito hand-written stubs)

### MyRankingScreen (Task 25)
- 6 widgets: `ranking_hero_card` (dark anchor #1A1A1A composite hero) + `signal_score_row` (3 SacCard mini-cards) + `top_n_section` (anonymized) + `ranking_empty_state` (5 reasons enum) + `ranking_skeleton` (content-shaped) + screen
- HugeIcons only: `strokeRoundedBook01` / `strokeRoundedMedal01` / `strokeRoundedCampfire` (Tent01 not in 1.1.5 — Campfire fits Camporees)
- Pull-to-refresh, contextual nudge derived from lowest non-null signal, NO podium coloring
- 1115 LOC

### SectionRankingScreen (Task 26)
- 2 files (screen + `member_ranking_list_tile`) + extended `RankingEmptyState` with `unauthorized` reason
- RBAC client-gate via `clubContextProvider.roleName` ∈ ['director', 'sub_director', 'secretario', 'secretario_tesorero', 'counselor']
- Defense-in-depth: 3 RBAC layers (card visibility + backend perm + screen gate)
- 392 LOC

### Navigation wiring
- go_router StatefulShellBranch 17 (state-preserving, NOT in bottom nav) for MyRankingScreen at `/home/my-ranking`
- Plain GoRoute outside shell for SectionRankingScreen at `/section-ranking/:sectionId` (drill-down via push)
- 2 quick-access dashboard cards: "Mi ranking" universal + "Ranking de sección" gated by `units:update` permission with `routeResolver` closure deriving `sectionId` from `clubContextProvider`
- 4 i18n translation files (es/en/fr/pt-BR) — quick_access keys
- HugeIcons verified: `strokeRoundedRanking` + `strokeRoundedAward01`

## Visual direction "Cuaderno de Campo + Dark Anchor"

ui-ux-designer + nextlevelbuilder skill synthesis. Anti-toxicity techniques implemented end-to-end:
- Anonymized top_n via backend member_label
- Null = "—" textTertiary (NEVER 0/red)
- Contextual nudge derives from lowest non-null signal
- NO podium coloring positions 1-3
- "Registro de progreso" director framing (NOT "Ranking")
- Empty state visibility=hidden = SILENCE (no shouty placeholder)

## Consistency pass (Plan 8.4-A nits A+B+C)

- B (cross-cutting): `Failure abstract class implements Exception` — pre-existing tech debt, 1-line core fix
- C2 (a11y BUG): RankingSkeleton respects `reduceMotion` mid-life via symmetric stop+settle in didChangeDependencies

## Stack

- Flutter + Riverpod 2.6.1 + Clean Architecture (data/domain/presentation)
- Dio + cancelToken
- Either<Failure, T> via dartz
- HugeIcons (HugeIconData typedef mandatory per project memory)
- Existing Scout Vibrante theme (`AppColors.darkSurface` + `AppColors.accent` for hero anchor)

## Test plan

- [x] flutter analyze lib/features/rankings/ → 0 issues
- [x] flutter test test/features/rankings/ → 12/12 GREEN
- [x] Combined reviews per task — 2 CRITICAL + N IMPORTANT applied inline via Sonnet sub-agents
- [x] Backend contract verified (DTOs match real backend response shapes verbatim)
- [ ] Manual UI smoke on physical device after merge — verify dark hero card readability + RBAC gating + pull-to-refresh
- [ ] Verify quick-access cards render correctly per role (admin/director sees both, member only "Mi ranking")

## Companion PRs

- sacdia (root) — orchestration + canon docs
- sacdia-backend — REST APIs consumed
- sacdia-admin — admin parallel pages