### PR TITLE
fix(rankings): app polish bundle — i18n + breakdown drill-down + drop dead provider

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -3055,5 +3055,59 @@
       "empty_card": "Empty virtual card response from the server.",
       "load_failed": "We could not load your credential right now."
     }
+  },
+  "rankings": {
+    "my_ranking": {
+      "title": "My ranking",
+      "composite_score": "Composite score",
+      "pending": "Ranking pending",
+      "rank_of": "#{position} of {total}",
+      "rank_position": "#{position}",
+      "section_label": "Section: {name}",
+      "nudge_class": "Complete your next class lessons to improve your score.",
+      "nudge_investiture": "Work on the requirements for your next investiture.",
+      "nudge_camporee": "Participate in upcoming camporees to earn points."
+    },
+    "section_ranking": {
+      "title": "Section ranking",
+      "subtitle": "Progress record",
+      "subtitle_with_year": "Progress record — {year}",
+      "invalid_section": "Invalid section"
+    },
+    "empty_state": {
+      "unavailable_title": "Ranking unavailable",
+      "unavailable_subtitle": "Your director can enable ranking visibility when ready.",
+      "no_data_title": "No data yet",
+      "no_data_subtitle": "Your ranking is calculated automatically. Check back later.",
+      "network_error_title": "No connection",
+      "network_error_subtitle": "We could not load your ranking.",
+      "no_members_title": "No rankings yet",
+      "no_members_subtitle": "Rankings are calculated automatically every 24 h. Classes and camporees for the year must already be recorded.",
+      "unauthorized_title": "Access restricted",
+      "unauthorized_subtitle": "You do not have permission to view this section's ranking. Ask your director.",
+      "retry": "Retry"
+    },
+    "signals": {
+      "class": "Class",
+      "investiture": "Investiture",
+      "camporee": "Camporees"
+    },
+    "breakdown": {
+      "title": "Score breakdown",
+      "composite_score": "Composite score",
+      "calculated_at": "Calculated on {date}",
+      "weights_title": "Weights applied",
+      "weights_source": "Source: {source}",
+      "class_section": "Class",
+      "investiture_section": "Investiture",
+      "camporee_section": "Camporees",
+      "class_completed_sections": "{completed} of {required} sections completed",
+      "class_folder_status": "Folder: {status}",
+      "investiture_status": "Status: {status}",
+      "camporee_participated": "Participated in camporee",
+      "camporee_not_participated": "Did not participate in camporee",
+      "camporee_total": "{total} camporee(s) available",
+      "weight_pct": "{pct}%"
+    }
   }
 }

--- a/assets/translations/es.json
+++ b/assets/translations/es.json
@@ -3055,5 +3055,59 @@
       "empty_card": "Respuesta vacía de tarjeta virtual desde el servidor.",
       "load_failed": "No pudimos cargar tu credencial por ahora."
     }
+  },
+  "rankings": {
+    "my_ranking": {
+      "title": "Mi ranking",
+      "composite_score": "Puntaje compuesto",
+      "pending": "Ranking pendiente",
+      "rank_of": "#{position} de {total}",
+      "rank_position": "#{position}",
+      "section_label": "Sección: {name}",
+      "nudge_class": "Completá tus próximas lecciones de clase para mejorar tu puntaje.",
+      "nudge_investiture": "Trabajá en los requisitos de tu próxima investidura.",
+      "nudge_camporee": "Participá en los próximos camporees para sumar puntos."
+    },
+    "section_ranking": {
+      "title": "Ranking de sección",
+      "subtitle": "Registro de progreso",
+      "subtitle_with_year": "Registro de progreso — {year}",
+      "invalid_section": "Sección inválida"
+    },
+    "empty_state": {
+      "unavailable_title": "Ranking no disponible",
+      "unavailable_subtitle": "Tu director puede activar la visibilidad del ranking cuando esté listo.",
+      "no_data_title": "Aún no hay datos",
+      "no_data_subtitle": "Tu ranking se calcula automáticamente. Volvé a revisar más tarde.",
+      "network_error_title": "Sin conexión",
+      "network_error_subtitle": "No pudimos cargar tu ranking.",
+      "no_members_title": "Todavía no hay rankings",
+      "no_members_subtitle": "Los rankings se calculan automáticamente cada 24 hs. Las clases y camporees del año ya deben estar registrados.",
+      "unauthorized_title": "Acceso restringido",
+      "unauthorized_subtitle": "No tenés permisos para ver el ranking de esta sección. Consultá con tu director.",
+      "retry": "Reintentar"
+    },
+    "signals": {
+      "class": "Clase",
+      "investiture": "Investidura",
+      "camporee": "Camporees"
+    },
+    "breakdown": {
+      "title": "Desglose de puntaje",
+      "composite_score": "Puntaje compuesto",
+      "calculated_at": "Calculado el {date}",
+      "weights_title": "Pesos aplicados",
+      "weights_source": "Fuente: {source}",
+      "class_section": "Clase",
+      "investiture_section": "Investidura",
+      "camporee_section": "Camporees",
+      "class_completed_sections": "{completed} de {required} secciones completadas",
+      "class_folder_status": "Carpeta: {status}",
+      "investiture_status": "Estado: {status}",
+      "camporee_participated": "Participó en camporee",
+      "camporee_not_participated": "No participó en camporee",
+      "camporee_total": "{total} camporee(s) disponibles",
+      "weight_pct": "{pct}%"
+    }
   }
 }

--- a/assets/translations/fr.json
+++ b/assets/translations/fr.json
@@ -3055,5 +3055,59 @@
       "empty_card": "Réponse vide de la carte virtuelle du serveur.",
       "load_failed": "Impossible de charger votre carte pour le moment."
     }
+  },
+  "rankings": {
+    "my_ranking": {
+      "title": "Mon classement",
+      "composite_score": "Score composite",
+      "pending": "Classement en attente",
+      "rank_of": "#{position} sur {total}",
+      "rank_position": "#{position}",
+      "section_label": "Section : {name}",
+      "nudge_class": "Terminez vos prochaines leçons de classe pour améliorer votre score.",
+      "nudge_investiture": "Travaillez sur les exigences de votre prochaine investiture.",
+      "nudge_camporee": "Participez aux prochains camporees pour gagner des points."
+    },
+    "section_ranking": {
+      "title": "Classement de section",
+      "subtitle": "Registre de progression",
+      "subtitle_with_year": "Registre de progression — {year}",
+      "invalid_section": "Section invalide"
+    },
+    "empty_state": {
+      "unavailable_title": "Classement indisponible",
+      "unavailable_subtitle": "Votre directeur peut activer la visibilité du classement lorsqu'il sera prêt.",
+      "no_data_title": "Pas encore de données",
+      "no_data_subtitle": "Votre classement est calculé automatiquement. Revenez plus tard.",
+      "network_error_title": "Sans connexion",
+      "network_error_subtitle": "Nous n'avons pas pu charger votre classement.",
+      "no_members_title": "Pas encore de classements",
+      "no_members_subtitle": "Les classements sont calculés automatiquement toutes les 24 h. Les cours et camporees de l'année doivent déjà être enregistrés.",
+      "unauthorized_title": "Accès restreint",
+      "unauthorized_subtitle": "Vous n'avez pas la permission de voir le classement de cette section. Consultez votre directeur.",
+      "retry": "Réessayer"
+    },
+    "signals": {
+      "class": "Classe",
+      "investiture": "Investiture",
+      "camporee": "Camporees"
+    },
+    "breakdown": {
+      "title": "Détail du score",
+      "composite_score": "Score composite",
+      "calculated_at": "Calculé le {date}",
+      "weights_title": "Pondérations appliquées",
+      "weights_source": "Source : {source}",
+      "class_section": "Classe",
+      "investiture_section": "Investiture",
+      "camporee_section": "Camporees",
+      "class_completed_sections": "{completed} sur {required} sections terminées",
+      "class_folder_status": "Dossier : {status}",
+      "investiture_status": "Statut : {status}",
+      "camporee_participated": "A participé au camporee",
+      "camporee_not_participated": "N'a pas participé au camporee",
+      "camporee_total": "{total} camporee(s) disponible(s)",
+      "weight_pct": "{pct}%"
+    }
   }
 }

--- a/assets/translations/pt-BR.json
+++ b/assets/translations/pt-BR.json
@@ -3055,5 +3055,59 @@
       "empty_card": "Resposta vazia da credencial virtual do servidor.",
       "load_failed": "Não foi possível carregar sua credencial agora."
     }
