### PR TITLE
feat(rankings): add AwardTier enum and wire tier through domain/DTO/widgets

### DIFF
--- a/lib/features/rankings/data/models/member_ranking_dto.dart
+++ b/lib/features/rankings/data/models/member_ranking_dto.dart
@@ -1,4 +1,5 @@
 import '../../../../core/utils/json_helpers.dart';
+import '../../domain/entities/award_tier.dart';
 import '../../domain/entities/member_ranking.dart';
 
 /// DTO for an award category embedded in ranking responses.
@@ -9,12 +10,16 @@ class AwardedCategoryDto {
   final double minPct;
   final double maxPct;
 
+  /// Raw tier string from the backend ('BRONZE' | 'SILVER' | 'GOLD' | 'DIAMOND' | null).
+  final AwardTier tier;
+
   const AwardedCategoryDto({
     required this.id,
     required this.name,
     this.icon,
     required this.minPct,
     required this.maxPct,
+    this.tier = AwardTier.unknown,
   });
 
   factory AwardedCategoryDto.fromJson(Map<String, dynamic> json) {
@@ -24,6 +29,7 @@ class AwardedCategoryDto {
       icon: safeStringOrNull(json['icon']),
       minPct: (json['min_pct'] as num?)?.toDouble() ?? 0.0,
       maxPct: (json['max_pct'] as num?)?.toDouble() ?? 0.0,
+      tier: AwardTier.fromString(json['tier'] as String?),
     );
   }
 
@@ -34,6 +40,7 @@ class AwardedCategoryDto {
       icon: icon,
       minPct: minPct,
       maxPct: maxPct,
+      tier: tier,
     );
   }
 }

--- a/lib/features/rankings/domain/entities/award_tier.dart
+++ b/lib/features/rankings/domain/entities/award_tier.dart
@@ -1,0 +1,48 @@
+import 'package:flutter/material.dart';
+
+/// Tier de categoría de premiación en el sistema de rankings.
+///
+/// Espeja el enum `AwardCategoryTier` del backend.
+/// Excluye PLATINUM (no existe en el dominio de rankings — solo en logros).
+/// [unknown] se usa como fallback seguro para valores inesperados o null.
+enum AwardTier {
+  bronze,
+  silver,
+  gold,
+  diamond,
+  unknown;
+
+  /// Parsea un valor raw del backend (e.g. 'BRONZE', 'GOLD') al enum.
+  /// Retorna [AwardTier.unknown] si el valor es null o no reconocido.
+  static AwardTier fromString(String? value) {
+    switch (value?.toUpperCase()) {
+      case 'BRONZE':
+        return AwardTier.bronze;
+      case 'SILVER':
+        return AwardTier.silver;
+      case 'GOLD':
+        return AwardTier.gold;
+      case 'DIAMOND':
+        return AwardTier.diamond;
+      default:
+        return AwardTier.unknown;
+    }
+  }
+
+  /// Color representativo del tier — consistente con [achievementTierColor]
+  /// (mismos valores hex) para uniformidad visual en toda la app.
+  Color get color {
+    switch (this) {
+      case AwardTier.bronze:
+        return const Color(0xFFCD7F32);
+      case AwardTier.silver:
+        return const Color(0xFFC0C0C0);
+      case AwardTier.gold:
+        return const Color(0xFFFFD700);
+      case AwardTier.diamond:
+        return const Color(0xFFB9F2FF);
+      case AwardTier.unknown:
+        return const Color(0xFF303030); // AppColors.darkBorder
+    }
+  }
+}

--- a/lib/features/rankings/domain/entities/member_ranking.dart
+++ b/lib/features/rankings/domain/entities/member_ranking.dart
@@ -1,5 +1,7 @@
 import 'package:equatable/equatable.dart';
 
