### PR TITLE
chore(mobile): flutter analyze cleanup — 41 issues → 3 infos

### DIFF
--- a/lib/core/animations/celebration_overlay.dart
+++ b/lib/core/animations/celebration_overlay.dart
@@ -129,8 +129,9 @@ class _CelebrationOverlayState extends State<CelebrationOverlay>
 
   @override
   Widget build(BuildContext context) {
-    if (MediaQuery.of(context).disableAnimations)
+    if (MediaQuery.of(context).disableAnimations) {
       return const SizedBox.shrink();
+    }
 
     return IgnorePointer(
       child: AnimatedBuilder(

--- a/lib/core/widgets/evidence_staging/evidence_staging_manager.dart
+++ b/lib/core/widgets/evidence_staging/evidence_staging_manager.dart
@@ -160,6 +160,7 @@ class EvidenceStagingManagerState extends State<EvidenceStagingManager> {
   // ── File picking ──────────────────────────────────────────────────────────
 
   Future<void> _pickImages(BuildContext context) async {
+    final messenger = ScaffoldMessenger.of(context);
     final source = await showImageSourceDialog(context);
     if (source == null || !mounted) return;
 
@@ -224,15 +225,13 @@ class EvidenceStagingManagerState extends State<EvidenceStagingManager> {
       _notifyLocalFilesChanged();
     } catch (e) {
       AppLogger.e('Error al seleccionar imagen', error: e);
-      if (mounted) {
-        // ignore: use_build_context_synchronously
-        _showErrorSnackbar(
-            context, tr('core.evidence_staging.error_select_image'));
-      }
+      _showErrorSnackbarViaMessenger(
+          messenger, tr('core.evidence_staging.error_select_image'));
     }
   }
 
   Future<void> _pickPdfs(BuildContext context) async {
+    final messenger = ScaffoldMessenger.of(context);
     try {
       final result = await FilePicker.platform.pickFiles(
         type: FileType.custom,
@@ -274,11 +273,8 @@ class EvidenceStagingManagerState extends State<EvidenceStagingManager> {
       _notifyLocalFilesChanged();
     } catch (e) {
       AppLogger.e('Error al seleccionar PDF', error: e);
-      if (mounted) {
-        // ignore: use_build_context_synchronously
-        _showErrorSnackbar(
-            context, tr('core.evidence_staging.error_select_pdf'));
-      }
+      _showErrorSnackbarViaMessenger(
+          messenger, tr('core.evidence_staging.error_select_pdf'));
     }
   }
 
@@ -340,6 +336,7 @@ class EvidenceStagingManagerState extends State<EvidenceStagingManager> {
   }
 
   Future<void> _executeUploadQueue(BuildContext context) async {
+    final messenger = ScaffoldMessenger.of(context);
     setState(() => _isUploading = true);
 
     // Prepare the upload stream controller
@@ -431,13 +428,10 @@ class EvidenceStagingManagerState extends State<EvidenceStagingManager> {
             _allFiles.any((f) => f.status == StagedFileStatus.uploaded);
 
         if (!hasCompletedFiles && !hasRemoteFiles) {
-          if (mounted) {
-            // ignore: use_build_context_synchronously
-            _showErrorSnackbar(
-              context,
-              tr('core.evidence_staging.error_upload_none'),
-            );
-          }
+          _showErrorSnackbarViaMessenger(
+            messenger,
+            tr('core.evidence_staging.error_upload_none'),
+          );
           break;
         }
 
@@ -597,19 +591,29 @@ class EvidenceStagingManagerState extends State<EvidenceStagingManager> {
   void _showErrorSnackbar(BuildContext context, String message) {
     if (!mounted) return;
     ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(
-        content: Row(
-          children: [
-            const Icon(Icons.error_outline_rounded,
-                color: Colors.white, size: 18),
-            const SizedBox(width: 8),
-            Expanded(child: Text(message)),
-          ],
-        ),
-        backgroundColor: AppColors.error,
-        behavior: SnackBarBehavior.floating,
-        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+      _buildErrorSnackBar(message),
+    );
+  }
+
+  void _showErrorSnackbarViaMessenger(
+      ScaffoldMessengerState messenger, String message) {
+    if (!mounted) return;
+    messenger.showSnackBar(_buildErrorSnackBar(message));
+  }
+
+  SnackBar _buildErrorSnackBar(String message) {
+    return SnackBar(
+      content: Row(
+        children: [
+          const Icon(Icons.error_outline_rounded,
+              color: Colors.white, size: 18),
+          const SizedBox(width: 8),
+          Expanded(child: Text(message)),
+        ],
       ),
+      backgroundColor: AppColors.error,
+      behavior: SnackBarBehavior.floating,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
     );
   }
 

--- a/lib/core/widgets/sac_dropdown_field.dart
+++ b/lib/core/widgets/sac_dropdown_field.dart
@@ -88,8 +88,8 @@ class _SacDropdownFieldState<T> extends State<SacDropdownField<T>> {
             ),
             clipBehavior: Clip.antiAlias,
             child: DropdownButtonFormField<T>(
-              // Solo pasar el value si existe exactamente un item con ese valor
-              value: widget.value != null &&
+              // Solo pasar el initialValue si existe exactamente un item con ese valor
+              initialValue: widget.value != null &&
                       widget.items
                               .where((item) => item.value == widget.value)
                               .length ==

--- a/lib/core/widgets/section_switcher_sheet.dart
+++ b/lib/core/widgets/section_switcher_sheet.dart
@@ -50,8 +50,9 @@ Color _sectionColor(String? clubTypeName) {
   final lower = clubTypeName.toLowerCase();
   if (lower.contains('conquistador')) return AppColors.primary;
   if (lower.contains('aventurer')) return AppColors.sacBlue;
-  if (lower.contains('guía') || lower.contains('guia'))
+  if (lower.contains('guía') || lower.contains('guia')) {
     return AppColors.secondary;
+  }
   return AppColors.primary;
 }
 

--- a/lib/features/achievements/presentation/widgets/achievement_grid_card.dart
+++ b/lib/features/achievements/presentation/widgets/achievement_grid_card.dart
@@ -116,7 +116,6 @@ class AchievementGridCard extends StatelessWidget {
       ),
     );
   }
-
 }
 
 // ── Secret badge placeholder ────────────────────────────────────────────────────

--- a/lib/features/achievements/presentation/widgets/achievement_grid_card.dart
+++ b/lib/features/achievements/presentation/widgets/achievement_grid_card.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:sacdia_app/core/theme/sac_colors.dart';
 
-import '../../domain/entities/achievement.dart';
 import '../../domain/entities/user_achievement.dart';
 import '../../domain/repositories/achievements_repository.dart';
 import 'achievement_badge.dart';
@@ -36,8 +35,6 @@ class AchievementGridCard extends StatelessWidget {
         userAchievement?.visualState ?? AchievementVisualState.locked;
 
     final progressValue = userAchievement?.progressValue ?? 0;
-    final progressTarget =
-        userAchievement?.progressTarget ?? _extractTarget(achievement);
     final progressPercentage = userAchievement?.progressPercentage ?? 0.0;
     final timesCompleted = userAchievement?.timesCompleted ?? 0;
 
@@ -120,13 +117,6 @@ class AchievementGridCard extends StatelessWidget {
     );
   }
 
-  int _extractTarget(Achievement achievement) {
-    final target = achievement.criteria['target'];
-    if (target is int) return target;
-    if (target is double) return target.toInt();
-    if (target is String) return int.tryParse(target) ?? 0;
-    return 0;
-  }
 }
 
 // ── Secret badge placeholder ────────────────────────────────────────────────────

--- a/lib/features/auth/presentation/views/login_view.dart
+++ b/lib/features/auth/presentation/views/login_view.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_svg/flutter_svg.dart';
 import 'package:hugeicons/hugeicons.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -92,16 +91,6 @@ class _LoginViewState extends ConsumerState<LoginView> {
       // Successful login — reset counter.
       _failedAttempts = 0;
     }
-  }
-
-  Future<void> _signInWithGoogle() async {
-    await ref.read(authNotifierProvider.notifier).signInWithGoogle();
-    // OAuthLaunchResult.launched → browser opened, wait for deep link.
-    // OAuthLaunchResult.failed   → error shown via authState.hasError.
-  }
-
-  Future<void> _signInWithApple() async {
-    await ref.read(authNotifierProvider.notifier).signInWithApple();
   }
 
   @override
@@ -365,50 +354,3 @@ class _LoginViewState extends ConsumerState<LoginView> {
   }
 }
 
-// ── OAuth button ───────────────────────────────────────────────────────────────
-
-class _OAuthButton extends StatelessWidget {
-  final VoidCallback? onPressed;
-  final String iconPath;
-  final String label;
-
-  const _OAuthButton({
-    required this.onPressed,
-    required this.iconPath,
-    required this.label,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    return OutlinedButton(
-      onPressed: onPressed,
-      style: OutlinedButton.styleFrom(
-        padding: const EdgeInsets.symmetric(vertical: 12),
-        side: BorderSide(color: context.sac.border),
-        shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(12),
-        ),
-        backgroundColor: context.sac.surface,
-      ),
-      child: Row(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: [
-          SvgPicture.asset(
-            iconPath,
-            width: 20,
-            height: 20,
-          ),
-          const SizedBox(width: 8),
-          Text(
-            label,
-            style: TextStyle(
-              color: context.sac.text,
-              fontWeight: FontWeight.w600,
-              fontSize: 14,
-            ),
-          ),
-        ],
-      ),
-    );
-  }
-}

--- a/lib/features/auth/presentation/views/login_view.dart
+++ b/lib/features/auth/presentation/views/login_view.dart
@@ -353,4 +353,3 @@ class _LoginViewState extends ConsumerState<LoginView> {
     );
   }
 }
-

--- a/lib/features/certifications/presentation/providers/certifications_providers.dart
+++ b/lib/features/certifications/presentation/providers/certifications_providers.dart
@@ -56,7 +56,7 @@ final certificationsProvider =
 /// NOT applied here. [certificationsProvider] returns [Certification] objects
 /// (name, description, active, modulesCount — no module tree), whereas this
 /// provider returns [CertificationDetail] which includes the full
-/// List<CertificationModule> with nested sections. The detail view renders
+/// `List<CertificationModule>` with nested sections. The detail view renders
 /// that module/section tree and computes totalSections from it, so the network
 /// call to GET /certifications/{id} is always required.
 final certificationDetailProvider = FutureProvider.autoDispose

--- a/lib/features/classes/presentation/views/requirement_detail_view.dart
+++ b/lib/features/classes/presentation/views/requirement_detail_view.dart
@@ -263,8 +263,9 @@ class _RequirementDetailViewState extends ConsumerState<RequirementDetailView> {
                             onProgress: onProgress,
                             skipInvalidation: true,
                           );
-                      if (!success)
+                      if (!success) {
                         throw Exception(tr('classes.errors.upload_failed'));
+                      }
                     },
                     onDeleteRemote: (fileId) async {
                       await ref

--- a/lib/features/classes/presentation/views/section_detail_view.dart
+++ b/lib/features/classes/presentation/views/section_detail_view.dart
@@ -15,10 +15,10 @@ class SectionDetailView extends ConsumerStatefulWidget {
   final int classId;
 
   const SectionDetailView({
-    Key? key,
+    super.key,
     required this.section,
     required this.classId,
-  }) : super(key: key);
+  });
 
   @override
   ConsumerState<SectionDetailView> createState() => _SectionDetailViewState();