+  },
+  "rankings": {
+    "my_ranking": {
+      "title": "Meu ranking",
+      "composite_score": "Pontuação composta",
+      "pending": "Ranking pendente",
+      "rank_of": "#{position} de {total}",
+      "rank_position": "#{position}",
+      "section_label": "Seção: {name}",
+      "nudge_class": "Conclua suas próximas lições de classe para melhorar sua pontuação.",
+      "nudge_investiture": "Trabalhe nos requisitos da sua próxima investidura.",
+      "nudge_camporee": "Participe dos próximos camporees para ganhar pontos."
+    },
+    "section_ranking": {
+      "title": "Ranking da seção",
+      "subtitle": "Registro de progresso",
+      "subtitle_with_year": "Registro de progresso — {year}",
+      "invalid_section": "Seção inválida"
+    },
+    "empty_state": {
+      "unavailable_title": "Ranking indisponível",
+      "unavailable_subtitle": "Seu diretor pode ativar a visibilidade do ranking quando estiver pronto.",
+      "no_data_title": "Ainda não há dados",
+      "no_data_subtitle": "Seu ranking é calculado automaticamente. Volte mais tarde.",
+      "network_error_title": "Sem conexão",
+      "network_error_subtitle": "Não foi possível carregar seu ranking.",
+      "no_members_title": "Ainda não há rankings",
+      "no_members_subtitle": "Os rankings são calculados automaticamente a cada 24 h. As aulas e camporees do ano já devem estar registrados.",
+      "unauthorized_title": "Acesso restrito",
+      "unauthorized_subtitle": "Você não tem permissão para ver o ranking desta seção. Consulte seu diretor.",
+      "retry": "Tentar novamente"
+    },
+    "signals": {
+      "class": "Classe",
+      "investiture": "Investidura",
+      "camporee": "Camporees"
+    },
+    "breakdown": {
+      "title": "Detalhes da pontuação",
+      "composite_score": "Pontuação composta",
+      "calculated_at": "Calculado em {date}",
+      "weights_title": "Pesos aplicados",
+      "weights_source": "Fonte: {source}",
+      "class_section": "Classe",
+      "investiture_section": "Investidura",
+      "camporee_section": "Camporees",
+      "class_completed_sections": "{completed} de {required} seções concluídas",
+      "class_folder_status": "Pasta: {status}",
+      "investiture_status": "Status: {status}",
+      "camporee_participated": "Participou de camporee",
+      "camporee_not_participated": "Não participou de camporee",
+      "camporee_total": "{total} camporee(s) disponível(is)",
+      "weight_pct": "{pct}%"
+    }
   }
 }

--- a/lib/core/config/route_names.dart
+++ b/lib/core/config/route_names.dart
@@ -164,7 +164,12 @@ class RouteNames {
   // Rankings
   static const String homeMyRanking = '/home/my-ranking';
   static const String sectionRanking = '/section-ranking/:sectionId';
+  static const String memberBreakdown =
+      '/rankings/breakdown/:enrollmentId';
 
   static String sectionRankingPath(int sectionId) =>
       '/section-ranking/$sectionId';
+
+  static String memberBreakdownPath(int enrollmentId, int yearId) =>
+      '/rankings/breakdown/$enrollmentId?year_id=$yearId';
 }

--- a/lib/core/config/router.dart
+++ b/lib/core/config/router.dart
@@ -53,6 +53,7 @@ import 'package:sacdia_app/features/support/presentation/views/support_view.dart
 import 'package:sacdia_app/features/support/presentation/views/faq_view.dart';
 import 'package:sacdia_app/features/support/presentation/views/contact_view.dart';
 import 'package:sacdia_app/features/support/presentation/views/report_problem_view.dart';
+import 'package:sacdia_app/features/rankings/presentation/screens/member_breakdown_screen.dart';
 import 'package:sacdia_app/features/rankings/presentation/screens/my_ranking_screen.dart';
 import 'package:sacdia_app/features/rankings/presentation/screens/section_ranking_screen.dart';
 
@@ -964,6 +965,37 @@ final routerProvider = Provider<GoRouter>((ref) {
             context,
             state,
             SectionRankingScreen(sectionId: sectionId),
+          );
+        },
+      ),
+
+      // Desglose de puntaje de un miembro — drill-down desde MyRankingScreen o
+      // SectionRankingScreen. Recibe enrollmentId como path param e yearId como
+      // query param para construir el request sin dependencia de contexto.
+      GoRoute(
+        path: RouteNames.memberBreakdown,
+        pageBuilder: (context, state) {
+          final enrollmentIdStr = state.pathParameters['enrollmentId'];
+          final yearIdStr = state.uri.queryParameters['year_id'];
+          final enrollmentId = int.tryParse(enrollmentIdStr ?? '');
+          final yearId = int.tryParse(yearIdStr ?? '');
+          if (enrollmentId == null || yearId == null) {
+            return _sharedAxisBuild(
+              context,
+              state,
+              const Scaffold(
+                body: Center(
+                    child: Text('Parámetros de desglose inválidos')),
+              ),
+            );
+          }
+          return _sharedAxisBuild(
+            context,
+            state,
+            MemberBreakdownScreen(
+              enrollmentId: enrollmentId,
+              yearId: yearId,
+            ),
           );
         },
       ),

--- a/lib/features/rankings/data/datasources/rankings_remote_data_source.dart
+++ b/lib/features/rankings/data/datasources/rankings_remote_data_source.dart
@@ -4,6 +4,7 @@ import 'package:easy_localization/easy_localization.dart';
 import '../../../../core/constants/api_endpoints.dart';
 import '../../../../core/errors/exceptions.dart';
 import '../../../../core/utils/app_logger.dart';
+import '../models/member_breakdown_dto.dart';
 import '../models/member_ranking_dto.dart';
 import '../models/section_ranking_dto.dart';
 
@@ -25,6 +26,17 @@ abstract class RankingsRemoteDataSource {
   /// Throws [AuthException] on other 403s.
   /// Throws [ServerException] on other errors.
   Future<MyRankingResponseDto> getMyRanking(
+    int yearId, {
+    CancelToken? cancelToken,
+  });
+
+  /// `GET /member-rankings/:enrollmentId/breakdown?year_id=[yearId]`
+  ///
+  /// Returns the per-component score breakdown for a specific enrollment.
+  /// Throws [AuthException] on 403.
+  /// Throws [ServerException] on other errors.
+  Future<MemberBreakdownDtoModel> getBreakdown(
+    int enrollmentId,
     int yearId, {
     CancelToken? cancelToken,
   });
@@ -161,6 +173,40 @@ class RankingsRemoteDataSourceImpl implements RankingsRemoteDataSource {
     } catch (e) {
       if (e is DioException && e.type == DioExceptionType.cancel) rethrow;
       AppLogger.e('Error en getMyRanking', tag: _tag, error: e);
+      _rethrow(e);
+    }
+  }
+
+  // ── GET /member-rankings/:enrollmentId/breakdown ─────────────────────────────
+
+  @override
+  Future<MemberBreakdownDtoModel> getBreakdown(
+    int enrollmentId,
+    int yearId, {
+    CancelToken? cancelToken,
+  }) async {
+    try {
+      final response = await _dio.get(
+        '$_baseUrl${ApiEndpoints.memberRankings}/$enrollmentId/breakdown',
+        queryParameters: {'year_id': yearId},
+        cancelToken: cancelToken,
+      );
+
+      if (response.statusCode == 200) {
+        final data = response.data;
+        final json = data is Map && data.containsKey('data')
+            ? data['data'] as Map<String, dynamic>
+            : data as Map<String, dynamic>;
+        return MemberBreakdownDtoModel.fromJson(json);
+      }
+
+      throw ServerException(
+        message: tr('member_rankings.errors.get_breakdown'),
+        code: response.statusCode,
+      );
+    } catch (e) {
+      if (e is DioException && e.type == DioExceptionType.cancel) rethrow;
+      AppLogger.e('Error en getBreakdown', tag: _tag, error: e);
       _rethrow(e);
     }
   }