+import 'award_tier.dart';
+
 /// Visibility mode for member rankings — mirrors backend VisibilityMode type.
 enum MyRankingVisibilityMode {
   hidden,
@@ -26,16 +28,21 @@ class AwardCategory extends Equatable {
   final double minPct;
   final double maxPct;
 
+  /// Tier de la categoría — expuesto por el backend desde la fase B.
+  /// [AwardTier.unknown] cuando el campo no está presente o no es reconocido.
+  final AwardTier tier;
+
   const AwardCategory({
     required this.id,
     required this.name,
     this.icon,
     required this.minPct,
     required this.maxPct,
+    this.tier = AwardTier.unknown,
   });
 
   @override
-  List<Object?> get props => [id, name, icon, minPct, maxPct];
+  List<Object?> get props => [id, name, icon, minPct, maxPct, tier];
 }
 
 /// Domain entity for a single member ranking row.

--- a/lib/features/rankings/presentation/screens/my_ranking_screen.dart
+++ b/lib/features/rankings/presentation/screens/my_ranking_screen.dart
@@ -4,6 +4,7 @@ import 'package:hugeicons/hugeicons.dart';
 
 import '../../../../core/theme/sac_colors.dart';
 import '../../../../providers/catalogs_provider.dart';
+import '../../domain/entities/award_tier.dart';
 import '../../domain/entities/member_ranking.dart';
 import '../providers/my_ranking_provider.dart';
 import '../widgets/ranking_empty_state.dart';
@@ -103,7 +104,8 @@ class _RankingBody extends ConsumerWidget {
                   rankPosition: ranking.rankPosition,
                   totalInSection: _resolveTotalInSection(view),
                   awardedCategoryName: ranking.awardedCategory?.name,
-                  awardedCategoryTierId: ranking.awardedCategory?.id,
+                  awardedCategoryTier:
+                      ranking.awardedCategory?.tier ?? AwardTier.unknown,
                   sectionName: ranking.sectionName,
                   ecclesiasticalYearLabel: yearLabel,
                 ),

--- a/lib/features/rankings/presentation/screens/section_ranking_screen.dart
+++ b/lib/features/rankings/presentation/screens/section_ranking_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../../core/auth/club_role_names.dart';
 import '../../../../providers/catalogs_provider.dart';
 import '../../../members/presentation/providers/members_providers.dart';
+import '../../domain/entities/award_tier.dart';
 import '../providers/section_ranking_provider.dart';
 import '../widgets/member_ranking_list_tile.dart';
 import '../widgets/ranking_empty_state.dart';
@@ -140,7 +141,8 @@ class SectionRankingScreen extends ConsumerWidget {
                 sectionName: m.sectionName,
                 compositeScore: m.compositeScorePct,
                 awardedCategoryName: m.awardedCategory?.name,
-                awardedCategoryTierId: m.awardedCategory?.id,
+                awardedCategoryTier:
+                    m.awardedCategory?.tier ?? AwardTier.unknown,
               );
             },
           );

--- a/lib/features/rankings/presentation/widgets/member_ranking_list_tile.dart
+++ b/lib/features/rankings/presentation/widgets/member_ranking_list_tile.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 
-import '../../../../core/theme/app_colors.dart';
 import '../../../../core/theme/sac_colors.dart';
+import '../../domain/entities/award_tier.dart';
 
 /// Fila de ranking de un miembro dentro de su sección.
 ///
