### PR TITLE
feat(virtual_card): horizontal layout, shared QR tile, responsive skeleton

### DIFF
--- a/lib/features/achievements/presentation/views/achievement_detail_sheet.dart
+++ b/lib/features/achievements/presentation/views/achievement_detail_sheet.dart
@@ -76,13 +76,15 @@ class AchievementDetailSheet extends StatelessWidget {
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.center,
                     children: [
+                      const SizedBox(height: 16),
+
                       // Badge large
                       AchievementBadge(
                         badgeImageUrl: achievement.badgeImageUrl,
                         tier: achievement.tier,
                         visualState: visualState,
                         isSecret: achievement.secret,
-                        size: 96,
+                        size: 146,
                         progress: userAchievement?.progressPercentage ?? 0.0,
                       ),
                       const SizedBox(height: 16),
@@ -92,11 +94,11 @@ class AchievementDetailSheet extends StatelessWidget {
                         isSecret ? '???' : achievement.name,
                         style: Theme.of(context)
                             .textTheme
-                            .headlineSmall
+                            .headlineMedium
                             ?.copyWith(fontWeight: FontWeight.w700),
                         textAlign: TextAlign.center,
                       ),
-                      const SizedBox(height: 8),
+                      const SizedBox(height: 15),
 
                       // Tier + Points badges
                       Row(
@@ -206,7 +208,7 @@ class AchievementDetailSheet extends StatelessWidget {
                           label: 'achievements.views.detail_completed_on'.tr(),
                           value: _formatDate(userAchievement!.completedAt!),
                         ),
-                        const SizedBox(height: 8),
+                        const SizedBox(height: 12),
                       ],
 
                       const SizedBox(height: 32),

--- a/lib/features/virtual_card/data/models/virtual_card_model.dart
+++ b/lib/features/virtual_card/data/models/virtual_card_model.dart
@@ -20,6 +20,12 @@ class VirtualCardModel extends VirtualCard {
   });
 
   factory VirtualCardModel.fromJson(Map<String, dynamic> json) {
+    final member = json['member'] is Map
+        ? Map<String, dynamic>.from(json['member'] as Map)
+        : null;
+    final visual = json['visual'] is Map
+        ? Map<String, dynamic>.from(json['visual'] as Map)
+        : null;
     final club = json['club'] is Map<String, dynamic>
         ? json['club'] as Map<String, dynamic>
         : null;
@@ -29,42 +35,71 @@ class VirtualCardModel extends VirtualCard {
     final rawExpiresAt = json['qr_expires_at'] as String? ??
         json['expires_at'] as String? ??
         json['expiresAt'] as String?;
+    final userId = _pickString([
+      json['user_id'],
+      member?['user_id'],
+      json['id'],
+    ]);
+    final cardIdShort = _pickString([
+      json['card_id_short'],
+      json['card_id'],
+      json['short_id'],
+      userId == null ? null : _shortId(userId),
+    ]);
 
     return VirtualCardModel(
-      userId: (json['user_id'] as String? ?? json['id'] as String? ?? '').trim(),
-      fullName: (json['name_full'] as String? ??
-              json['full_name'] as String? ??
-              json['name'] as String? ??
-              '')
-          .trim(),
-      photoUrl: json['photo_url'] as String? ??
-          json['avatar'] as String? ??
-          json['user_image'] as String?,
-      roleLabel: json['role_label'] as String? ??
-          json['role'] as String? ??
-          json['role_name'] as String?,
-      roleCode: json['role_code'] as String? ??
-          json['role_name'] as String? ??
-          json['role'] as String?,
-      clubName: json['club_name'] as String? ??
-          club?['club_name'] as String? ??
-          club?['name'] as String?,
+      userId: userId ?? '',
+      fullName: _pickString([
+            json['name_full'],
+            json['full_name'],
+            member?['full_name'],
+            visual?['primary_line'],
+            json['name'],
+          ]) ??
+          '',
+      photoUrl: _pickString([
+        json['photo_url'],
+        json['avatar'],
+        member?['avatar'],
+        json['user_image'],
+      ]),
+      roleLabel: _pickString([
+        json['role_label'],
+        json['role'],
+        json['role_name'],
+      ]),
+      roleCode: _pickString([
+        json['role_code'],
+        json['role_name'],
+        json['role'],
+      ]),
+      clubName: _pickString([
+        json['club_name'],
+        member?['club_name'],
+        visual?['club_name'],
+        club?['club_name'],
+        club?['name'],
+      ]),
       clubLogoUrl: json['club_logo_url'] as String? ??
           json['club_logo'] as String? ??
           club?['logo_url'] as String?,
-      sectionName: json['section_name'] as String? ??
-          json['section'] as String? ??
-          json['current_class'] as String?,
-      memberSince: rawMemberSince != null ? DateTime.tryParse(rawMemberSince) : null,
+      sectionName: _pickString([
+        json['section_name'],
+        member?['section_name'],
+        visual?['section_name'],
+        json['section'],
+        json['current_class'],
+      ]),
+      memberSince:
+          rawMemberSince != null ? DateTime.tryParse(rawMemberSince) : null,
       achievementTier: VirtualCardTier.fromString(
         (json['achievement_tier'] as String? ?? json['tier'] as String?),
       ),
-      cardIdShort: json['card_id_short'] as String? ??
-          json['card_id'] as String? ??
-          json['short_id'] as String?,
+      cardIdShort: cardIdShort,
       qrToken: json['qr_token'] as String? ?? json['token'] as String?,
-      qrExpiresAt:
-          rawExpiresAt != null ? DateTime.tryParse(rawExpiresAt)?.toUtc() : null,
+      qrExpiresAt: rawExpiresAt != null
+          ? DateTime.tryParse(rawExpiresAt)?.toUtc()
+          : null,
       isActive: json['is_active'] as bool? ?? true,
       isOffline: json['is_offline'] as bool? ?? false,
     );
@@ -88,5 +123,21 @@ class VirtualCardModel extends VirtualCard {
       'is_active': isActive,
       'is_offline': isOffline,
     };
+  }
+
+  static String? _pickString(Iterable<Object?> values) {
+    for (final value in values) {
+      final normalized = value?.toString().trim();
+      if (normalized != null && normalized.isNotEmpty) {
+        return normalized;
+      }
+    }
+    return null;
+  }
+
+  static String _shortId(String value) {
+    final normalized = value.trim();
+    if (normalized.length <= 8) return normalized;
+    return normalized.substring(normalized.length - 8);
   }
 }

--- a/lib/features/virtual_card/presentation/views/virtual_card_qr_fullscreen_view.dart
+++ b/lib/features/virtual_card/presentation/views/virtual_card_qr_fullscreen_view.dart
@@ -2,9 +2,9 @@ import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:hugeicons/hugeicons.dart';
-import 'package:qr_flutter/qr_flutter.dart';
 
 import '../../domain/entities/virtual_card.dart';
+import '../widgets/virtual_card_qr_tile.dart';
 
 class VirtualCardQrFullscreenView extends StatefulWidget {
   const VirtualCardQrFullscreenView({
@@ -51,25 +51,28 @@ class _VirtualCardQrFullscreenViewState
                   children: [
                     Hero(
                       tag: 'virtual-card-qr-${card.userId}',
+                      transitionOnUserGestures: true,
                       child: _QrTile(card: card),
                     ),
                     const SizedBox(height: 24),
                     Text(
                       card.fullName,
                       textAlign: TextAlign.center,
-                      style: Theme.of(context).textTheme.headlineSmall?.copyWith(
-                            fontWeight: FontWeight.w700,
-                            color: Colors.black,
-                          ),
+                      style:
+                          Theme.of(context).textTheme.headlineSmall?.copyWith(
+                                fontWeight: FontWeight.w700,
+                                color: Colors.black,
+                              ),
                     ),
                     const SizedBox(height: 6),
                     if ((card.roleLabel ?? '').trim().isNotEmpty)
                       Text(
                         card.roleLabel!,
                         textAlign: TextAlign.center,
-                        style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                              color: Colors.black87,
-                            ),
+                        style:
+                            Theme.of(context).textTheme.titleMedium?.copyWith(
+                                  color: Colors.black87,
+                                ),
                       ),
                     const SizedBox(height: 20),
                     if (qrToken == null || qrToken.isEmpty)
@@ -116,34 +119,33 @@ class _QrTile extends StatelessWidget {
       width: MediaQuery.sizeOf(context).width * 0.8,
       child: AspectRatio(
         aspectRatio: 1,
-        child: Container(
-          padding: const EdgeInsets.all(20),
-          decoration: BoxDecoration(
-            color: Colors.white,
-            borderRadius: BorderRadius.circular(28),
-            boxShadow: const [
-              BoxShadow(
-                blurRadius: 28,
-                spreadRadius: 0,
-                offset: Offset(0, 12),
-                color: Color(0x220F1B2D),
-              ),
-            ],
-          ),
-          child: card.canShowQr
-              ? QrImageView(
-                  data: card.qrToken!,
-                  version: QrVersions.auto,
-                  backgroundColor: Colors.white,
-                  errorCorrectionLevel: QrErrorCorrectLevel.M,
-                )
-              : Center(
+        child: card.canShowQr
+            ? VirtualCardQrTile(
+                data: card.qrToken!,
+                maxSize: double.infinity,
+                padding: 20,
+                borderRadius: 28,
+                showShadow: true,
+              )
+            : DecoratedBox(
+                decoration: BoxDecoration(
+                  color: Colors.white,
+                  borderRadius: BorderRadius.circular(28),
+                  boxShadow: const [
+                    BoxShadow(
+                      blurRadius: 28,
+                      offset: Offset(0, 12),
+                      color: Color(0x220F1B2D),
+                    ),
+                  ],
+                ),
+                child: Center(
                   child: Text(
                     'virtual_card.qr_unavailable'.tr(),
                     textAlign: TextAlign.center,
                   ),
                 ),
-        ),
+              ),
       ),
     );
   }

--- a/lib/features/virtual_card/presentation/views/virtual_card_view.dart
+++ b/lib/features/virtual_card/presentation/views/virtual_card_view.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:hugeicons/hugeicons.dart';
 
 import '../../../../core/errors/exceptions.dart';
+import '../../domain/entities/virtual_card.dart';
 import '../providers/virtual_card_providers.dart';
 import '../widgets/virtual_card_face.dart';
 import '../widgets/virtual_card_skeleton.dart';
@@ -80,15 +81,11 @@ class _VirtualCardViewState extends ConsumerState<VirtualCardView> {
                               card: card,
                               onShowQr: card.canShowQr
                                   ? () => Navigator.of(context).push(
-                                        MaterialPageRoute(
-                                          builder: (_) =>
-                                              VirtualCardQrFullscreenView(
-                                            card: card,
-                                          ),
-                                        ),
+                                        _qrFullscreenRoute(card),
                                       )
                                   : _refresh,
-                              onPhotoTap: card.photoUrl?.trim().isNotEmpty == true
+                              onPhotoTap: card.photoUrl?.trim().isNotEmpty ==
+                                      true
                                   ? () => Navigator.of(context).push(
                                         MaterialPageRoute(
                                           builder: (_) => VirtualCardPhotoView(
@@ -173,4 +170,24 @@ String virtualCardErrorMessageKey(Object error) {
   }
 
   return 'virtual_card.errors.load_failed';
+}
+
+Route<void> _qrFullscreenRoute(VirtualCard card) {
+  return PageRouteBuilder<void>(
+    transitionDuration: const Duration(milliseconds: 260),
+    reverseTransitionDuration: const Duration(milliseconds: 220),
+    pageBuilder: (_, __, ___) => VirtualCardQrFullscreenView(card: card),
+    transitionsBuilder: (_, animation, __, child) {
+      final curved = CurvedAnimation(
+        parent: animation,
+        curve: Curves.easeOutCubic,
+        reverseCurve: Curves.easeInCubic,
+      );
+
+      return FadeTransition(
+        opacity: curved,
+        child: child,
+      );
+    },
+  );
 }

--- a/lib/features/virtual_card/presentation/widgets/virtual_card_face.dart
+++ b/lib/features/virtual_card/presentation/widgets/virtual_card_face.dart
@@ -2,9 +2,9 @@ import 'package:cached_network_image/cached_network_image.dart';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:hugeicons/hugeicons.dart';
-import 'package:qr_flutter/qr_flutter.dart';
 
 import '../../domain/entities/virtual_card.dart';
+import 'virtual_card_qr_tile.dart';
 
 class VirtualCardFace extends StatelessWidget {
   const VirtualCardFace({
@@ -26,9 +26,12 @@ class VirtualCardFace extends StatelessWidget {
     final isDark = brightness == Brightness.dark;
     final background = isDark ? const Color(0xFF1A2235) : Colors.white;
     final header = isDark ? const Color(0xFF0B1A36) : const Color(0xFF0F2645);
-    final textPrimary = isDark ? const Color(0xFFF4F7FB) : const Color(0xFF0F1B2D);
-    final textSecondary = isDark ? const Color(0xFFA0AABF) : const Color(0xFF5A6378);
-    final textTertiary = isDark ? const Color(0xFF5A6378) : const Color(0xFF9099AB);
+    final textPrimary =
+        isDark ? const Color(0xFFF4F7FB) : const Color(0xFF0F1B2D);
+    final textSecondary =
+        isDark ? const Color(0xFFA0AABF) : const Color(0xFF5A6378);
+    final textTertiary =
+        isDark ? const Color(0xFF5A6378) : const Color(0xFF9099AB);
     final divider = isDark ? const Color(0xFF2A344C) : const Color(0xFFE5E8EE);
 
     final tier = card.achievementTier ?? VirtualCardTier.unknown;
@@ -73,94 +76,30 @@ class VirtualCardFace extends StatelessWidget {
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.stretch,
                     children: [
-                      Center(
-                        child: GestureDetector(
-                          onTap: card.photoUrl?.trim().isNotEmpty == true
-                              ? onPhotoTap
-                              : null,
-                          child: Semantics(
-                            label: 'virtual_card.photo_alt'.tr(
-                              namedArgs: {'name': card.fullName},
-                            ),
-                            child: _Avatar(
-                              photoUrl: card.photoUrl,
-                              fullName: card.fullName,
-                              tierColor: tierPalette.border,
-                            ),
-                          ),
-                        ),
-                      ),
-                      const SizedBox(height: 18),
-                      Text(
-                        card.fullName,
-                        textAlign: TextAlign.center,
-                        maxLines: 2,
-                        overflow: TextOverflow.ellipsis,
-                        style: TextStyle(
-                          fontSize: 24,
-                          fontWeight: FontWeight.w700,
-                          color: textPrimary,
-                          letterSpacing: -0.4,
-                        ),
-                      ),
-                      if ((card.roleLabel ?? '').trim().isNotEmpty) ...[
-                        const SizedBox(height: 8),
-                        Text(
-                          card.roleLabel!,
-                          textAlign: TextAlign.center,
-                          style: TextStyle(
-                            fontSize: 14,
-                            fontWeight: FontWeight.w500,
-                            color: textSecondary,
-                            letterSpacing: 0.6,
-                          ),
-                        ),
-                      ],
-                      const SizedBox(height: 18),
-                      Divider(color: divider, height: 1),
-                      const SizedBox(height: 16),
-                      _MetaRow(
-                        label: 'virtual_card.club_label'.tr(),
-                        value: card.clubName,
+                      _IdentitySummary(
+                        card: card,
+                        tierColor: tierPalette.border,
                         textPrimary: textPrimary,
                         textSecondary: textSecondary,
+                        onPhotoTap: onPhotoTap,
                       ),
-                      if ((card.sectionName ?? '').trim().isNotEmpty) ...[
-                        const SizedBox(height: 14),
-                        _MetaRow(
-                          label: 'virtual_card.section_label'.tr(),
-                          value: card.sectionName,
-                          textPrimary: textPrimary,
-                          textSecondary: textSecondary,
-                        ),
-                      ],
-                      if (card.memberSince != null) ...[
-                        const SizedBox(height: 14),
-                        _MetaRow(
-                          label: 'virtual_card.member_since_label'.tr(),
-                          value: DateFormat.yMMMM(context.locale.toString())
-                              .format(card.memberSince!.toLocal()),
-                          textPrimary: textPrimary,
-                          textSecondary: textSecondary,
-                        ),
-                      ],
-                      const SizedBox(height: 18),
-                      Divider(color: divider, height: 1),
                       const SizedBox(height: 16),
+                      Divider(color: divider, height: 1),
+                      const SizedBox(height: 14),
                       Expanded(
-                        child: Center(
-                          child: card.canShowQr
-                              ? GestureDetector(
-                                  onTap: onShowQr,
-                                  child: Hero(
-                                    tag: 'virtual-card-qr-${card.userId}',
-                                    child: _QrPreview(card: card),
+                        child: Padding(
+                          padding: const EdgeInsets.symmetric(vertical: 2),
+                          child: Center(
+                            child: card.canShowQr
+                                ? _QrHero(
+                                    card: card,
+                                    onTap: onShowQr,
+                                  )
+                                : _QrUnavailableState(
+                                    card: card,
+                                    onRefresh: onRefresh,
                                   ),
-                                )
-                              : _QrUnavailableState(
-                                  card: card,
-                                  onRefresh: onRefresh,
-                                ),
+                          ),
                         ),
                       ),
                       const SizedBox(height: 12),
@@ -168,7 +107,8 @@ class VirtualCardFace extends StatelessWidget {
                         child: TextButton.icon(
                           key: const Key('virtual-card-fullscreen-action'),
                           onPressed: card.canShowQr ? onShowQr : onRefresh,
-                          icon: const Icon(Icons.open_in_full_outlined, size: 18),
+                          icon:
+                              const Icon(Icons.open_in_full_outlined, size: 18),
                           label: Text(
                             card.canShowQr
                                 ? 'virtual_card.show_fullscreen'.tr()
@@ -183,7 +123,8 @@ class VirtualCardFace extends StatelessWidget {
                         children: [
                           Expanded(
                             child: Text(
-                              card.cardIdShort == null || card.cardIdShort!.isEmpty
+                              card.cardIdShort == null ||
+                                      card.cardIdShort!.isEmpty
                                   ? 'virtual_card.id_missing'.tr()
                                   : '${'virtual_card.id_prefix'.tr()} ${card.cardIdShort}',
                               maxLines: 1,
@@ -322,16 +263,124 @@ class _ClubHeaderLogo extends StatelessWidget {
   }
 }
 
+class _IdentitySummary extends StatelessWidget {
+  const _IdentitySummary({
+    required this.card,
+    required this.tierColor,
+    required this.textPrimary,
+    required this.textSecondary,
+    required this.onPhotoTap,
+  });
+
+  final VirtualCard card;
+  final Color tierColor;
+  final Color textPrimary;
+  final Color textSecondary;
+  final VoidCallback onPhotoTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final hasPhoto = card.photoUrl?.trim().isNotEmpty == true;
+    final club = card.clubName?.trim();
+    final section = card.sectionName?.trim();
+    final memberSince = card.memberSince == null
+        ? null
+        : DateFormat.yMMMM(context.locale.toString())
+            .format(card.memberSince!.toLocal());
+
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.center,
+      children: [
+        GestureDetector(
+          onTap: hasPhoto ? onPhotoTap : null,
+          child: Semantics(
+            label: 'virtual_card.photo_alt'.tr(
+              namedArgs: {'name': card.fullName},
+            ),
+            child: _Avatar(
+              photoUrl: card.photoUrl,
+              fullName: card.fullName,
+              tierColor: tierColor,
+              size: 86,
+            ),
+          ),
+        ),
+        const SizedBox(width: 16),
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text(
+                card.fullName,
+                maxLines: 2,
+                overflow: TextOverflow.ellipsis,
+                style: TextStyle(
+                  fontSize: 20,
+                  fontWeight: FontWeight.w800,
+                  color: textPrimary,
+                  height: 1.08,
+                  letterSpacing: -0.35,
+                ),
+              ),
+              if ((card.roleLabel ?? '').trim().isNotEmpty) ...[
+                const SizedBox(height: 5),
+                Text(
+                  card.roleLabel!,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: TextStyle(
+                    fontSize: 12,
+                    fontWeight: FontWeight.w600,
+                    color: textSecondary,
+                    letterSpacing: 0.4,
+                  ),
+                ),
+              ],
+              if (club != null && club.isNotEmpty) ...[
+                const SizedBox(height: 8),
+                _InlineInfo(
+                  label: 'virtual_card.club_label'.tr(),
+                  value: club,
+                  color: textSecondary,
+                ),
+              ],
+              if (section != null && section.isNotEmpty) ...[
+                const SizedBox(height: 4),
+                _InlineInfo(
+                  label: 'virtual_card.section_label'.tr(),
+                  value: section,
+                  color: textSecondary,
+                ),
+              ],
+              if (memberSince != null) ...[
+                const SizedBox(height: 4),
+                _InlineInfo(
+                  label: 'virtual_card.member_since_label'.tr(),
+                  value: memberSince,
+                  color: textSecondary,
+                ),
+              ],
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
 class _Avatar extends StatelessWidget {
   const _Avatar({
     required this.photoUrl,
     required this.fullName,
     required this.tierColor,
+    this.size = 124,
   });
 
   final String? photoUrl;
   final String fullName;
   final Color tierColor;
+  final double size;
 
   @override
   Widget build(BuildContext context) {
@@ -345,8 +394,8 @@ class _Avatar extends StatelessWidget {
 
     final hasPhoto = photoUrl?.trim().isNotEmpty == true;
     return Container(
-      width: 124,
-      height: 124,
+      width: size,
+      height: size,
       padding: const EdgeInsets.all(4),
       decoration: BoxDecoration(
         shape: BoxShape.circle,
@@ -357,19 +406,22 @@ class _Avatar extends StatelessWidget {
             ? CachedNetworkImage(
                 imageUrl: photoUrl!,
                 fit: BoxFit.cover,
-                placeholder: (_, __) => _Placeholder(initials: initials),
-                errorWidget: (_, __, ___) => _Placeholder(initials: initials),
+                placeholder: (_, __) =>
+                    _Placeholder(initials: initials, size: size),
+                errorWidget: (_, __, ___) =>
+                    _Placeholder(initials: initials, size: size),
               )
-            : _Placeholder(initials: initials),
+            : _Placeholder(initials: initials, size: size),
       ),
     );
   }
 }
 
 class _Placeholder extends StatelessWidget {
-  const _Placeholder({required this.initials});
+  const _Placeholder({required this.initials, required this.size});
 
   final String initials;
+  final double size;
 
   @override
   Widget build(BuildContext context) {
@@ -378,86 +430,97 @@ class _Placeholder extends StatelessWidget {
       alignment: Alignment.center,
       child: Text(
         initials.isEmpty ? '·' : initials,
-        style: const TextStyle(
-          fontSize: 34,
+        style: TextStyle(
+          fontSize: size * 0.27,
           fontWeight: FontWeight.w800,
-          color: Color(0xFF0F1B2D),
+          color: const Color(0xFF0F1B2D),
         ),
       ),
     );
   }
 }
 
-class _MetaRow extends StatelessWidget {
-  const _MetaRow({
+class _InlineInfo extends StatelessWidget {
+  const _InlineInfo({
     required this.label,
     required this.value,
-    required this.textPrimary,
-    required this.textSecondary,
+    required this.color,
   });
 
   final String label;
-  final String? value;
-  final Color textPrimary;
-  final Color textSecondary;
+  final String value;
+  final Color color;
 
   @override
   Widget build(BuildContext context) {
-    if (value == null || value!.trim().isEmpty) {
-      return const SizedBox.shrink();
-    }
-
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Text(
-          label.toUpperCase(),
-          style: TextStyle(
-            fontSize: 10,
-            fontWeight: FontWeight.w600,
-            letterSpacing: 1.2,
-            color: textSecondary,
+    return Text.rich(
+      TextSpan(
+        children: [
+          TextSpan(
+            text: '${label.toUpperCase()}: ',
+            style: const TextStyle(fontWeight: FontWeight.w700),
           ),
-        ),
-        const SizedBox(height: 4),
-        Text(
-          value!,
-          maxLines: 1,
-          overflow: TextOverflow.ellipsis,
-          style: TextStyle(
-            fontSize: 16,
-            fontWeight: FontWeight.w400,
-            color: textPrimary,
-          ),
-        ),
-      ],
+          TextSpan(text: value),
+        ],
+      ),
+      maxLines: 1,
+      overflow: TextOverflow.ellipsis,
+      style: TextStyle(
+        fontSize: 11,
+        height: 1.1,
+        color: color,
+        letterSpacing: 0.35,
+      ),
     );
   }
 }
 
-class _QrPreview extends StatelessWidget {
-  const _QrPreview({required this.card});
+class _QrHero extends StatelessWidget {
+  const _QrHero({
+    required this.card,
+    required this.onTap,
+  });
 
   final VirtualCard card;
+  final VoidCallback onTap;
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      width: 160,
-      height: 160,
-      padding: const EdgeInsets.all(12),
-      decoration: BoxDecoration(
-        color: Colors.white,
-        borderRadius: BorderRadius.circular(20),
-        border: Border.all(color: const Color(0xFFE5E8EE)),
-      ),
-      child: Semantics(
-        label: 'virtual_card.qr_alt'.tr(),
-        child: QrImageView(
+    return GestureDetector(
+      key: const Key('virtual-card-qr-preview'),
+      behavior: HitTestBehavior.opaque,
+      onTap: onTap,
+      child: Hero(
+        tag: 'virtual-card-qr-${card.userId}',
+        transitionOnUserGestures: true,
+        flightShuttleBuilder: (
+          context,
+          animation,
+          direction,
+          fromContext,
+          toContext,
+        ) {
+          final curved = CurvedAnimation(
+            parent: animation,
+            curve: Curves.easeOutCubic,
+            reverseCurve: Curves.easeInCubic,
+          );
+
+          return FadeTransition(
+            opacity: curved,
+            child: ScaleTransition(
+              scale: Tween<double>(begin: 0.96, end: 1).animate(curved),
+              child: direction == HeroFlightDirection.push
+                  ? toContext.widget
+                  : fromContext.widget,
+            ),
+          );
+        },
+        child: VirtualCardQrTile(
           data: card.qrToken!,
-          version: QrVersions.auto,
-          backgroundColor: Colors.white,
-          errorCorrectionLevel: QrErrorCorrectLevel.M,
+          maxSize: 148,
+          padding: 10,
+          borderRadius: 18,
         ),
       ),
     );

--- a/lib/features/virtual_card/presentation/widgets/virtual_card_qr_tile.dart
+++ b/lib/features/virtual_card/presentation/widgets/virtual_card_qr_tile.dart
@@ -1,0 +1,74 @@
+import 'dart:math' as math;
+
+import 'package:easy_localization/easy_localization.dart';
+import 'package:flutter/material.dart';
+import 'package:qr_flutter/qr_flutter.dart';
+
+class VirtualCardQrTile extends StatelessWidget {
+  const VirtualCardQrTile({
+    super.key,
+    required this.data,
+    this.maxSize = 160,
+    this.padding = 12,
+    this.borderRadius = 20,
+    this.showShadow = false,
+  });
+
+  final String data;
+  final double maxSize;
+  final double padding;
+  final double borderRadius;
+  final bool showShadow;
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final availableWidth =
+            constraints.hasBoundedWidth ? constraints.maxWidth : maxSize;
+        final availableHeight =
+            constraints.hasBoundedHeight ? constraints.maxHeight : maxSize;
+        final size = math.max(
+          0.0,
+          math.min(maxSize, math.min(availableWidth, availableHeight)),
+        );
+
+        return RepaintBoundary(
+          child: SizedBox.square(
+            dimension: size,
+            child: DecoratedBox(
+              decoration: BoxDecoration(
+                color: Colors.white,
+                borderRadius: BorderRadius.circular(borderRadius),
+                border: Border.all(color: const Color(0xFFE5E8EE)),
+                boxShadow: showShadow
+                    ? const [
+                        BoxShadow(
+                          blurRadius: 28,
+                          offset: Offset(0, 12),
+                          color: Color(0x220F1B2D),
+                        ),
+                      ]
+                    : null,
+              ),
+              child: Padding(
+                padding: EdgeInsets.all(padding),
+                child: Semantics(
+                  image: true,
+                  label: 'virtual_card.qr_alt'.tr(),
+                  child: QrImageView(
+                    key: ValueKey(data),
+                    data: data,
+                    version: QrVersions.auto,
+                    backgroundColor: Colors.white,
+                    errorCorrectionLevel: QrErrorCorrectLevel.M,
+                  ),
+                ),
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/features/virtual_card/presentation/widgets/virtual_card_skeleton.dart
+++ b/lib/features/virtual_card/presentation/widgets/virtual_card_skeleton.dart
@@ -1,3 +1,5 @@
+import 'dart:math' as math;
+
 import 'package:flutter/material.dart';
 
 class VirtualCardSkeleton extends StatelessWidget {
@@ -12,47 +14,100 @@ class VirtualCardSkeleton extends StatelessWidget {
         borderRadius: BorderRadius.circular(24),
       ),
       padding: const EdgeInsets.all(24),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: [
-          Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      child: LayoutBuilder(
+        builder: (context, constraints) {
+          final avatarSize = (constraints.maxHeight * 0.18).clamp(76.0, 108.0);
+
+          return Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
             children: [
-              _bar(width: 92, height: 30, color: bg.withValues(alpha: 0.8)),
-              _bar(width: 64, height: 30, color: bg.withValues(alpha: 0.8)),
+              Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  _bar(width: 92, height: 30, color: bg.withValues(alpha: 0.8)),
+                  _bar(width: 64, height: 30, color: bg.withValues(alpha: 0.8)),
+                ],
+              ),
+              const SizedBox(height: 20),
+              Center(
+                child: _circle(
+                  size: avatarSize,
+                  color: bg.withValues(alpha: 0.85),
+                ),
+              ),
+              const SizedBox(height: 16),
+              Center(
+                child: _bar(
+                  width: 180,
+                  height: 22,
+                  color: bg.withValues(alpha: 0.8),
+                ),
+              ),
+              const SizedBox(height: 8),
+              Center(
+                child: _bar(
+                  width: 140,
+                  height: 14,
+                  color: bg.withValues(alpha: 0.7),
+                ),
+              ),
+              const SizedBox(height: 18),
+              _bar(
+                  width: double.infinity,
+                  height: 1,
+                  color: bg.withValues(alpha: 0.7)),
+              const SizedBox(height: 12),
+              _bar(width: 120, height: 14, color: bg.withValues(alpha: 0.8)),
+              const SizedBox(height: 8),
+              _bar(width: 180, height: 18, color: bg.withValues(alpha: 0.85)),
+              const SizedBox(height: 10),
+              _bar(width: 90, height: 14, color: bg.withValues(alpha: 0.8)),
+              const SizedBox(height: 8),
+              _bar(width: 160, height: 18, color: bg.withValues(alpha: 0.85)),
+              const SizedBox(height: 16),
+              Expanded(
+                child: LayoutBuilder(
+                  builder: (context, qrConstraints) {
+                    final qrSize = math.min(
+                      160.0,
+                      math.min(qrConstraints.maxWidth, qrConstraints.maxHeight),
+                    );
+
+                    return Center(
+                      child: _square(
+                        size: qrSize,
+                        color: bg.withValues(alpha: 0.75),
+                      ),
+                    );
+                  },
+                ),
+              ),
+              const SizedBox(height: 12),
+              Center(
+                child: _bar(
+                  width: 132,
+                  height: 18,
+                  color: bg.withValues(alpha: 0.8),
+                ),
+              ),
+              const SizedBox(height: 18),
+              _bar(
+                  width: double.infinity,
+                  height: 1,
+                  color: bg.withValues(alpha: 0.7)),
+              const SizedBox(height: 10),
+              Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  _bar(
+                      width: 128, height: 12, color: bg.withValues(alpha: 0.8)),
+                  _bar(
+                      width: 78, height: 20, color: bg.withValues(alpha: 0.85)),
+                ],
+              ),
             ],
-          ),
-          const SizedBox(height: 28),
-          Center(child: _circle(size: 108, color: bg.withValues(alpha: 0.85))),
-          const SizedBox(height: 24),
-          Center(child: _bar(width: 180, height: 24, color: bg.withValues(alpha: 0.8))),
-          const SizedBox(height: 10),
-          Center(child: _bar(width: 140, height: 16, color: bg.withValues(alpha: 0.7))),
-          const SizedBox(height: 28),
-          _bar(width: double.infinity, height: 1, color: bg.withValues(alpha: 0.7)),
-          const SizedBox(height: 18),
-          _bar(width: 120, height: 14, color: bg.withValues(alpha: 0.8)),
-          const SizedBox(height: 10),
-          _bar(width: 180, height: 18, color: bg.withValues(alpha: 0.85)),
-          const SizedBox(height: 12),
-          _bar(width: 90, height: 14, color: bg.withValues(alpha: 0.8)),
-          const SizedBox(height: 10),
-          _bar(width: 160, height: 18, color: bg.withValues(alpha: 0.85)),
-          const SizedBox(height: 24),
-          Center(child: _square(size: 160, color: bg.withValues(alpha: 0.75))),
-          const SizedBox(height: 18),
-          Center(child: _bar(width: 132, height: 18, color: bg.withValues(alpha: 0.8))),
-          const SizedBox(height: 26),
-          _bar(width: double.infinity, height: 1, color: bg.withValues(alpha: 0.7)),
-          const SizedBox(height: 14),
-          Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            children: [
-              _bar(width: 128, height: 12, color: bg.withValues(alpha: 0.8)),
-              _bar(width: 78, height: 20, color: bg.withValues(alpha: 0.85)),
-            ],
-          ),
-        ],
+          );
+        },
       ),
     );
   }

--- a/test/features/virtual_card/virtual_card_face_test.dart
+++ b/test/features/virtual_card/virtual_card_face_test.dart
@@ -53,7 +53,8 @@ VirtualCard _sampleCard({
     achievementTier: tier == null ? null : VirtualCardTier.fromString(tier),
     cardIdShort: 'SACDIA-202410-0421',
     qrToken: 'eyJ1aWQiOiJ1c3JfMTIzIn0.sig',
-    qrExpiresAt: expiresAt ?? DateTime.utc(2099, 1, 1),
+    qrExpiresAt:
+        expiresAt ?? DateTime.now().toUtc().add(const Duration(days: 365)),
     isActive: isActive,
     isOffline: isOffline,
   );
@@ -68,6 +69,8 @@ void main() {
   });
 
   testWidgets('renders the active card layout', (tester) async {
+    expect(_sampleCard(tier: 'gold').canShowQr, isTrue);
+
     await tester.pumpWidget(
       _wrapApp(
         VirtualCardFace(

--- a/test/features/virtual_card/virtual_card_test.dart
+++ b/test/features/virtual_card/virtual_card_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:sacdia_app/features/virtual_card/data/models/virtual_card_model.dart';
 import 'package:sacdia_app/features/virtual_card/domain/entities/virtual_card.dart';
 
 void main() {
@@ -32,6 +33,62 @@ void main() {
       expect(offline.qrToken, card.qrToken);
       expect(offline.isOffline, isTrue);
       expect(offline.isExpired, isFalse);
+    });
+  });
+
+  group('VirtualCardModel', () {
+    test('maps backend /qr/me/card nested member and visual payload', () {
+      final card = VirtualCardModel.fromJson({
+        'token': 'qr-token',
+        'expires_at': '2099-01-01T00:00:00.000Z',
+        'expires_in': 300,
+        'member': {
+          'user_id': '104a2549-2056-4b9b-aaeb-51d8fd43191d',
+          'full_name': 'Abner Reyes Ramírez',
+          'avatar': 'https://example.com/avatar.png',
+          'club_name': 'ACV',
+          'section_name': 'Conquistadores',
+        },
+        'visual': {
+          'title': 'SACDIA',
+          'subtitle': 'Credencial digital',
+          'primary_line': 'Abner Reyes Ramírez',
+          'secondary_line': 'abner@example.com',
+          'club_name': 'ACV',
+          'section_name': 'Conquistadores',
+        },
+      });
+
+      expect(card.userId, '104a2549-2056-4b9b-aaeb-51d8fd43191d');
+      expect(card.fullName, 'Abner Reyes Ramírez');
+      expect(card.photoUrl, 'https://example.com/avatar.png');
+      expect(card.clubName, 'ACV');
+      expect(card.sectionName, 'Conquistadores');
+      expect(card.cardIdShort, 'fd43191d');
+      expect(card.qrToken, 'qr-token');
+      expect(card.canShowQr, isTrue);
+    });
+
+    test('keeps supporting legacy flat virtual card payloads', () {
+      final card = VirtualCardModel.fromJson({
+        'user_id': 'usr_123',
+        'full_name': 'Juan Pérez Martínez',
+        'photo_url': 'https://example.com/photo.png',
+        'club_name': 'Central',
+        'section_name': 'Guías Mayores',
+        'card_id_short': 'VC-123',
+        'qr_token': 'legacy-token',
+        'qr_expires_at': '2099-01-01T00:00:00.000Z',
+        'is_active': true,
+      });
+
+      expect(card.userId, 'usr_123');
+      expect(card.fullName, 'Juan Pérez Martínez');
+      expect(card.photoUrl, 'https://example.com/photo.png');
+      expect(card.clubName, 'Central');
+      expect(card.sectionName, 'Guías Mayores');
+      expect(card.cardIdShort, 'VC-123');
+      expect(card.qrToken, 'legacy-token');
     });
   });
 }


### PR DESCRIPTION
## Summary

Recovers virtual_card improvements from a pre-rankings-phase4 stash. 8 modified + 1 new file. Visual + structural improvements with full backward-compat for the legacy API payload.

### Highlights

- **Model**: `fromJson` handles new nested API shape (`member`/`visual` sub-objects) alongside legacy flat payload. `cardIdShort` falls back to last 8 chars of `userId` via `_shortId` helper.
- **Face**: layout reworked to horizontal identity (avatar left, name/role/club/section right) with QR as focal element. New `_QrHero` with custom `flightShuttleBuilder` (FadeTransition + ScaleTransition). `_Avatar.size` parameterized. `_Placeholder` font scales proportionally (`size * 0.27`).
- **`virtual_card_qr_tile.dart`** (NEW): shared widget extracts QR rendering with `RepaintBoundary`, `ValueKey(data)` for token rotation rebuilds, `Semantics(image: true)`.
- **QR fullscreen view**: now consumes `VirtualCardQrTile` (DRY); removed direct `qr_flutter` import.
- **View**: fade `PageRouteBuilder` for QR fullscreen to match Hero animation.
- **Skeleton**: `LayoutBuilder`-driven responsive avatar (76–108px) and QR sizing.
- **achievement_detail_sheet**: badge 96 → 146px + `headlineSmall` → `headlineMedium` for visual polish (zero virtual_card coupling).
- **Tests**: nested + flat payload parsing for `VirtualCardModel`; widget smokes updated for new layout.

## Verification

- `flutter analyze` (scoped): **0 issues**
- `flutter test test/features/virtual_card/`: **13/13 pass**
- HugeIcons compliance: pass (`HugeIconData` typedef)

## Discussion items (non-blocking — please weigh in at review)

1. **`_shortId` derivation** (last 8 chars of UUID) is new fallback behavior. Does the backend guarantee `cardIdShort` will always be present in the new nested payload? If always present, the fallback is dead code; otherwise, add a fixture covering the absent case.
2. **achievement_detail_sheet badge size 96 → 146px**: visually verified on iPhone SE (320px width)? At 146px the badge occupies ~45% of the screen width — confirm no collision with tier/points badges row.
3. **Asymmetric route transitions in `virtual_card_view.dart`**: QR fullscreen uses a custom fade `PageRouteBuilder`; `onPhotoTap` still uses default `MaterialPageRoute` (slide). Is this intentional or should the photo route also use fade for consistency?

## Test plan

- [x] flutter analyze passes
- [x] virtual_card unit + widget tests pass (13/13)
- [ ] Visual QA on small-screen device (iPhone SE / 320px) for the badge size change
- [ ] Manual smoke: open virtual card → tap QR → fullscreen Hero animation → close
- [ ] Manual smoke: trigger token rotation while card is open → verify `RepaintBoundary` keeps the layout stable

## Out of scope

- Pre-existing analyzer issues elsewhere in the app
- Rankings phase 4 work (this stash predates it)

## References

- Stash origin: `On development: WIP virtual_card pre-rankings-phase4` (preserved in reflog)
- Engram review: `sacdia-app/virtual-card/2026-04-30-stash-recovery-review`