### PR TITLE
refactor(rankings): move provider to data layer (Plan 8.4-A E5)

### DIFF
--- a/lib/features/rankings/data/datasources/rankings_remote_data_source.dart
+++ b/lib/features/rankings/data/datasources/rankings_remote_data_source.dart
@@ -1,8 +1,11 @@
 import 'package:dio/dio.dart';
 import 'package:easy_localization/easy_localization.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../../core/constants/api_endpoints.dart';
+import '../../../../core/constants/app_constants.dart';
 import '../../../../core/errors/exceptions.dart';
+import '../../../../providers/dio_provider.dart';
 import '../../../../core/utils/app_logger.dart';
 import '../models/member_ranking_dto.dart';
 import '../models/section_ranking_dto.dart';
@@ -248,3 +251,17 @@ class RankingsRemoteDataSourceImpl implements RankingsRemoteDataSource {
     }
   }
 }
+
+// ── Infrastructure provider ───────────────────────────────────────────────────
+
+/// Provider for the shared rankings remote data source.
+/// Co-located with [RankingsRemoteDataSource] following Clean Architecture
+/// (infrastructure dependency belongs in the data layer).
+/// Both member and section repository providers read from this single instance.
+final rankingsRemoteDataSourceProvider =
+    Provider<RankingsRemoteDataSource>((ref) {
+  return RankingsRemoteDataSourceImpl(
+    dio: ref.read(dioProvider),
+    baseUrl: AppConstants.baseUrl,
+  );
+});

--- a/lib/features/rankings/presentation/providers/my_ranking_provider.dart
+++ b/lib/features/rankings/presentation/providers/my_ranking_provider.dart
@@ -1,8 +1,6 @@
 import 'package:dio/dio.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-import '../../../../core/constants/app_constants.dart';
-import '../../../../providers/dio_provider.dart';
 import '../../../auth/presentation/providers/auth_providers.dart';
 import '../../data/datasources/rankings_remote_data_source.dart';
 import '../../data/repositories/member_rankings_repository_impl.dart';
@@ -10,16 +8,6 @@ import '../../domain/entities/member_ranking.dart';
 import '../../domain/repositories/member_rankings_repository.dart';
 
 // ── Infrastructure providers ──────────────────────────────────────────────────
-
-/// Provider for the shared rankings remote data source.
-/// Both member and section repository providers read from this single instance.
-final rankingsRemoteDataSourceProvider =
-    Provider<RankingsRemoteDataSource>((ref) {
-  return RankingsRemoteDataSourceImpl(
-    dio: ref.read(dioProvider),
-    baseUrl: AppConstants.baseUrl,
-  );
-});
 
 /// Provider for the member rankings repository.
 final memberRankingsRepositoryProvider =

--- a/lib/features/rankings/presentation/providers/section_ranking_provider.dart
+++ b/lib/features/rankings/presentation/providers/section_ranking_provider.dart
@@ -2,10 +2,10 @@ import 'package:dio/dio.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../auth/presentation/providers/auth_providers.dart';
+import '../../data/datasources/rankings_remote_data_source.dart';
 import '../../data/repositories/section_rankings_repository_impl.dart';
 import '../../domain/entities/section_ranking.dart';
 import '../../domain/repositories/section_rankings_repository.dart';
-import 'my_ranking_provider.dart';
 
 // ── Param types ───────────────────────────────────────────────────────────────
 
@@ -19,7 +19,7 @@ typedef SectionMembersParams = ({int sectionId, int yearId});
 // ── Infrastructure provider ───────────────────────────────────────────────────
 
 /// Provider for the section rankings repository.
-/// Reads the shared [rankingsRemoteDataSourceProvider] defined in my_ranking_provider.
+/// Reads the shared [rankingsRemoteDataSourceProvider] defined in the data layer.
 final sectionRankingsRepositoryProvider =
     Provider<SectionRankingsRepository>((ref) {
   return SectionRankingsRepositoryImpl(


### PR DESCRIPTION
## Summary

Plan 8.4-A Category E nit E5 — relocate \`rankingsRemoteDataSourceProvider\` from \`presentation/providers/my_ranking_provider.dart\` to the data layer (co-located with \`RankingsRemoteDataSourceImpl\`).

## Why

The provider's only dependencies (\`dioProvider\`, \`AppConstants.baseUrl\`) are infrastructure concerns — they belong in the data layer per Clean Architecture. Co-location with the implementation also makes the dependency direction explicit (presentation → data, never the inverse).

\`section_ranking_provider.dart\` now imports the provider directly from the data layer instead of relying on the implicit re-export through \`my_ranking_provider\`. Dart does not re-export symbols from imports, so the chain was already a latent fragility — fixed.

## E6 — skipped with rationale

Riverpod 2.x tuple combine pattern (\`yearAsync + ctxAsync\`) was scoped for this PR but skipped after investigation:
- No equivalent tuple-combine / \`AsyncValue.combine\` pattern exists anywhere in the codebase
- The current \`section_ranking_screen.dart\` correctly handles the two-AsyncValue case: \`.when()\` on the primary \`yearAsync\`, \`.valueOrNull\` on the secondary \`ctxAsync\` inside the \`data\` branch (lines 85-95)
- Forcing a tuple combine here would introduce a derived provider or utility for no readability gain

The current pattern is idiomatic for this scenario.

## Test plan

- [ ] \`flutter analyze\` clean (verified locally)
- [ ] Rankings tests pass (22/22 verified locally)
- [ ] Post-merge: my-ranking + section-ranking screens render identically (no behavior change)