--- a/lib/features/rankings/data/models/member_breakdown_dto.dart
+++ b/lib/features/rankings/data/models/member_breakdown_dto.dart
@@ -1,0 +1,226 @@
+import '../../../../core/utils/json_helpers.dart';
+import '../../domain/entities/award_tier.dart';
+import '../../domain/entities/member_breakdown.dart';
+import 'member_ranking_dto.dart';
+
+/// DTO for [ClassBreakdown] — mirrors [ClassBreakdownDto] from the backend.
+class ClassBreakdownDtoModel {
+  final int completedSections;
+  final int requiredSections;
+  final String? folderStatus;
+
+  const ClassBreakdownDtoModel({
+    required this.completedSections,
+    required this.requiredSections,
+    this.folderStatus,
+  });
+
+  factory ClassBreakdownDtoModel.fromJson(Map<String, dynamic> json) {
+    return ClassBreakdownDtoModel(
+      completedSections: safeInt(json['completed_sections']),
+      requiredSections: safeInt(json['required_sections']),
+      folderStatus: safeStringOrNull(json['folder_status']),
+    );
+  }
+
+  ClassBreakdown toEntity() {
+    return ClassBreakdown(
+      completedSections: completedSections,
+      requiredSections: requiredSections,
+      folderStatus: folderStatus,
+    );
+  }
+}
+
+/// DTO for [InvestitureBreakdown] — mirrors [InvestitureBreakdownDto].
+class InvestitureBreakdownDtoModel {
+  final String? status;
+
+  const InvestitureBreakdownDtoModel({this.status});
+
+  factory InvestitureBreakdownDtoModel.fromJson(Map<String, dynamic> json) {
+    return InvestitureBreakdownDtoModel(
+      status: safeStringOrNull(json['status']),
+    );
+  }
+
+  InvestitureBreakdown toEntity() {
+    return InvestitureBreakdown(status: status);
+  }
+}
+
+/// DTO for [CamporeeBreakdown] — mirrors [CamporeeBreakdownDto].
+class CamporeeBreakdownDtoModel {
+  final bool participated;
+  final int? totalCamporees;
+
+  const CamporeeBreakdownDtoModel({
+    required this.participated,
+    this.totalCamporees,
+  });
+
+  factory CamporeeBreakdownDtoModel.fromJson(Map<String, dynamic> json) {
+    return CamporeeBreakdownDtoModel(
+      participated: (json['participated'] as bool?) ?? false,
+      totalCamporees: safeIntOrNull(json['total_camporees']),
+    );
+  }
+
+  CamporeeBreakdown toEntity() {
+    return CamporeeBreakdown(
+      participated: participated,
+      totalCamporees: totalCamporees,
+    );
+  }
+}
+
+/// DTO for [BreakdownWeights] — mirrors [WeightsBreakdownDto].
+///
+/// Accepts both `weights` and `weights_applied` as root keys for forward
+/// compatibility (admin normalizer pattern).
+class BreakdownWeightsDtoModel {
+  final int classPct;
+  final int investiturePct;
+  final int camporeePct;
+  final String source;
+
+  const BreakdownWeightsDtoModel({
+    required this.classPct,
+    required this.investiturePct,
+    required this.camporeePct,
+    required this.source,
+  });
+
+  factory BreakdownWeightsDtoModel.fromJson(Map<String, dynamic> json) {
+    return BreakdownWeightsDtoModel(
+      classPct: safeInt(json['class_pct']),
+      investiturePct: safeInt(json['investiture_pct']),
+      camporeePct: safeInt(json['camporee_pct']),
+      source: safeString(json['source'], 'global-default'),
+    );
+  }
+
+  BreakdownWeights toEntity() {
+    return BreakdownWeights(
+      classPct: classPct,
+      investiturePct: investiturePct,
+      camporeePct: camporeePct,
+      source: source,
+    );
+  }
+}
+
+/// DTO for the full breakdown response from
+/// `GET /member-rankings/:enrollmentId/breakdown?year_id=N`.
+///
+/// Extends [MemberRankingDto] fields (snake_case mirrors [MemberBreakdownDto]
+/// from the backend) with the four breakdown sub-objects.
+///
+/// Field-naming flexibility:
+/// - The weights object may arrive under `weights` or `weights_applied` —
+///   both keys are checked in `fromJson` to handle future API evolution.
+class MemberBreakdownDtoModel {
+  // ── Core fields (from MemberRankingResponseDto) ────────────────────────────
+  final int enrollmentId;
+  final String userId;
+  final String memberName;
+  final int? clubSectionId;
+  final String? sectionName;
+  final double? classScorePct;
+  final double? investitureScorePct;
+  final double? camporeeScorePct;
+  final double? compositeScorePct;
+  final int? rankPosition;
+  final AwardedCategoryDto? awardedCategory;
+  final DateTime? compositeCalculatedAt;
+
+  // ── Breakdown fields ───────────────────────────────────────────────────────
+  final ClassBreakdownDtoModel classBreakdown;
+  final InvestitureBreakdownDtoModel investitureBreakdown;
+  final CamporeeBreakdownDtoModel camporeeBreakdown;
+  final BreakdownWeightsDtoModel weights;
+
+  const MemberBreakdownDtoModel({
+    required this.enrollmentId,
+    required this.userId,
+    required this.memberName,
+    this.clubSectionId,
+    this.sectionName,
+    this.classScorePct,
+    this.investitureScorePct,
+    this.camporeeScorePct,
+    this.compositeScorePct,
+    this.rankPosition,
+    this.awardedCategory,
+    this.compositeCalculatedAt,
+    required this.classBreakdown,
+    required this.investitureBreakdown,
+    required this.camporeeBreakdown,
+    required this.weights,
+  });
+
+  factory MemberBreakdownDtoModel.fromJson(Map<String, dynamic> json) {
+    // Accept both `weights` and `weights_applied` for forward compatibility.
+    final rawWeights = (json['weights'] ?? json['weights_applied'])
+        as Map<String, dynamic>?;
+
+    return MemberBreakdownDtoModel(
+      enrollmentId: safeInt(json['enrollment_id']),
+      userId: safeString(json['user_id']),
+      memberName: safeString(json['member_name']),
+      clubSectionId: safeIntOrNull(json['club_section_id']),
+      sectionName: safeStringOrNull(json['section_name']),
+      classScorePct: (json['class_score_pct'] as num?)?.toDouble(),
+      investitureScorePct:
+          (json['investiture_score_pct'] as num?)?.toDouble(),
+      camporeeScorePct: (json['camporee_score_pct'] as num?)?.toDouble(),
+      compositeScorePct: (json['composite_score_pct'] as num?)?.toDouble(),
+      rankPosition: safeIntOrNull(json['rank_position']),
+      awardedCategory: json['awarded_category'] != null
+          ? AwardedCategoryDto.fromJson(
+              json['awarded_category'] as Map<String, dynamic>)
+          : null,
+      compositeCalculatedAt: json['composite_calculated_at'] != null
+          ? DateTime.tryParse(safeString(json['composite_calculated_at']))
+          : null,
+      classBreakdown: ClassBreakdownDtoModel.fromJson(
+        json['class_breakdown'] as Map<String, dynamic>? ?? {},
+      ),
+      investitureBreakdown: InvestitureBreakdownDtoModel.fromJson(
+        json['investiture_breakdown'] as Map<String, dynamic>? ?? {},
+      ),
+      camporeeBreakdown: CamporeeBreakdownDtoModel.fromJson(
+        json['camporee_breakdown'] as Map<String, dynamic>? ?? {},
+      ),
+      weights: rawWeights != null
+          ? BreakdownWeightsDtoModel.fromJson(rawWeights)
+          : const BreakdownWeightsDtoModel(
+              classPct: 50,
+              investiturePct: 30,
+              camporeePct: 20,
+              source: 'global-default',
+            ),
+    );
+  }
+
+  MemberBreakdown toEntity() {
+    return MemberBreakdown(
+      enrollmentId: enrollmentId,
+      userId: userId,
+      memberName: memberName,
+      clubSectionId: clubSectionId,
+      sectionName: sectionName,
+      classScorePct: classScorePct,
+      investitureScorePct: investitureScorePct,
+      camporeeScorePct: camporeeScorePct,
+      compositeScorePct: compositeScorePct,
+      rankPosition: rankPosition,
+      awardedCategory: awardedCategory?.toEntity(),
+      compositeCalculatedAt: compositeCalculatedAt,
+      classBreakdown: classBreakdown.toEntity(),
+      investitureBreakdown: investitureBreakdown.toEntity(),
+      camporeeBreakdown: camporeeBreakdown.toEntity(),
+      weights: weights.toEntity(),
+    );
+  }
+}

--- a/lib/features/rankings/data/repositories/member_rankings_repository_impl.dart
+++ b/lib/features/rankings/data/repositories/member_rankings_repository_impl.dart
@@ -4,6 +4,7 @@ import 'package:dio/dio.dart';
 import '../../../../core/errors/exceptions.dart';
 import '../../../../core/errors/failures.dart';
 import '../../../../core/network/network_info.dart';
