### PR TITLE
fix(mobile): repair 5 pre-existing test failures + remove CI suppression

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,8 +46,6 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     needs: analyze
-    continue-on-error: true  # 7 pre-existing failures in app_bootstrap_provider_test + app_constants_test — tracked separately
-
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -63,11 +61,7 @@ jobs:
         run: flutter pub get
 
       - name: Run unit tests
-        # `|| true` suppresses 5 pre-existing failures in
-        # app_bootstrap_provider_test + app_constants_test (tracked separately).
-        # Keeps the check status SUCCESS so PR mergeStateStatus stays CLEAN.
-        # Remove the suppression once those failures are fixed.
-        run: flutter test --no-pub || true
+        run: flutter test --no-pub
 
   # Build Android (APK) job intentionally omitted. Release APKs are produced
   # via fastlane / manual dev pipeline, not from CI. The transitive

--- a/lib/features/notifications/presentation/providers/notifications_providers.dart
+++ b/lib/features/notifications/presentation/providers/notifications_providers.dart
@@ -76,9 +76,18 @@ class NotificationsInboxState {
 class NotificationsInboxNotifier extends Notifier<NotificationsInboxState> {
   static const _pageSize = 20;
   CancelToken? _currentToken;
+  // Tracks whether the notifier's lifecycle has ended (disposal or
+  // invalidation). Used to guard async callbacks that fire after disposal
+  // and would otherwise crash with "ProviderContainer already disposed".
+  bool _disposed = false;
 
   @override
   NotificationsInboxState build() {
+    _disposed = false;
+    ref.onDispose(() {
+      _disposed = true;
+      _currentToken?.cancel();
+    });
     // Carga la primera página al inicializar.
     Future.microtask(() => _loadPage(1, refresh: true));
     return const NotificationsInboxState(isLoading: true);
@@ -121,6 +130,12 @@ class NotificationsInboxNotifier extends Notifier<NotificationsInboxState> {
 
     _currentToken?.cancel();
     _currentToken = CancelToken();
+
+    // Guard: if the notifier was disposed while we were waiting (e.g. during
+    // a nuclear reset in tests or rapid navigation), bail out to avoid a
+    // "Tried to read a provider from a ProviderContainer that was already
+    // disposed" crash.
+    if (_disposed) return;
 
     final repository = ref.read(notificationsRepositoryProvider);
     final result = await repository.getHistory(

--- a/test/core/constants/app_constants_test.dart
+++ b/test/core/constants/app_constants_test.dart
@@ -4,7 +4,7 @@ import 'package:sacdia_app/core/constants/app_constants.dart';
 void main() {
   test('uses the local development API URL for physical devices by default',
       () {
-    expect(AppConstants.baseUrl, 'http://192.168.1.14:3000/api/v1');
+    expect(AppConstants.baseUrl, 'http://localhost:3000/api/v1');
   });
 
   test('allows overriding the API URL when needed', () {

--- a/test/features/auth/domain/utils/authorization_utils_test.dart
+++ b/test/features/auth/domain/utils/authorization_utils_test.dart
@@ -35,9 +35,11 @@ void main() {
     });
 
     test('uses resolved role names from authorization grants', () {
+      // resolvedRoleNames returns globalGrants + active club assignment only.
+      // Use globalGrants to assert that role names are normalised to lowercase.
       final user = buildUser(
         id: 'actor',
-        clubAssignments: const [
+        globalGrants: const [
           AuthorizationGrant(roleName: 'Director'),
           AuthorizationGrant(roleName: 'Secretary'),
         ],
@@ -49,9 +51,11 @@ void main() {
     test(
         'allows third-party administrative completion with explicit global access',
         () {
+      // The fine-grained permission for postRegistration update is
+      // 'users:update_profile' (not the generic 'users:update').
       final user = buildUser(
         id: 'actor',
-        permissions: const ['users:update'],
+        permissions: const ['users:update_profile'],
       );
 
       expect(
@@ -139,9 +143,11 @@ void main() {
     test(
         'allows fine-grained updates without treating users:update as sensitive read',
         () {
+      // 'users:update_profile' grants postRegistration update but not read.
+      // This verifies that update-only permissions do not bleed into read gates.
       final updater = buildUser(
         id: 'actor',
-        permissions: const ['users:update'],
+        permissions: const ['users:update_profile'],
       );
       final fineGrained = buildUser(
         id: 'actor',


### PR DESCRIPTION
## Summary

Plan 8.4-A Category E follow-up — fix the 5 pre-existing failures that PR #19 had to soft-fail with \`|| true\`, and remove the suppression so the test gate hard-fails on real regressions going forward.

Final test count: **151 passed / 0 failed**.

## Fixes

### Production code (1 fix)

\`lib/features/notifications/presentation/providers/notifications_providers.dart\`

\`ref.invalidate(notificationsInboxProvider)\` re-runs \`build()\`, which schedules \`Future.microtask(() => _loadPage(1, refresh: true))\`. When that microtask fires after the \`ProviderContainer\` has been disposed (test 'nuclear reset', or rapid in-app navigation), \`_loadPage\`'s \`ref.read(notificationsRepositoryProvider)\` crashes with:
\`Tried to read a provider from a ProviderContainer that was already disposed\`.

**Fix**: add a \`_disposed\` flag set in \`ref.onDispose()\` and short-circuit \`_loadPage\` when the notifier is gone. \`ref.onDispose\` also now cancels the in-flight \`CancelToken\`, which is a small correctness improvement in production too — invalidations no longer leak HTTP requests.

The \`Notifier<T>\` base class in Riverpod 2.6.1 does not expose \`ref.mounted\` (only \`AsyncNotifier\` does internally), so the manual flag is the correct idiom for plain \`Notifier\` subclasses.

### Tests (4 fixes)

| Test | Cause | Fix |
|---|---|---|
| \`app_constants_test\` "uses the local development API URL for physical devices by default" | \`defaultBaseUrl\` was changed from \`192.168.1.14:3000\` to \`localhost:3000\` months ago; expectation never moved | Update assertion |
| \`authorization_utils_test\` "uses resolved role names from authorization grants" | Fixture used \`clubAssignments\` without \`activeAssignmentId\` and no \`globalGrants\`; \`resolvedRoleNames\` always returned \`{}\` | Reseat fixture on \`globalGrants\` |
| \`authorization_utils_test\` "allows third-party administrative completion with explicit global access" | \`postRegistration\` sensitive permissions tightened from \`users:update\` to \`users:update_profile\` | Update permission key |
| \`authorization_utils_test\` "allows fine-grained updates without treating users:update as sensitive read" | Same as above for the \`updater\` user; original assertion intent preserved | Update permission key |

## CI workflow

- Drop \`|| true\` from \`flutter test\` step
- Drop \`continue-on-error: true\` from the Test job

Future test regressions now hard-fail.

## Test plan

- [ ] CI Analyze & Format + Test pass (151/0 expected)
- [ ] Post-merge: future PRs cannot land with broken tests

## Deferred (not in scope)

- EasyLocalization warnings (\`[WARNING] Localization key [...] not found\`) on bootstrap tests — cosmetic, requires seeding test translation fixtures