### PR TITLE
fix(rankings,units): use canonical kebab-case CLUB role_names

### DIFF
--- a/lib/core/auth/club_role_names.dart
+++ b/lib/core/auth/club_role_names.dart
@@ -1,0 +1,34 @@
+/// Canonical CLUB-scope role_name values from
+/// sacdia-backend/prisma/seeds/role-permissions.seed.sql.
+///
+/// `activeGrant.roleName` returns these strings verbatim — never Spanish
+/// or snake_case variants.
+abstract class ClubRoleNames {
+  static const director = 'director';
+  static const deputyDirector = 'deputy-director';
+  static const secretary = 'secretary';
+  static const treasurer = 'treasurer';
+  static const secretaryTreasurer = 'secretary-treasurer';
+  static const counselor = 'counselor';
+  static const member = 'member';
+
+  /// Roles autorizados a gestionar unidades.
+  static const management = <String>[
+    director,
+    deputyDirector,
+    secretary,
+    treasurer,
+    secretaryTreasurer,
+  ];
+
+  /// Roles autorizados a ver el ranking de sección
+  /// (management staff + counselors responsables de su unidad).
+  static const sectionRankingViewers = <String>[
+    director,
+    deputyDirector,
+    secretary,
+    treasurer,
+    secretaryTreasurer,
+    counselor,
+  ];
+}

--- a/lib/features/rankings/presentation/screens/section_ranking_screen.dart
+++ b/lib/features/rankings/presentation/screens/section_ranking_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../../../core/auth/club_role_names.dart';
 import '../../../../providers/catalogs_provider.dart';
 import '../../../members/presentation/providers/members_providers.dart';
 import '../providers/section_ranking_provider.dart';
@@ -10,22 +11,9 @@ import '../widgets/ranking_skeleton.dart';
 
 // ── Role helpers ──────────────────────────────────────────────────────────────
 
-/// Roles autorizados a ver el ranking de sección.
-///
-/// Equivalente al conjunto de [_kManagementRoles] de units_list_view.dart
-/// más 'counselor' — los counselors son responsables de su unidad y
-/// necesitan visibilidad del ranking para hacer seguimiento.
-const _kSectionRankingRoles = [
-  'director',
-  'sub_director',
-  'secretario',
-  'secretario_tesorero',
-  'counselor',
-];
-
 bool _canViewSectionRanking(String? role) {
   if (role == null) return false;
-  return _kSectionRankingRoles.contains(role.trim().toLowerCase());
+  return ClubRoleNames.sectionRankingViewers.contains(role.trim().toLowerCase());
 }
 
 // ── Screen ────────────────────────────────────────────────────────────────────

--- a/lib/features/units/presentation/views/units_list_view.dart
+++ b/lib/features/units/presentation/views/units_list_view.dart
@@ -8,6 +8,7 @@ import 'package:sacdia_app/core/theme/app_colors.dart';
 import 'package:sacdia_app/core/theme/sac_colors.dart';
 import 'package:sacdia_app/core/widgets/sac_card.dart';
 
+import '../../../../core/auth/club_role_names.dart';
 import '../../../auth/presentation/providers/auth_providers.dart';
 import '../../../members/presentation/providers/members_providers.dart';
 import '../../domain/entities/member_of_month.dart';
@@ -19,16 +20,9 @@ import 'unit_form_sheet.dart';
 
 // ── Role helpers ──────────────────────────────────────────────────────────────
 
-const _kManagementRoles = [
-  'director',
-  'sub_director',
-  'secretario',
-  'secretario_tesorero',
-];
-
 bool _canManageRole(String? role) {
   if (role == null) return false;
-  return _kManagementRoles.contains(role.trim().toLowerCase());
+  return ClubRoleNames.management.contains(role.trim().toLowerCase());
 }
 
 bool _canDeleteRole(String? role) {


### PR DESCRIPTION
## Summary

- `_kManagementRoles` and `_kSectionRankingRoles` used Spanish snake_case names (`'sub_director'`, `'secretario'`, `'secretario_tesorero'`) that never appear in `activeGrant.role_name`.
- Postgres returns the canonical kebab-case English values (`'deputy-director'`, `'secretary'`, `'secretary-treasurer'`) per `sacdia-backend/prisma/seeds/role-permissions.seed.sql`.
- Result: section ranking screen and unit management actions showed `unauthorized` for legitimate club staff (secretary, treasurer, deputy-director, secretary-treasurer).
- Extracted into `lib/core/auth/club_role_names.dart` (`ClubRoleNames`) so future role drift is fixed in one place.

## Files

- New: `lib/core/auth/club_role_names.dart` (canonical CLUB role names + management/sectionRankingViewers lists)
- `lib/features/rankings/presentation/screens/section_ranking_screen.dart` — uses `ClubRoleNames.sectionRankingViewers`
- `lib/features/units/presentation/views/units_list_view.dart` — uses `ClubRoleNames.management`

## Out of scope (same bug pattern, follow-up PR)

- `lib/features/units/presentation/views/unit_detail_view.dart:49-50`
- `lib/features/enrollment/presentation/views/enrollment_form_view.dart:215, 220, 238`

## Test plan

- [ ] Login `director-club@sacdia.com` (role `director`) → Section Ranking → list visible
- [ ] Login `secretary-club@sacdia.com` (role `secretary`) → list visible
- [ ] Login `counselor@sacdia.com` (role `counselor`) → list visible
- [ ] Login plain `member` → `RankingEmptyState.unauthorized`
- [ ] Backend RBAC fix (`sacdia-backend#35`) merged + applied first — otherwise GET returns 403 regardless

Closes #10