@@ -34,9 +34,9 @@ class MemberRankingListTile extends StatelessWidget {
   /// Nombre de la categoría premiada (e.g. "Oro", "Plata"). Null si no asignada.
   final String? awardedCategoryName;
 
-  /// ID UUID de la categoría — se usa para resolver el color del tier.
-  /// Neutro cuando null (sin tier asignado todavía).
-  final String? awardedCategoryTierId;
+  /// Tier tipado de la categoría — determina el color del score badge.
+  /// [AwardTier.unknown] cuando no hay categoría asignada (color neutro).
+  final AwardTier awardedCategoryTier;
 
   const MemberRankingListTile({
     super.key,
@@ -45,23 +45,13 @@ class MemberRankingListTile extends StatelessWidget {
     this.sectionName,
     this.compositeScore,
     this.awardedCategoryName,
-    this.awardedCategoryTierId,
+    this.awardedCategoryTier = AwardTier.unknown,
   });
 
-  /// Resuelve el color del tier para el score badge.
-  ///
-  /// Mismo enfoque que [RankingHeroCard._tierColor()]: la capa de dominio
-  /// no expone un campo `tier` tipado todavía — se usa el color de acento
-  /// cuando hay categoría y neutro cuando no.
+  /// Resuelve el color del tier para el score badge desde el campo tipado.
+  /// Usa los mismos valores hex que [achievementTierColor] para consistencia visual.
   Color _tierColor() {
-    if (awardedCategoryTierId == null) {
-      // Sin tier: color neutro que NO colisione con AppColors.accent
-      // (el accent se reserva para énfasis de puntaje compuesto en hero card).
-      return AppColors.secondary; // verde SACDIA — neutral, no compite
-    }
-    // Mientras el backend no exponga un campo `tier` en AwardCategory,
-    // usamos el color de acento como fallback para cualquier categoría presente.
-    return AppColors.accent;
+    return awardedCategoryTier.color;
   }
 
   /// Formatea el puntaje con 1 decimal fijo para alineación de columna.

--- a/lib/features/rankings/presentation/widgets/ranking_hero_card.dart
+++ b/lib/features/rankings/presentation/widgets/ranking_hero_card.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import '../../../../core/theme/app_colors.dart';
 import '../../../../core/theme/app_theme.dart';
+import '../../domain/entities/award_tier.dart';
 
 /// Hero card con fondo oscuro (#1A1A1A) que muestra el puntaje compuesto del
 /// miembro como ancla visual principal.
@@ -15,7 +16,7 @@ class RankingHeroCard extends StatelessWidget {
   final int? rankPosition;
   final int? totalInSection;
   final String? awardedCategoryName;
-  final String? awardedCategoryTierId;
+  final AwardTier awardedCategoryTier;
   final String? sectionName;
   final String ecclesiasticalYearLabel;
 
@@ -25,22 +26,18 @@ class RankingHeroCard extends StatelessWidget {
     this.rankPosition,
     this.totalInSection,
     this.awardedCategoryName,
-    this.awardedCategoryTierId,
+    this.awardedCategoryTier = AwardTier.unknown,
     this.sectionName,
     required this.ecclesiasticalYearLabel,
   });
 
-  /// Resuelve el color del tier a partir del ID de categoría.
-  /// Usa la misma función [achievementTierColor] que el resto de la app.
+  /// Resuelve el color del tier desde el campo tipado [awardedCategoryTier].
+  /// Usa los mismos valores hex que [achievementTierColor] para consistencia visual.
   Color _tierColor() {
-    if (awardedCategoryTierId == null) {
-      // TODO(rankings): replace with domain tier field when AwardCategory exposes it via Task 24 entity update
+    if (awardedCategoryTier == AwardTier.unknown) {
       return AppColors.darkBorder;
     }
-    // Mapeamos el UUID a un tier heurístico por nombre convencional.
-    // Los UUIDs reales los maneja el backend; esta función es un fallback
-    // hasta que la capa de dominio exponga un campo `tier` en AwardCategory.
-    return AppColors.accent;
+    return awardedCategoryTier.color;
   }
 
   /// Formatea el puntaje: 1 decimal cuando la parte fraccionaria != 0.

--- a/test/features/rankings/data/models/member_ranking_dto_test.dart
+++ b/test/features/rankings/data/models/member_ranking_dto_test.dart
@@ -1,0 +1,73 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sacdia_app/features/rankings/data/models/member_ranking_dto.dart';
+import 'package:sacdia_app/features/rankings/domain/entities/award_tier.dart';
+
+void main() {
+  group('AwardedCategoryDto.fromJson — tier parsing', () {
+    Map<String, dynamic> baseJson({String? tier}) => {
+          'id': 'cat-uuid-123',
+          'name': 'Oro',
+          'icon': null,
+          'min_pct': 80.0,
+          'max_pct': 100.0,
+          if (tier != null) 'tier': tier,
+        };
+
+    test('tier = "GOLD" parses to AwardTier.gold', () {
+      final dto = AwardedCategoryDto.fromJson(baseJson(tier: 'GOLD'));
+      expect(dto.tier, AwardTier.gold);
+      expect(dto.toEntity().tier, AwardTier.gold);
+    });
+
+    test('tier = "BRONZE" parses to AwardTier.bronze', () {
+      final dto = AwardedCategoryDto.fromJson(baseJson(tier: 'BRONZE'));
+      expect(dto.tier, AwardTier.bronze);
+      expect(dto.toEntity().tier, AwardTier.bronze);
+    });
+
+    test('tier = "SILVER" parses to AwardTier.silver', () {
+      final dto = AwardedCategoryDto.fromJson(baseJson(tier: 'SILVER'));
+      expect(dto.tier, AwardTier.silver);
+      expect(dto.toEntity().tier, AwardTier.silver);
+    });
+
+    test('tier = "DIAMOND" parses to AwardTier.diamond', () {
+      final dto = AwardedCategoryDto.fromJson(baseJson(tier: 'DIAMOND'));
+      expect(dto.tier, AwardTier.diamond);
+      expect(dto.toEntity().tier, AwardTier.diamond);
+    });
+
+    test('tier = null (field absent) parses to AwardTier.unknown', () {
+      // Field entirely absent from JSON.
+      final dto = AwardedCategoryDto.fromJson(baseJson());
+      expect(dto.tier, AwardTier.unknown);
+      expect(dto.toEntity().tier, AwardTier.unknown);
+    });
+
+    test('tier = "INVALID" parses to AwardTier.unknown', () {
+      final dto = AwardedCategoryDto.fromJson(baseJson(tier: 'INVALID'));
+      expect(dto.tier, AwardTier.unknown);
+      expect(dto.toEntity().tier, AwardTier.unknown);
+    });
+
+    test('tier = lowercase "gold" still parses correctly (toUpperCase)', () {
+      final dto = AwardedCategoryDto.fromJson(baseJson(tier: 'gold'));
+      expect(dto.tier, AwardTier.gold);
+    });
+  });
+
+  group('AwardTier.fromString — static parser', () {
+    test('null returns unknown', () {
+      expect(AwardTier.fromString(null), AwardTier.unknown);
+    });
+
+    test('empty string returns unknown', () {
+      expect(AwardTier.fromString(''), AwardTier.unknown);
+    });
+
+    test('mixed case is normalized', () {
+      expect(AwardTier.fromString('Bronze'), AwardTier.bronze);
+      expect(AwardTier.fromString('SILVER'), AwardTier.silver);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Plan 8.4-A Category D Phase D — Flutter consumes the new \`AwardTier\` field from the backend (sacdia-backend#38 merged + dev Neon migration applied).

## Changes

- **New** \`lib/features/rankings/domain/entities/award_tier.dart\`:
  - Enum with 5 variants: \`bronze\`, \`silver\`, \`gold\`, \`diamond\`, \`unknown\` (fallback for null + unexpected values)
  - \`fromString()\` static helper (uppercase-tolerant)
  - \`.color\` getter (BRONZE \`#CD7F32\`, SILVER \`#C0C0C0\`, GOLD \`#FFD700\`, DIAMOND \`#B9F2FF\`, unknown \`#303030\`)
- **\`member_ranking.dart\`**: \`AwardCategory.tier: AwardTier\` (default \`unknown\`); added to \`props\`
- **\`member_ranking_dto.dart\`**: \`AwardedCategoryDto.tier\` field; \`fromJson\` parses via \`AwardTier.fromString\`; \`toEntity()\` passes through
- **\`ranking_hero_card.dart\`** + **\`member_ranking_list_tile.dart\`**: resolved 2 TODOs — props \`awardedCategoryTierId: String?\` replaced by \`awardedCategoryTier: AwardTier\`. Color lookup delegates to \`.color\` getter (visual parity with \`achievementTierColor\`)
- **\`my_ranking_screen.dart\`** + **\`section_ranking_screen.dart\`**: call sites updated

## Tests

- **New file** \`test/features/rankings/data/models/member_ranking_dto_test.dart\`
- 11 tier-parse tests: BRONZE / SILVER / GOLD / DIAMOND / null / INVALID / lowercase / mixed case + edges
- All 22 rankings tests pass (6 repository + 6 section repository + 10 new)

## Verification

- \`flutter analyze\`: 0 issues
- \`flutter test test/features/rankings/\`: 22/22 pass

## Test plan

- [ ] Manual: open \`MyRankingScreen\` on a member with \`awarded_category.tier = "GOLD"\` → hero card lateral bar renders gold
- [ ] Manual: open same screen with \`tier = null\` → falls back to neutral border (\`unknown\` color)
- [ ] Manual: \`SectionRankingScreen\` list tile colors match per-row tier

## Open question (non-blocking)

\`AwardTier.unknown\` color hardcoded as \`Color(0xFF303030)\` (matches \`AppColors.darkBorder\`). Domain layer avoids importing \`app_colors.dart\` for purity. If theme changes, update both. Could extract a shared constant later if it becomes a maintenance concern.

## References

- Backend PR: sacdia-backend#38 (merged)
- Admin PR: sacdia-admin#14 (in flight)
- Dev Neon migration applied: engram \`sacdia-backend/category-d/tier-enum-migration-dev\`

## Out of scope

- Staging/prod Neon migration (pending pause + confirm)
- Visual QA on devices (will follow in app review)