@@ -115,6 +115,7 @@ class _SectionDetailViewState extends ConsumerState<SectionDetailView> {
                   if (userId == null) return;
 
                   final newStatus = !_isCompleted;
+                  final messenger = ScaffoldMessenger.of(context);
 
                   // Actualizar progreso
                   await ref
@@ -134,7 +135,7 @@ class _SectionDetailViewState extends ConsumerState<SectionDetailView> {
                     _isCompleted = newStatus;
                   });
 
-                  ScaffoldMessenger.of(context).showSnackBar(
+                  messenger.showSnackBar(
                     SnackBar(
                       content: Text(
                         newStatus

--- a/lib/features/classes/presentation/widgets/progress_ring.dart
+++ b/lib/features/classes/presentation/widgets/progress_ring.dart
@@ -9,11 +9,11 @@ class ProgressRing extends StatelessWidget {
   final double strokeWidth;
 
   const ProgressRing({
-    Key? key,
+    super.key,
     required this.progress,
     this.size = 60,
     this.strokeWidth = 4,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/features/club/data/repositories/club_repository_impl.dart
+++ b/lib/features/club/data/repositories/club_repository_impl.dart
@@ -3,7 +3,6 @@ import 'package:dio/dio.dart';
 
 import '../../../../core/errors/exceptions.dart';
 import '../../../../core/errors/failures.dart';
-import '../../../../core/network/network_info.dart';
 import '../../domain/entities/club_info.dart';
 import '../../domain/repositories/club_repository.dart';
 import '../datasources/club_remote_data_source.dart';
@@ -11,13 +10,10 @@ import '../datasources/club_remote_data_source.dart';
 /// Implementación de [ClubRepository].
 class ClubRepositoryImpl implements ClubRepository {
   final ClubRemoteDataSource _remoteDataSource;
-  final NetworkInfo _networkInfo;
 
   const ClubRepositoryImpl({
     required ClubRemoteDataSource remoteDataSource,
-    required NetworkInfo networkInfo,
-  })  : _remoteDataSource = remoteDataSource,
-        _networkInfo = networkInfo;
+  }) : _remoteDataSource = remoteDataSource;
 
   // ── getClub ───────────────────────────────────────────────────────────────
 

--- a/lib/features/club/presentation/providers/club_providers.dart
+++ b/lib/features/club/presentation/providers/club_providers.dart
@@ -26,7 +26,6 @@ final clubRemoteDataSourceProvider = Provider<ClubRemoteDataSource>((ref) {
 final clubRepositoryProvider = Provider<ClubRepository>((ref) {
   return ClubRepositoryImpl(
     remoteDataSource: ref.read(clubRemoteDataSourceProvider),
-    networkInfo: ref.read(networkInfoProvider),
   );
 });
 

--- a/lib/features/dashboard/presentation/widgets/club_info_card.dart
+++ b/lib/features/dashboard/presentation/widgets/club_info_card.dart
@@ -48,8 +48,9 @@ class ClubInfoCard extends ConsumerWidget {
     final lower = type.toLowerCase();
     if (lower.contains('conquistador')) return AppColors.primary;
     if (lower.contains('aventurer')) return AppColors.sacBlue;
-    if (lower.contains('guía') || lower.contains('guia'))
+    if (lower.contains('guía') || lower.contains('guia')) {
       return AppColors.secondary;
+    }
     return AppColors.primary;
   }
 

--- a/lib/features/enrollment/data/datasources/enrollment_remote_data_source.dart
+++ b/lib/features/enrollment/data/datasources/enrollment_remote_data_source.dart
@@ -277,8 +277,9 @@ class EnrollmentRemoteDataSourceImpl implements EnrollmentRemoteDataSource {
       if (fee != null) data['fee'] = fee;
       if (feeAmount != null) data['fee_amount'] = feeAmount;
       if (directorId != null) data['director_id'] = directorId;
-      if (deputyDirectorIds != null)
+      if (deputyDirectorIds != null) {
         data['deputy_director_ids'] = deputyDirectorIds;
+      }
       if (secretaryId != null) data['secretary_id'] = secretaryId;
       if (treasurerId != null) data['treasurer_id'] = treasurerId;
       if (secretaryTreasurerId != null) {

--- a/lib/features/enrollment/data/repositories/enrollment_repository_impl.dart
+++ b/lib/features/enrollment/data/repositories/enrollment_repository_impl.dart
@@ -3,20 +3,16 @@ import 'package:dio/dio.dart';
 
 import '../../../../core/errors/exceptions.dart';
 import '../../../../core/errors/failures.dart';
-import '../../../../core/network/network_info.dart';
 import '../../domain/entities/enrollment.dart';
 import '../../domain/repositories/enrollment_repository.dart';
 import '../datasources/enrollment_remote_data_source.dart';
 
 class EnrollmentRepositoryImpl implements EnrollmentRepository {
   final EnrollmentRemoteDataSource _remoteDataSource;
-  final NetworkInfo _networkInfo;
 
   const EnrollmentRepositoryImpl({
     required EnrollmentRemoteDataSource remoteDataSource,
-    required NetworkInfo networkInfo,
-  })  : _remoteDataSource = remoteDataSource,
-        _networkInfo = networkInfo;
+  }) : _remoteDataSource = remoteDataSource;
 
   @override
   Future<Either<Failure, Enrollment>> createEnrollment({

--- a/lib/features/enrollment/presentation/providers/enrollment_providers.dart
+++ b/lib/features/enrollment/presentation/providers/enrollment_providers.dart
@@ -25,7 +25,6 @@ final enrollmentRemoteDataSourceProvider =
 final enrollmentRepositoryProvider = Provider<EnrollmentRepository>((ref) {
   return EnrollmentRepositoryImpl(
     remoteDataSource: ref.read(enrollmentRemoteDataSourceProvider),
-    networkInfo: ref.read(networkInfoProvider),
   );
 });
 

--- a/lib/features/enrollment/presentation/views/enrollment_form_view.dart
+++ b/lib/features/enrollment/presentation/views/enrollment_form_view.dart
@@ -1188,7 +1188,8 @@ class _ToggleRow extends StatelessWidget {
           Switch.adaptive(
             value: value,
             onChanged: enabled ? onChanged : null,
-            activeColor: AppColors.primary,
+            activeThumbColor: AppColors.primary,
+            activeTrackColor: AppColors.primary.withValues(alpha: 0.5),
           ),
         ],
       ),

--- a/lib/features/evidence_folder/presentation/views/evidence_section_detail_view.dart
+++ b/lib/features/evidence_folder/presentation/views/evidence_section_detail_view.dart
@@ -249,9 +249,10 @@ class _EvidenceSectionDetailViewState
                             onProgress: onProgress,
                             skipInvalidation: true,
                           );
-                      if (!success)
+                      if (!success) {
                         throw Exception(
                             tr('evidence_folder.errors.upload_failed'));
+                      }
                     },
                     onDeleteRemote: (fileId) async {
                       await ref

--- a/lib/features/finances/presentation/widgets/finance_line_chart.dart
+++ b/lib/features/finances/presentation/widgets/finance_line_chart.dart
@@ -422,8 +422,9 @@ class _ChartView extends StatelessWidget {
 
   String _formatYValue(double v) {
     if (v == 0) return '\$0';
-    if (v >= 1000)
+    if (v >= 1000) {
       return '\$${(v / 1000).toStringAsFixed(v % 1000 == 0 ? 0 : 1)}k';
+    }
     return '\$${v.toStringAsFixed(0)}';
   }
 

--- a/lib/features/post_registration/data/models/allergy_model.dart
+++ b/lib/features/post_registration/data/models/allergy_model.dart
@@ -6,7 +6,7 @@ class AllergyModel extends Equatable {
   final String name;
   final bool isSelected;
 
-  AllergyModel({
+  const AllergyModel({
     required this.id,
     required this.name,
     this.isSelected = false,

--- a/lib/features/post_registration/data/models/disease_model.dart
+++ b/lib/features/post_registration/data/models/disease_model.dart
@@ -6,7 +6,7 @@ class DiseaseModel extends Equatable {
   final String name;
   final bool isSelected;
 
-  DiseaseModel({
+  const DiseaseModel({
     required this.id,
     required this.name,
     this.isSelected = false,

--- a/lib/features/post_registration/presentation/widgets/cascading_dropdown.dart
+++ b/lib/features/post_registration/presentation/widgets/cascading_dropdown.dart
@@ -57,7 +57,7 @@ class CascadingDropdown<T> extends StatelessWidget {
           )
         else
           DropdownButtonFormField<dynamic>(
-            value:
+            initialValue:
                 selectedValue != null ? getItemValue(selectedValue as T) : null,
             decoration: InputDecoration(
               hintText: hintText ??

--- a/lib/features/profile/presentation/providers/active_sessions_providers.dart
+++ b/lib/features/profile/presentation/providers/active_sessions_providers.dart
@@ -78,8 +78,9 @@ class ActiveSessionsNotifier
   /// Retorna null en éxito o un mensaje de error localizado.
   Future<String?> revoke(String sessionId) async {
     final previous = state.valueOrNull;
-    if (previous == null)
+    if (previous == null) {
       return 'profile.active_sessions.errors.no_sessions_loaded'.tr();
+    }
 
     // Optimistic remove — quitar de la lista localmente de inmediato.
     state = AsyncData(
@@ -111,11 +112,12 @@ class ActiveSessionsNotifier
   /// Retorna el número de sesiones revocadas, o un mensaje de error.
   Future<({int count, String? error})> revokeAllOthers() async {
     final previous = state.valueOrNull;
-    if (previous == null)
+    if (previous == null) {
       return (
         count: 0,
         error: 'profile.active_sessions.errors.no_sessions_loaded'.tr()
       );
+    }
 
     final othersCount = previous.where((s) => !s.isCurrent).length;
 

--- a/lib/features/profile/presentation/providers/notification_preferences_providers.dart
+++ b/lib/features/profile/presentation/providers/notification_preferences_providers.dart
@@ -79,8 +79,9 @@ class NotificationPreferencesNotifier
   /// Retorna null en éxito o un mensaje de error localizado.
   Future<String?> patch(Map<String, bool> delta) async {
     final previous = state.valueOrNull;
-    if (previous == null)
+    if (previous == null) {
       return 'profile.notification_preferences.errors.no_prefs_loaded'.tr();
+    }
 
     // Optimistic update — aplicar delta localmente de forma inmediata.
     final optimistic = _applyDelta(previous, delta);

--- a/lib/features/rankings/data/models/member_breakdown_dto.dart
+++ b/lib/features/rankings/data/models/member_breakdown_dto.dart
@@ -1,5 +1,4 @@
 import '../../../../core/utils/json_helpers.dart';
-import '../../domain/entities/award_tier.dart';
 import '../../domain/entities/member_breakdown.dart';
 import 'member_ranking_dto.dart';
 

--- a/lib/features/rankings/domain/entities/member_breakdown.dart
+++ b/lib/features/rankings/domain/entities/member_breakdown.dart
@@ -1,6 +1,5 @@
 import 'package:equatable/equatable.dart';
 
-import 'award_tier.dart';
 import 'member_ranking.dart';
 
 /// Breakdown detail for the class signal component.

--- a/lib/features/rankings/presentation/screens/member_breakdown_screen.dart
+++ b/lib/features/rankings/presentation/screens/member_breakdown_screen.dart
@@ -8,7 +8,6 @@ import '../../../../core/theme/app_theme.dart';
 import '../../../../core/theme/sac_colors.dart';
 import '../../../../core/utils/icon_helper.dart';
 import '../../../../core/widgets/sac_card.dart';
-import '../../domain/entities/award_tier.dart';
 import '../../domain/entities/member_breakdown.dart';
 import '../providers/member_breakdown_provider.dart';
 import '../widgets/ranking_empty_state.dart';

--- a/lib/features/settings/domain/entities/sync_result.dart
+++ b/lib/features/settings/domain/entities/sync_result.dart
@@ -25,9 +25,8 @@ class SyncResult {
     required this.errorMessage,
   });
 
-  const SyncResult.ok(DateTime syncedAt)
+  const SyncResult.ok(this.syncedAt)
       : success = true,
-        syncedAt = syncedAt,
         errorMessage = null;
 
   const SyncResult.error(String message)

--- a/lib/features/transfers/data/repositories/transfer_repository_impl.dart
+++ b/lib/features/transfers/data/repositories/transfer_repository_impl.dart
@@ -3,20 +3,16 @@ import 'package:dio/dio.dart';
 
 import '../../../../core/errors/exceptions.dart';
 import '../../../../core/errors/failures.dart';
-import '../../../../core/network/network_info.dart';
 import '../../domain/entities/transfer_request.dart';
 import '../../domain/repositories/transfer_repository.dart';
 import '../datasources/transfer_remote_data_source.dart';
 
 class TransferRepositoryImpl implements TransferRepository {
   final TransferRemoteDataSource _remoteDataSource;
-  final NetworkInfo _networkInfo;
 
   const TransferRepositoryImpl({
     required TransferRemoteDataSource remoteDataSource,
-    required NetworkInfo networkInfo,
-  })  : _remoteDataSource = remoteDataSource,
-        _networkInfo = networkInfo;
+  }) : _remoteDataSource = remoteDataSource;
 
   @override
   Future<Either<Failure, TransferRequest>> createTransferRequest({

--- a/lib/features/transfers/presentation/providers/transfer_providers.dart
+++ b/lib/features/transfers/presentation/providers/transfer_providers.dart
@@ -21,7 +21,6 @@ final transferRemoteDataSourceProvider =
 final transferRepositoryProvider = Provider<TransferRepository>((ref) {
   return TransferRepositoryImpl(
     remoteDataSource: ref.read(transferRemoteDataSourceProvider),
-    networkInfo: ref.read(networkInfoProvider),
   );
 });
 

--- a/lib/features/units/data/models/unit_model.dart
+++ b/lib/features/units/data/models/unit_model.dart
@@ -72,8 +72,8 @@ class UnitModel extends Unit {
     // Miembros
     final rawMembers = json['unit_members'] as List<dynamic>? ?? [];
     final members = rawMembers
-        .where((m) => m is Map<String, dynamic>)
-        .map((m) => UnitMemberModel.fromJson(m as Map<String, dynamic>))
+        .whereType<Map<String, dynamic>>()
+        .map((m) => UnitMemberModel.fromJson(m))
         .cast<UnitMember>()
         .toList();
 

--- a/lib/features/validation/data/repositories/validation_repository_impl.dart
+++ b/lib/features/validation/data/repositories/validation_repository_impl.dart
@@ -3,20 +3,16 @@ import 'package:dio/dio.dart';
 
 import '../../../../core/errors/exceptions.dart';
 import '../../../../core/errors/failures.dart';
-import '../../../../core/network/network_info.dart';
 import '../../domain/entities/validation.dart';
 import '../../domain/repositories/validation_repository.dart';
 import '../datasources/validation_remote_data_source.dart';
 
 class ValidationRepositoryImpl implements ValidationRepository {
   final ValidationRemoteDataSource _remoteDataSource;
-  final NetworkInfo _networkInfo;
 
   const ValidationRepositoryImpl({
     required ValidationRemoteDataSource remoteDataSource,
-    required NetworkInfo networkInfo,
-  })  : _remoteDataSource = remoteDataSource,
-        _networkInfo = networkInfo;
+  }) : _remoteDataSource = remoteDataSource;
 
   @override
   Future<Either<Failure, ValidationSubmitResult>> submitForReview({

--- a/lib/features/validation/presentation/providers/validation_providers.dart
+++ b/lib/features/validation/presentation/providers/validation_providers.dart
@@ -23,7 +23,6 @@ final validationRemoteDataSourceProvider =
 final validationRepositoryProvider = Provider<ValidationRepository>((ref) {
   return ValidationRepositoryImpl(
     remoteDataSource: ref.read(validationRemoteDataSourceProvider),
-    networkInfo: ref.read(networkInfoProvider),
   );
 });
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -990,7 +990,7 @@ packages:
     source: hosted
     version: "2.3.0"
   local_auth_android:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: local_auth_android
       sha256: a0bdfcc0607050a26ef5b31d6b4b254581c3d3ce3c1816ab4d4f4a9173e84467
@@ -998,7 +998,7 @@ packages:
     source: hosted
     version: "1.0.56"
   local_auth_darwin:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: local_auth_darwin
       sha256: "699873970067a40ef2f2c09b4c72eb1cfef64224ef041b3df9fdc5c4c1f91f49"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -63,6 +63,8 @@ dependencies:
   flutter_markdown: ^0.7.4
   device_info_plus: ^10.1.2
   local_auth: ^2.3.0
+  local_auth_android: ^1.0.56
+  local_auth_darwin: ^1.6.1
 
   # Firebase
   firebase_core: ^3.8.0

--- a/test/features/auth/data/delete_account_test.dart
+++ b/test/features/auth/data/delete_account_test.dart
@@ -56,7 +56,7 @@ class MockAdapter implements HttpClientAdapter {
     Future<void>? cancelFuture,
   ) async {
     final responseBody = body != null
-        ? '${body!.entries.map((e) => '"${e.key}":"${e.value}"').join(',')}'
+        ? body!.entries.map((e) => '"${e.key}":"${e.value}"').join(',')
         : '';
     return ResponseBody.fromString(
       '{$responseBody}',


### PR DESCRIPTION
## Summary

Clean up \`flutter analyze\` warnings and infos. From **9 warnings + 32 infos = 41** down to **0 warnings + 3 infos**. \`flutter test\` still 151/0.

## Buckets fixed

| Rule | Sites | Notes |
|---|---|---|
| \`unused_import\` | 4 | rankings, auth, achievement |
| \`unused_element\` (dead code) | 3 | login_view OAuth stubs (~58 LOC), achievement _extractTarget, evidence model field |
| \`unused_field\` (\`_networkInfo\`) | 4 | club/enrollment/transfers/validation repos |
| \`use_build_context_synchronously\` | 4 | pre-capture ScaffoldMessenger before async gaps |
| \`deprecated_member_use\` | 3 | Switch.activeColor → activeThumb+activeTrack, Dropdown.value → initialValue |
| \`curly_braces_in_flow_control_structures\` | 8 | 10 sites |
| \`use_super_parameters\` | 2 | section_detail_view, progress_ring |
| \`prefer_const_constructors_in_immutables\` | 2 | allergy/disease models |
| \`prefer_initializing_formals\` | 1 | SyncResult.ok |
| \`prefer_iterable_wheretype\` | 1 | UnitModel.fromJson |
| \`unintended_html_in_doc_comment\` | 1 | certifications doc |
| \`unnecessary_string_interpolations\` | 1 | delete_account_test |
| \`depend_on_referenced_packages\` | 2 | local_auth_android + local_auth_darwin explicit in pubspec |

## Behavioral notes

- **\`_networkInfo\` removal** (4 repos): purely cosmetic at runtime — the field was never read in any of those repos. Constructors and the matching providers updated together. The \`NetworkInfo\` interface and \`networkInfoProvider\` remain in DI for future offline-aware features; nothing is retired from the architecture.
- **pubspec.lock regenerated** for the 2 new explicit deps. Versions match what was already pulled transitively.
- **\`use_build_context_synchronously\` fixes** are real correctness improvements — pre-capturing the messenger avoids reading a disposed BuildContext after \`await\`.

## Deferred (3 infos remain)

- \`avoid_types_as_parameter_names\` on \`lib/core/usecases/usecase.dart\` — uses \`Type\` as the generic param. Renaming to \`T\` or \`Output\` is a public Clean Architecture API change touching every use-case class and its tests. Separate refactor ticket.

## Test plan

- [ ] CI Analyze & Format pass (target: 0 errors, 0 warnings, ≤3 infos)
- [ ] CI Test pass (151/0)