+import '../../domain/entities/member_breakdown.dart';
 import '../../domain/entities/member_ranking.dart';
 import '../../domain/repositories/member_rankings_repository.dart';
 import '../datasources/rankings_remote_data_source.dart';
@@ -52,6 +53,34 @@ class MemberRankingsRepositoryImpl implements MemberRankingsRepository {
     } on MemberRankingHiddenException {
       // Visibility = hidden → graceful empty state (not an error).
       return const Right(null);
+    } on ServerException catch (e) {
+      return _serverFailure(e);
+    } on AuthException catch (e) {
+      return _authFailure(e);
+    } catch (e) {
+      return _unexpectedFailure(e);
+    }
+  }
+
+  @override
+  Future<Either<Failure, MemberBreakdown>> getBreakdown(
+    int enrollmentId,
+    int yearId, {
+    CancelToken? cancelToken,
+  }) async {
+    if (!await networkInfo.isConnected) {
+      return const Left(
+        NetworkFailure(message: 'Sin conexión a internet'),
+      );
+    }
+
+    try {
+      final dto = await remoteDataSource.getBreakdown(
+        enrollmentId,
+        yearId,
+        cancelToken: cancelToken,
+      );
+      return Right(dto.toEntity());
     } on ServerException catch (e) {
       return _serverFailure(e);
     } on AuthException catch (e) {

--- a/lib/features/rankings/domain/entities/member_breakdown.dart
+++ b/lib/features/rankings/domain/entities/member_breakdown.dart
@@ -1,0 +1,129 @@
+import 'package:equatable/equatable.dart';
+
+import 'award_tier.dart';
+import 'member_ranking.dart';
+
+/// Breakdown detail for the class signal component.
+class ClassBreakdown extends Equatable {
+  final int completedSections;
+  final int requiredSections;
+  final String? folderStatus;
+
+  const ClassBreakdown({
+    required this.completedSections,
+    required this.requiredSections,
+    this.folderStatus,
+  });
+
+  @override
+  List<Object?> get props => [completedSections, requiredSections, folderStatus];
+}
+
+/// Breakdown detail for the investiture signal component.
+class InvestitureBreakdown extends Equatable {
+  final String? status;
+
+  const InvestitureBreakdown({this.status});
+
+  @override
+  List<Object?> get props => [status];
+}
+
+/// Breakdown detail for the camporee signal component.
+class CamporeeBreakdown extends Equatable {
+  final bool participated;
+  final int? totalCamporees;
+
+  const CamporeeBreakdown({
+    required this.participated,
+    this.totalCamporees,
+  });
+
+  @override
+  List<Object?> get props => [participated, totalCamporees];
+}
+
+/// Applied weights for the composite score formula.
+class BreakdownWeights extends Equatable {
+  final int classPct;
+  final int investiturePct;
+  final int camporeePct;
+
+  /// Describes where these weights came from (e.g. 'global-default', 'club-custom').
+  final String source;
+
+  const BreakdownWeights({
+    required this.classPct,
+    required this.investiturePct,
+    required this.camporeePct,
+    required this.source,
+  });
+
+  @override
+  List<Object?> get props => [classPct, investiturePct, camporeePct, source];
+}
+
+/// Full breakdown of a member's ranking — returned by
+/// `GET /member-rankings/:enrollmentId/breakdown?year_id=N`.
+///
+/// Extends the base [MemberRanking] fields with per-signal detail and weights.
+class MemberBreakdown extends Equatable {
+  // ── Core ranking fields (mirrors MemberRanking) ────────────────────────────
+  final int enrollmentId;
+  final String userId;
+  final String memberName;
+  final int? clubSectionId;
+  final String? sectionName;
+  final double? classScorePct;
+  final double? investitureScorePct;
+  final double? camporeeScorePct;
+  final double? compositeScorePct;
+  final int? rankPosition;
+  final AwardCategory? awardedCategory;
+  final DateTime? compositeCalculatedAt;
+
+  // ── Breakdown-specific fields ──────────────────────────────────────────────
+  final ClassBreakdown classBreakdown;
+  final InvestitureBreakdown investitureBreakdown;
+  final CamporeeBreakdown camporeeBreakdown;
+  final BreakdownWeights weights;
+
+  const MemberBreakdown({
+    required this.enrollmentId,
+    required this.userId,
+    required this.memberName,
+    this.clubSectionId,
+    this.sectionName,
+    this.classScorePct,
+    this.investitureScorePct,
+    this.camporeeScorePct,
+    this.compositeScorePct,
+    this.rankPosition,
+    this.awardedCategory,
+    this.compositeCalculatedAt,
+    required this.classBreakdown,
+    required this.investitureBreakdown,
+    required this.camporeeBreakdown,
+    required this.weights,
+  });
+
+  @override
+  List<Object?> get props => [
+        enrollmentId,
+        userId,
+        memberName,
+        clubSectionId,
+        sectionName,
+        classScorePct,
+        investitureScorePct,
+        camporeeScorePct,
+        compositeScorePct,
+        rankPosition,
+        awardedCategory,
+        compositeCalculatedAt,
+        classBreakdown,
+        investitureBreakdown,
+        camporeeBreakdown,
+        weights,
+      ];
+}

--- a/lib/features/rankings/domain/repositories/member_rankings_repository.dart
+++ b/lib/features/rankings/domain/repositories/member_rankings_repository.dart
@@ -2,6 +2,7 @@ import 'package:dartz/dartz.dart';
 import 'package:dio/dio.dart';
 
 import '../../../../core/errors/failures.dart';
+import '../entities/member_breakdown.dart';
 import '../entities/member_ranking.dart';
 
 /// Abstract repository for member rankings domain operations.
@@ -12,6 +13,18 @@ abstract class MemberRankingsRepository {
   /// - 403 MEMBER_RANKING_HIDDEN → [Right(null)] (graceful empty state)
   /// - Other 403 / 4xx / 5xx → [Left<Failure>]
   Future<Either<Failure, MyRankingView?>> getMyRanking(
+    int yearId, {
+    CancelToken? cancelToken,
+  });
+
+  /// Returns the per-component score breakdown for a specific enrollment.
+  ///
+  /// `GET /member-rankings/:enrollmentId/breakdown?year_id=[yearId]`
+  ///
+  /// - 200 OK → [Right<MemberBreakdown>]
+  /// - 4xx / 5xx → [Left<Failure>]
+  Future<Either<Failure, MemberBreakdown>> getBreakdown(
+    int enrollmentId,
     int yearId, {
     CancelToken? cancelToken,
   });

--- a/lib/features/rankings/presentation/providers/member_breakdown_provider.dart
+++ b/lib/features/rankings/presentation/providers/member_breakdown_provider.dart
@@ -1,0 +1,37 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../domain/entities/member_breakdown.dart';
+import 'my_ranking_provider.dart';
+
+/// Parameter record for [memberBreakdownProvider].
+/// Using a Dart record ensures structural equality for provider family keying.
+typedef MemberBreakdownParams = ({int enrollmentId, int yearId});
+
+/// Fetches the per-component score breakdown for a specific enrollment.
+///
+/// Returns:
+/// - [AsyncValue.data(MemberBreakdown)] — breakdown available
+/// - [AsyncValue.error(Failure)] — auth or network error
+///
+/// Keyed by [MemberBreakdownParams] so the provider family deduplicates
+/// simultaneous requests for the same (enrollmentId, yearId) pair.
+final memberBreakdownProvider = FutureProvider.autoDispose
+    .family<MemberBreakdown, MemberBreakdownParams>(
+        (ref, params) async {
+  ref.keepAlive();
+  final cancelToken = CancelToken();
+  ref.onDispose(() => cancelToken.cancel());
+
+  final repo = ref.watch(memberRankingsRepositoryProvider);
+  final result = await repo.getBreakdown(
+    params.enrollmentId,
+    params.yearId,
+    cancelToken: cancelToken,
+  );
+
+  return result.fold(
+    (failure) => throw failure,
+    (breakdown) => breakdown,
+  );
+});

--- a/lib/features/rankings/presentation/providers/section_ranking_provider.dart
+++ b/lib/features/rankings/presentation/providers/section_ranking_provider.dart
@@ -9,10 +9,6 @@ import 'my_ranking_provider.dart';
 
 // ── Param types ───────────────────────────────────────────────────────────────
 
-/// Parameter record for [sectionRankingsProvider].
-/// Using a Dart record ensures structural equality for provider family keying.
-typedef SectionRankingsParams = ({int yearId, int? clubId});
-
 /// Parameter record for [sectionMembersProvider].
 typedef SectionMembersParams = ({int sectionId, int yearId});
 
@@ -29,29 +25,6 @@ final sectionRankingsRepositoryProvider =
 });
 
 // ── Data providers ────────────────────────────────────────────────────────────
-
-/// Fetches paginated section rankings.
-///
-/// [params.clubId] is optional — backend applies RBAC scope filter when null.
-final sectionRankingsProvider = FutureProvider.autoDispose
-    .family<List<SectionRanking>, SectionRankingsParams>(
-        (ref, params) async {
-  ref.keepAlive();
-  final cancelToken = CancelToken();
-  ref.onDispose(() => cancelToken.cancel());
-
-  final repo = ref.watch(sectionRankingsRepositoryProvider);
-  final result = await repo.getSectionRankings(
-    yearId: params.yearId,
-    clubId: params.clubId,
-    cancelToken: cancelToken,
-  );
-
-  return result.fold(
-    (failure) => throw failure,
-    (sections) => sections,
-  );
-});
 
 /// Fetches members ranked within a specific section.
 ///

--- a/lib/features/rankings/presentation/screens/member_breakdown_screen.dart
+++ b/lib/features/rankings/presentation/screens/member_breakdown_screen.dart
@@ -1,0 +1,527 @@
+import 'package:easy_localization/easy_localization.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:hugeicons/hugeicons.dart';
+
+import '../../../../core/theme/app_colors.dart';
+import '../../../../core/theme/app_theme.dart';
+import '../../../../core/theme/sac_colors.dart';
+import '../../../../core/utils/icon_helper.dart';
+import '../../../../core/widgets/sac_card.dart';
+import '../../domain/entities/award_tier.dart';
+import '../../domain/entities/member_breakdown.dart';
+import '../providers/member_breakdown_provider.dart';
+import '../widgets/ranking_empty_state.dart';
+import '../widgets/ranking_skeleton.dart';
+
+/// Pantalla de desglose de puntaje por componente de un miembro.
+///
+/// Muestra:
+/// - Hero con nombre + puntaje compuesto + badge de categoría.
+/// - 3 tarjetas de señal (clase, investidura, camporees) con detalle expandido.
+/// - Fila de pesos aplicados con fuente.
+/// - Estados skeleton, vacío y error estándar.
+///
+/// Recibe [enrollmentId] y [yearId] como parámetros de constructor.
+/// Ambos se pasan como args al provider [memberBreakdownProvider].
+class MemberBreakdownScreen extends ConsumerWidget {
+  final int enrollmentId;
+  final int yearId;
+
+  const MemberBreakdownScreen({
+    super.key,
+    required this.enrollmentId,
+    required this.yearId,
+  });
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final params = (enrollmentId: enrollmentId, yearId: yearId);
+    final breakdownAsync = ref.watch(memberBreakdownProvider(params));
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(tr('rankings.breakdown.title')),
+      ),
+      body: breakdownAsync.when(
+        data: (breakdown) => _BreakdownBody(breakdown: breakdown),
+        loading: () => RankingSkeleton.myRanking(),
+        error: (_, __) => RankingEmptyState(
+          reason: RankingEmptyReason.networkError,
+          onRetry: () =>
+              ref.invalidate(memberBreakdownProvider(params)),
+        ),
+      ),
+    );
+  }
+}
+
+// ── Body ─────────────────────────────────────────────────────────���────────────
+
+class _BreakdownBody extends StatelessWidget {
+  final MemberBreakdown breakdown;
+
+  const _BreakdownBody({required this.breakdown});
+
+  String _formatScore(double value) {
+    if (value == value.truncateToDouble()) return value.toStringAsFixed(0);
+    return value.toStringAsFixed(1);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return CustomScrollView(
+      physics: const AlwaysScrollableScrollPhysics(),
+      slivers: [
+        // ── Hero ──────────────────────���─────────────────────��─────────────────
+        SliverToBoxAdapter(
+          child: _BreakdownHero(breakdown: breakdown),
+        ),
+
+        // ── Señal: Clase ─────────────────────────────────────────────��────────
+        SliverToBoxAdapter(
+          child: _SignalDetailCard(
+            icon: HugeIcons.strokeRoundedBook01,
+            title: tr('rankings.breakdown.class_section'),
+            scorePct: breakdown.classScorePct,
+            weightPct: breakdown.weights.classPct,
+            formatScore: _formatScore,
+            details: _classDetails(context, breakdown.classBreakdown),
+          ),
+        ),
+
+        // ── Señal: Investidura ────────────────────────────────────────────────
+        SliverToBoxAdapter(
+          child: _SignalDetailCard(
+            icon: HugeIcons.strokeRoundedMedal01,
+            title: tr('rankings.breakdown.investiture_section'),
+            scorePct: breakdown.investitureScorePct,
+            weightPct: breakdown.weights.investiturePct,
+            formatScore: _formatScore,
+            details:
+                _investitureDetails(context, breakdown.investitureBreakdown),
+          ),
+        ),
+
+        // ── Señal: Camporees ──────────────────────────────────────────────────
+        SliverToBoxAdapter(
+          child: _SignalDetailCard(
+            icon: HugeIcons.strokeRoundedCampfire,
+            title: tr('rankings.breakdown.camporee_section'),
+            scorePct: breakdown.camporeeScorePct,
+            weightPct: breakdown.weights.camporeePct,
+            formatScore: _formatScore,
+            details: _camporeeDetails(context, breakdown.camporeeBreakdown),
+          ),
+        ),
+
+        // ── Pesos aplicados ───────────────────────────────────────────────────
+        SliverToBoxAdapter(
+          child: _WeightsSummary(weights: breakdown.weights),
+        ),
+
+        // ── Timestamp ─────────────────────────────────────────────────────────
+        if (breakdown.compositeCalculatedAt != null)
+          SliverToBoxAdapter(
+            child: _CalculatedAtRow(
+              calculatedAt: breakdown.compositeCalculatedAt!,
+            ),
+          ),
+
+        const SliverPadding(padding: EdgeInsets.only(bottom: 32)),
+      ],
+    );
+  }
+
+  List<String> _classDetails(BuildContext context, ClassBreakdown cb) {
+    final lines = <String>[
+      tr('rankings.breakdown.class_completed_sections', namedArgs: {
+        'completed': cb.completedSections.toString(),
+        'required': cb.requiredSections.toString(),
+      }),
+    ];
+    if (cb.folderStatus != null) {
+      lines.add(
+        tr('rankings.breakdown.class_folder_status',
+            namedArgs: {'status': cb.folderStatus!}),
+      );
+    }
+    return lines;
+  }
+
+  List<String> _investitureDetails(
+      BuildContext context, InvestitureBreakdown ib) {
+    if (ib.status == null) return [];
+    return [
+      tr('rankings.breakdown.investiture_status',
+          namedArgs: {'status': ib.status!}),
+    ];
+  }
+
+  List<String> _camporeeDetails(BuildContext context, CamporeeBreakdown cb) {
+    final lines = <String>[
+      cb.participated
+          ? tr('rankings.breakdown.camporee_participated')
+          : tr('rankings.breakdown.camporee_not_participated'),
+    ];
+    if (cb.totalCamporees != null) {
+      lines.add(
+        tr('rankings.breakdown.camporee_total',
+            namedArgs: {'total': cb.totalCamporees.toString()}),
+      );
+    }
+    return lines;
+  }
+}
+
+// ── Hero ──────────────────────────────────────────────────────────────────────
+
+class _BreakdownHero extends StatelessWidget {
+  final MemberBreakdown breakdown;
+
+  const _BreakdownHero({required this.breakdown});
+
+  Color _tierColor() {
+    return breakdown.awardedCategory?.tier.color ?? AppColors.darkBorder;
+  }
+
+  String _formatScore(double score) {
+    if (score == score.truncateToDouble()) return score.toStringAsFixed(0);
+    return score.toStringAsFixed(1);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final tierColor = _tierColor();
+    final hasComposite = breakdown.compositeScorePct != null;
+
+    return Container(
+      constraints: const BoxConstraints(minHeight: 100),
+      margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      decoration: BoxDecoration(
+        color: AppColors.darkSurface,
+        borderRadius: BorderRadius.circular(AppTheme.radiusMD),
+      ),
+      child: ClipRRect(
+        borderRadius: BorderRadius.circular(AppTheme.radiusMD),
+        child: IntrinsicHeight(
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Container(width: 4, color: tierColor),
+              Expanded(
+                child: Padding(
+                  padding: const EdgeInsets.all(20),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Row(
+                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                        children: [
+                          Expanded(
+                            child: Text(
+                              breakdown.memberName,
+                              style: Theme.of(context)
+                                  .textTheme
+                                  .titleMedium
+                                  ?.copyWith(
+                                    color: Colors.white,
+                                    fontWeight: FontWeight.w600,
+                                  ),
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                            ),
+                          ),
+                          if (breakdown.awardedCategory != null)
+                            _CategoryPill(
+                              name: breakdown.awardedCategory!.name,
+                              color: tierColor,
+                            ),
+                        ],
+                      ),
+                      const SizedBox(height: 12),
+                      if (hasComposite) ...[
+                        Text(
+                          _formatScore(breakdown.compositeScorePct!),
+                          style: Theme.of(context)
+                              .textTheme
+                              .displayLarge
+                              ?.copyWith(
+                                color: AppColors.accent,
+                                fontWeight: FontWeight.w700,
+                                fontSize: 32,
+                              ),
+                        ),
+                        const SizedBox(height: 2),
+                        Text(
+                          tr('rankings.breakdown.composite_score'),
+                          style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                                color: Colors.white.withValues(alpha: 0.6),
+                                fontSize: 12,
+                              ),
+                        ),
+                      ] else
+                        Text(
+                          tr('rankings.my_ranking.pending'),
+                          style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                                color: Colors.white.withValues(alpha: 0.6),
+                              ),
+                        ),
+                    ],
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _CategoryPill extends StatelessWidget {
+  final String name;
+  final Color color;
+
+  const _CategoryPill({required this.name, required this.color});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 3),
+      decoration: BoxDecoration(
+        color: color,
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Text(
+        name.toUpperCase(),
+        style: Theme.of(context).textTheme.labelSmall?.copyWith(
+              color: Colors.white,
+              fontWeight: FontWeight.w600,
+              fontSize: 10,
+            ),
+        overflow: TextOverflow.ellipsis,
+        maxLines: 1,
+      ),
+    );
+  }
+}
+
+// ── Signal detail card ────────────────────────────────────────────────────────
+
+class _SignalDetailCard extends StatelessWidget {
+  final HugeIconData icon;
+  final String title;
+  final double? scorePct;
+  final int weightPct;
+  final String Function(double) formatScore;
+  final List<String> details;
+
+  const _SignalDetailCard({
+    required this.icon,
+    required this.title,
+    this.scorePct,
+    required this.weightPct,
+    required this.formatScore,
+    required this.details,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final c = context.sac;
+    final hasScore = scorePct != null;
+    final scoreLabel = hasScore ? '${formatScore(scorePct!)}%' : '—';
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+      child: SacCard(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // Header row: icon + title + score badge
+            Row(
+              children: [
+                HugeIcon(
+                  icon: icon,
+                  size: 20,
+                  color: hasScore ? AppColors.primary : c.textTertiary,
+                ),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: Text(
+                    title,
+                    style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                          fontWeight: FontWeight.w600,
+                          color: c.text,
+                        ),
+                  ),
+                ),
+                // Score + weight chip
+                Column(
+                  crossAxisAlignment: CrossAxisAlignment.end,
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Text(
+                      scoreLabel,
+                      style: Theme.of(context)
+                          .textTheme
+                          .headlineSmall
+                          ?.copyWith(
+                            fontSize: 18,
+                            fontWeight: FontWeight.w700,
+                            color: hasScore ? c.text : c.textTertiary,
+                          ),
+                    ),
+                    Text(
+                      tr('rankings.breakdown.weight_pct',
+                          namedArgs: {'pct': weightPct.toString()}),
+                      style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                            color: c.textTertiary,
+                            fontSize: 10,
+                          ),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+
+            // Detail lines
+            if (details.isNotEmpty) ...[
+              const SizedBox(height: 10),
+              const Divider(height: 1),
+              const SizedBox(height: 10),
+              ...details.map(
+                (line) => Padding(
+                  padding: const EdgeInsets.only(bottom: 4),
+                  child: Text(
+                    line,
+                    style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                          color: c.textSecondary,
+                        ),
+                  ),
+                ),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+// ── Weights summary ─────────────────────────────────��─────────────────────────
+
+class _WeightsSummary extends StatelessWidget {
+  final BreakdownWeights weights;
+
+  const _WeightsSummary({required this.weights});
+
+  @override
+  Widget build(BuildContext context) {
+    final c = context.sac;
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+      child: SacCard(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              tr('rankings.breakdown.weights_title'),
+              style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                    fontWeight: FontWeight.w600,
+                    color: c.text,
+                  ),
+            ),
+            const SizedBox(height: 10),
+            _WeightRow(
+              label: tr('rankings.breakdown.class_section'),
+              pct: weights.classPct,
+            ),
+            _WeightRow(
+              label: tr('rankings.breakdown.investiture_section'),
+              pct: weights.investiturePct,
+            ),
+            _WeightRow(
+              label: tr('rankings.breakdown.camporee_section'),
+              pct: weights.camporeePct,
+            ),
+            const SizedBox(height: 8),
+            Text(
+              tr('rankings.breakdown.weights_source',
+                  namedArgs: {'source': weights.source}),
+              style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                    color: c.textTertiary,
+                    fontSize: 10,
+                  ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _WeightRow extends StatelessWidget {
+  final String label;
+  final int pct;
+
+  const _WeightRow({required this.label, required this.pct});
+
+  @override
+  Widget build(BuildContext context) {
+    final c = context.sac;
+
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 4),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          Text(
+            label,
+            style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                  color: c.textSecondary,
+                ),
+          ),
+          Text(
+            '$pct%',
+            style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                  fontWeight: FontWeight.w600,
+                  color: c.text,
+                ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+// ── Calculated at row ─────────────────────────────────────────────────────────
+
+class _CalculatedAtRow extends StatelessWidget {
+  final DateTime calculatedAt;
+
+  const _CalculatedAtRow({required this.calculatedAt});
+
+  @override
+  Widget build(BuildContext context) {
+    final c = context.sac;
+    final formatted =
+        DateFormat('dd/MM/yyyy HH:mm').format(calculatedAt.toLocal());
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      child: Text(
+        tr('rankings.breakdown.calculated_at', namedArgs: {'date': formatted}),
+        style: Theme.of(context).textTheme.labelSmall?.copyWith(
+              color: c.textTertiary,
+              fontSize: 10,
+            ),
+        textAlign: TextAlign.center,
+      ),
+    );
+  }
+}

--- a/lib/features/rankings/presentation/screens/my_ranking_screen.dart
+++ b/lib/features/rankings/presentation/screens/my_ranking_screen.dart
@@ -7,7 +7,6 @@ import 'package:hugeicons/hugeicons.dart';
 import '../../../../core/config/route_names.dart';
 import '../../../../core/theme/sac_colors.dart';
 import '../../../../providers/catalogs_provider.dart';
-import '../../domain/entities/award_tier.dart';
 import '../../domain/entities/member_ranking.dart';
 import '../providers/my_ranking_provider.dart';
 import '../widgets/ranking_empty_state.dart';
@@ -113,8 +112,7 @@ class _RankingBody extends ConsumerWidget {
                     rankPosition: ranking.rankPosition,
                     totalInSection: _resolveTotalInSection(view),
                     awardedCategoryName: ranking.awardedCategory?.name,
-                    awardedCategoryTier:
-                        ranking.awardedCategory?.tier ?? AwardTier.unknown,
+                    awardedCategoryTierId: ranking.awardedCategory?.id,
                     sectionName: ranking.sectionName,
                     ecclesiasticalYearLabel: yearLabel,
                   ),

--- a/lib/features/rankings/presentation/screens/my_ranking_screen.dart
+++ b/lib/features/rankings/presentation/screens/my_ranking_screen.dart
@@ -1,9 +1,11 @@
+import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:hugeicons/hugeicons.dart';
 
 import '../../../../core/theme/sac_colors.dart';
 import '../../../../providers/catalogs_provider.dart';
+import '../../domain/entities/award_tier.dart';
 import '../../domain/entities/member_ranking.dart';
 import '../providers/my_ranking_provider.dart';
 import '../widgets/ranking_empty_state.dart';
@@ -31,7 +33,7 @@ class MyRankingScreen extends ConsumerWidget {
 
     return Scaffold(
       appBar: AppBar(
-        title: const Text('Mi ranking'),
+        title: Text(tr('rankings.my_ranking.title')),
       ),
       body: yearAsync.when(
         data: (year) {
@@ -103,7 +105,8 @@ class _RankingBody extends ConsumerWidget {
                   rankPosition: ranking.rankPosition,
                   totalInSection: _resolveTotalInSection(view),
                   awardedCategoryName: ranking.awardedCategory?.name,
-                  awardedCategoryTierId: ranking.awardedCategory?.id,
+                  awardedCategoryTier:
+                      ranking.awardedCategory?.tier ?? AwardTier.unknown,
                   sectionName: ranking.sectionName,
                   ecclesiasticalYearLabel: yearLabel,
                 ),
@@ -169,7 +172,6 @@ class _RankingBody extends ConsumerWidget {
     }
     return null;
   }
-
 }
 
 // ── Nudge contextual ────────────────────────────────────────────────────────
@@ -182,8 +184,8 @@ class _ContextualNudge extends StatelessWidget {
 
   const _ContextualNudge({required this.ranking});
 
-  /// Devuelve el mensaje correspondiente a la señal con menor puntaje no-null.
-  String? _nudgeMessage() {
+  /// Devuelve la clave i18n correspondiente a la señal con menor puntaje no-null.
+  String? _nudgeKey() {
     final scores = <String, double?>{
       'class': ranking.classScorePct,
       'investiture': ranking.investitureScorePct,
@@ -200,11 +202,11 @@ class _ContextualNudge extends StatelessWidget {
 
     switch (available.first.key) {
       case 'class':
-        return 'Completá tus próximas lecciones de clase para mejorar tu puntaje.';
+        return 'rankings.my_ranking.nudge_class';
       case 'investiture':
-        return 'Trabajá en los requisitos de tu próxima investidura.';
+        return 'rankings.my_ranking.nudge_investiture';
       case 'camporee':
-        return 'Participá en los próximos camporees para sumar puntos.';
+        return 'rankings.my_ranking.nudge_camporee';
       default:
         return null;
     }
@@ -212,8 +214,8 @@ class _ContextualNudge extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final message = _nudgeMessage();
-    if (message == null) return const SizedBox.shrink();
+    final key = _nudgeKey();
+    if (key == null) return const SizedBox.shrink();
 
     final c = context.sac;
 
@@ -230,7 +232,7 @@ class _ContextualNudge extends StatelessWidget {
           const SizedBox(width: 4),
           Expanded(
             child: Text(
-              message,
+              tr(key),
               style: Theme.of(context).textTheme.bodySmall?.copyWith(
                     color: c.textSecondary,
                   ),

--- a/lib/features/rankings/presentation/screens/my_ranking_screen.dart
+++ b/lib/features/rankings/presentation/screens/my_ranking_screen.dart
@@ -1,8 +1,10 @@
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 import 'package:hugeicons/hugeicons.dart';
 
+import '../../../../core/config/route_names.dart';
 import '../../../../core/theme/sac_colors.dart';
 import '../../../../providers/catalogs_provider.dart';
 import '../../domain/entities/award_tier.dart';
@@ -99,16 +101,23 @@ class _RankingBody extends ConsumerWidget {
             physics: const AlwaysScrollableScrollPhysics(),
             slivers: [
               // Hero card con puntaje compuesto.
+              // Tapping navigates to the full breakdown drill-down.
               SliverToBoxAdapter(
-                child: RankingHeroCard(
-                  compositeScore: ranking.compositeScorePct,
-                  rankPosition: ranking.rankPosition,
-                  totalInSection: _resolveTotalInSection(view),
-                  awardedCategoryName: ranking.awardedCategory?.name,
-                  awardedCategoryTier:
-                      ranking.awardedCategory?.tier ?? AwardTier.unknown,
-                  sectionName: ranking.sectionName,
-                  ecclesiasticalYearLabel: yearLabel,
+                child: GestureDetector(
+                  onTap: () => context.push(
+                    RouteNames.memberBreakdownPath(
+                        ranking.enrollmentId, yearId),
+                  ),
+                  child: RankingHeroCard(
+                    compositeScore: ranking.compositeScorePct,
+                    rankPosition: ranking.rankPosition,
+                    totalInSection: _resolveTotalInSection(view),
+                    awardedCategoryName: ranking.awardedCategory?.name,
+                    awardedCategoryTier:
+                        ranking.awardedCategory?.tier ?? AwardTier.unknown,
+                    sectionName: ranking.sectionName,
+                    ecclesiasticalYearLabel: yearLabel,
+                  ),
                 ),
               ),
 

--- a/lib/features/rankings/presentation/screens/section_ranking_screen.dart
+++ b/lib/features/rankings/presentation/screens/section_ranking_screen.dart
@@ -1,3 +1,4 @@
+import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -47,25 +48,26 @@ class SectionRankingScreen extends ConsumerWidget {
           crossAxisAlignment: CrossAxisAlignment.start,
           mainAxisSize: MainAxisSize.min,
           children: [
-            const Text(
-              'Ranking de sección',
-              style: TextStyle(fontSize: 17, fontWeight: FontWeight.w600),
+            Text(
+              tr('rankings.section_ranking.title'),
+              style: const TextStyle(fontSize: 17, fontWeight: FontWeight.w600),
             ),
             // Subtítulo: se sobreescribe con el yearLabel cuando está disponible.
             // Mientras carga, muestra el texto base.
             yearAsync.maybeWhen(
               data: (year) => Text(
                 year != null
-                    ? 'Registro de progreso — ${year.name}'
-                    : 'Registro de progreso',
+                    ? tr('rankings.section_ranking.subtitle_with_year',
+                        namedArgs: {'year': year.name})
+                    : tr('rankings.section_ranking.subtitle'),
                 style: const TextStyle(
                   fontSize: 12,
                   fontWeight: FontWeight.w400,
                 ),
               ),
-              orElse: () => const Text(
-                'Registro de progreso',
-                style: TextStyle(
+              orElse: () => Text(
+                tr('rankings.section_ranking.subtitle'),
+                style: const TextStyle(
                   fontSize: 12,
                   fontWeight: FontWeight.w400,
                 ),

--- a/lib/features/rankings/presentation/screens/section_ranking_screen.dart
+++ b/lib/features/rankings/presentation/screens/section_ranking_screen.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 
 import '../../../../core/auth/club_role_names.dart';
+import '../../../../core/config/route_names.dart';
 import '../../../../providers/catalogs_provider.dart';
 import '../../../members/presentation/providers/members_providers.dart';
 import '../providers/section_ranking_provider.dart';
@@ -141,6 +143,9 @@ class SectionRankingScreen extends ConsumerWidget {
                 compositeScore: m.compositeScorePct,
                 awardedCategoryName: m.awardedCategory?.name,
                 awardedCategoryTierId: m.awardedCategory?.id,
+                onTap: () => context.push(
+                  RouteNames.memberBreakdownPath(m.enrollmentId, yearId),
+                ),
               );
             },
           );

--- a/lib/features/rankings/presentation/widgets/member_ranking_list_tile.dart
+++ b/lib/features/rankings/presentation/widgets/member_ranking_list_tile.dart
@@ -38,6 +38,10 @@ class MemberRankingListTile extends StatelessWidget {
   /// Neutro cuando null (sin tier asignado todavía).
   final String? awardedCategoryTierId;
 
+  /// Optional tap callback — wired by [SectionRankingScreen] to push the
+  /// breakdown drill-down for this member.
+  final VoidCallback? onTap;
+
   const MemberRankingListTile({
     super.key,
     required this.rankPosition,
@@ -46,6 +50,7 @@ class MemberRankingListTile extends StatelessWidget {
     this.compositeScore,
     this.awardedCategoryName,
     this.awardedCategoryTierId,
+    this.onTap,
   });
 
   /// Resuelve el color del tier para el score badge.
@@ -87,7 +92,7 @@ class MemberRankingListTile extends StatelessWidget {
       if (awardedCategoryName != null) 'categoría $awardedCategoryName',
     ].join(', ');
 
-    return Semantics(
+    final tile = Semantics(
       label: semanticsLabel,
       child: Container(
         constraints: const BoxConstraints(minHeight: 56),
@@ -162,6 +167,13 @@ class MemberRankingListTile extends StatelessWidget {
           ],
         ),
       ),
+    );
+
+    if (onTap == null) return tile;
+
+    return InkWell(
+      onTap: onTap,
+      child: tile,
     );
   }
 }

--- a/lib/features/rankings/presentation/widgets/ranking_empty_state.dart
+++ b/lib/features/rankings/presentation/widgets/ranking_empty_state.dart
@@ -1,3 +1,4 @@
+import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:hugeicons/hugeicons.dart';
 
@@ -80,7 +81,7 @@ class RankingEmptyState extends StatelessWidget {
                 style: ElevatedButton.styleFrom(
                   minimumSize: const Size(88, 44),
                 ),
-                child: const Text('Reintentar'),
+                child: Text(tr('rankings.empty_state.retry')),
               ),
             ],
           ],
@@ -94,36 +95,32 @@ class RankingEmptyState extends StatelessWidget {
       case RankingEmptyReason.hidden:
         return _EmptyConfig(
           icon: HugeIcons.strokeRoundedViewOff,
-          title: 'Ranking no disponible',
-          body:
-              'Tu director puede activar la visibilidad del ranking cuando esté listo.',
+          title: tr('rankings.empty_state.unavailable_title'),
+          body: tr('rankings.empty_state.unavailable_subtitle'),
         );
       case RankingEmptyReason.noData:
         return _EmptyConfig(
           icon: HugeIcons.strokeRoundedClock01,
-          title: 'Aún no hay datos',
-          body:
-              'Tu ranking se calcula automáticamente. Volvé a revisar más tarde.',
+          title: tr('rankings.empty_state.no_data_title'),
+          body: tr('rankings.empty_state.no_data_subtitle'),
         );
       case RankingEmptyReason.networkError:
         return _EmptyConfig(
           icon: HugeIcons.strokeRoundedWifiDisconnected01,
-          title: 'Sin conexión',
-          body: 'No pudimos cargar tu ranking.',
+          title: tr('rankings.empty_state.network_error_title'),
+          body: tr('rankings.empty_state.network_error_subtitle'),
         );
       case RankingEmptyReason.noSectionMembers:
         return _EmptyConfig(
           icon: HugeIcons.strokeRoundedUserSearch01,
-          title: 'Todavía no hay rankings',
-          body:
-              'Los rankings se calculan automáticamente cada 24 hs. Las clases y camporees del año ya deben estar registrados.',
+          title: tr('rankings.empty_state.no_members_title'),
+          body: tr('rankings.empty_state.no_members_subtitle'),
         );
       case RankingEmptyReason.unauthorized:
         return _EmptyConfig(
           icon: HugeIcons.strokeRoundedShieldKey,
-          title: 'Acceso restringido',
-          body:
-              'No tenés permisos para ver el ranking de esta sección. Consultá con tu director.',
+          title: tr('rankings.empty_state.unauthorized_title'),
+          body: tr('rankings.empty_state.unauthorized_subtitle'),
         );
     }
   }

--- a/lib/features/rankings/presentation/widgets/ranking_hero_card.dart
+++ b/lib/features/rankings/presentation/widgets/ranking_hero_card.dart
@@ -1,3 +1,4 @@
+import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 
 import '../../../../core/theme/app_colors.dart';
@@ -31,15 +32,10 @@ class RankingHeroCard extends StatelessWidget {
   });
 
   /// Resuelve el color del tier a partir del ID de categoría.
-  /// Usa la misma función [achievementTierColor] que el resto de la app.
   Color _tierColor() {
     if (awardedCategoryTierId == null) {
-      // TODO(rankings): replace with domain tier field when AwardCategory exposes it via Task 24 entity update
       return AppColors.darkBorder;
     }
-    // Mapeamos el UUID a un tier heurístico por nombre convencional.
-    // Los UUIDs reales los maneja el backend; esta función es un fallback
-    // hasta que la capa de dominio exponga un campo `tier` en AwardCategory.
     return AppColors.accent;
   }
 
@@ -66,7 +62,7 @@ class RankingHeroCard extends StatelessWidget {
     final semanticLabel = [
       hasComposite
           ? 'Tu puntaje compuesto es ${_formatScore(compositeScore!)}'
-          : 'Ranking pendiente',
+          : tr('rankings.my_ranking.pending'),
       if (rankLine != null) 'posición $rankLine',
       if (awardedCategoryName != null) 'categoría $awardedCategoryName',
     ].join(', ');
@@ -138,7 +134,7 @@ class RankingHeroCard extends StatelessWidget {
                           ),
                           const SizedBox(height: 2),
                           Text(
-                            'Puntaje compuesto',
+                            tr('rankings.my_ranking.composite_score'),
                             style: Theme.of(context)
                                 .textTheme
                                 .bodySmall
@@ -149,7 +145,7 @@ class RankingHeroCard extends StatelessWidget {
                           ),
                         ] else ...[
                           Text(
-                            'Ranking pendiente',
+                            tr('rankings.my_ranking.pending'),
                             style: Theme.of(context)
                                 .textTheme
                                 .bodyMedium
@@ -164,7 +160,7 @@ class RankingHeroCard extends StatelessWidget {
                           const SizedBox(height: 8),
                           Text(
                             '$rankLine'
-                            '${sectionName != null ? ' · Sección: $sectionName' : ''}',
+                            '${sectionName != null ? ' · ${tr('rankings.my_ranking.section_label', namedArgs: {'name': sectionName!})}' : ''}',
                             style: Theme.of(context)
                                 .textTheme
                                 .bodyMedium

--- a/lib/features/rankings/presentation/widgets/signal_score_row.dart
+++ b/lib/features/rankings/presentation/widgets/signal_score_row.dart
@@ -1,3 +1,4 @@
+import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:hugeicons/hugeicons.dart';
 
@@ -32,7 +33,7 @@ class SignalScoreRow extends StatelessWidget {
             child: _SignalScoreCard(
               icon: HugeIcons.strokeRoundedBook01,
               score: classScore,
-              label: 'Clase',
+              label: tr('rankings.signals.class'),
             ),
           ),
           const SizedBox(width: 8),
@@ -40,7 +41,7 @@ class SignalScoreRow extends StatelessWidget {
             child: _SignalScoreCard(
               icon: HugeIcons.strokeRoundedMedal01,
               score: investitureScore,
-              label: 'Investidura',
+              label: tr('rankings.signals.investiture'),
             ),
           ),
           const SizedBox(width: 8),
@@ -48,7 +49,7 @@ class SignalScoreRow extends StatelessWidget {
             child: _SignalScoreCard(
               icon: HugeIcons.strokeRoundedCampfire,
               score: camporeeScore,
-              label: 'Camporees',
+              label: tr('rankings.signals.camporee'),
             ),
           ),
         ],


### PR DESCRIPTION
## Summary

Addresses 3 of the 6 gaps from issue #11. The other 3 (`AwardedCategoryDto.is_legacy`, `AwardCategory.tier`, `total_in_section`) require backend coordination and stay in #11 backlog.

## Commits

1. `3d6921f` **i18n migration** — extracts user-facing strings from `ranking_empty_state.dart`, `signal_score_row.dart`, `my_ranking_screen.dart` into the `rankings.*` namespace. 41 keys × 4 locales (en, es, fr, pt-BR) = 164 entries added.
2. `2655e75` **member breakdown drill-down** — full Clean Architecture stack: entity, DTO, repo abstract method + impl, data source, `FutureProvider.autoDispose.family`, `MemberBreakdownScreen` (hero + 3 signal cards + weights summary), route registration, navigation hooks from `MyRankingScreen` (hero card tap) and `SectionRankingScreen` (per-tile tap).
3. `bdb4cea` **drop dead provider** — `sectionRankingsProvider` was declared but no screen observed it. Confirmed via grep. Endpoint stays available; rebuild when section list screen is on roadmap.
4. `a299ade` **i18n fixup** — covers `ranking_hero_card.dart` and `section_ranking_screen.dart` titles found in post-merge sweep, plus a type-mismatch fix between `RankingHeroCard` API (`awardedCategoryTierId: String?`) and the linter-migrated call sites.

## Backend contract

Breakdown DTO (`fromJson`) accepts both `weights` and `weights_applied` keys for forward compatibility, mirroring the admin normalizer pattern.

## Sweep results

- `rg "'Ranking|'Puntaje|'Clase|'Investidura|'Camporee" lib/features/rankings/` → only `'RankingsDS'` log tag remains (not user-facing).
- `rg "sectionRankingsProvider" lib/` → empty.

## Test plan

- [ ] Switch device locale to en/es/fr/pt-BR — all ranking screens render localized labels (no raw `rankings.*` keys visible)
- [ ] Login `director-club@sacdia.com` → MyRankingScreen → tap hero → breakdown screen renders with class/investiture/camporee cards + weights row
- [ ] Open SectionRankingScreen → tap any tile → breakdown screen for that enrollment
- [ ] Pull-to-refresh on breakdown screen
- [ ] Empty/error/skeleton states for breakdown
- [ ] Backend RBAC fix (sacdia-backend#37) already deployed — required for any of the above to return 200

Closes #11