### PR TITLE
build(mobile): bump AGP 8.9.1 + Gradle 8.11.1 + Kotlin 2.1 + image_cropper 9.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,33 +63,10 @@ jobs:
       - name: Run unit tests
         run: flutter test --no-pub
 
-  # ──────────────────────────────────────────────────────────────────────────
-  # JOB 3: Android build sanity check
-  # ──────────────────────────────────────────────────────────────────────────
-  build-android:
-    name: Build Android (APK)
-    runs-on: ubuntu-latest
-    needs: test
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Java 17
-        uses: actions/setup-java@v4
-        with:
-          distribution: temurin
-          java-version: '17'
-
-      - name: Setup Flutter
-        uses: subosito/flutter-action@v2
-        with:
-          flutter-version: '3.41.6'
-          channel: stable
-          cache: true
-
-      - name: Install dependencies
-        run: flutter pub get
-
-      - name: Build release APK
-        run: flutter build apk --release --no-tree-shake-icons
+  # Build Android (APK) job intentionally omitted. Release APKs are produced
+  # via fastlane / manual dev pipeline, not from CI. The release flavor wires
+  # in google-services.json, which is gitignored as a Firebase secret. Adding
+  # the build to CI requires either a GitHub Actions secret with the file
+  # base64-encoded + decoded at workflow time, or a CI-only build flavor
+  # without the google-services plugin. Until that is set up, analyze + test
+  # are the meaningful gates on PRs.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,10 +63,33 @@ jobs:
       - name: Run unit tests
         run: flutter test --no-pub
 
-  # Build Android (APK) job intentionally omitted. Release APKs are produced
-  # via fastlane / manual dev pipeline, not from CI. The transitive
-  # image_cropper 5.0.1 dependency still references the legacy v1 Android
-  # embedding (PluginRegistry.Registrar) which the current Flutter SDK no
-  # longer ships, so a CI build would fail until that package is bumped.
-  # That is real upgrade work tracked separately. analyze + test are the
-  # meaningful gates on PRs.
+  # ──────────────────────────────────────────────────────────────────────────
+  # JOB 3: Android build sanity check
+  # ──────────────────────────────────────────────────────────────────────────
+  build-android:
+    name: Build Android (APK)
+    runs-on: ubuntu-latest
+    needs: test
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Java 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: '3.41.6'
+          channel: stable
+          cache: true
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Build release APK
+        run: flutter build apk --release --no-tree-shake-icons

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-all.zip

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-all.zip

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -18,7 +18,7 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.7.3" apply false
+    id "com.android.application" version "8.9.1" apply false
     id "org.jetbrains.kotlin.android" version "1.8.22" apply false
     id "com.google.gms.google-services" version "4.4.2" apply false
 }

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -18,7 +18,7 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.1.0" apply false
+    id "com.android.application" version "8.7.3" apply false
     id "org.jetbrains.kotlin.android" version "1.8.22" apply false
     id "com.google.gms.google-services" version "4.4.2" apply false
 }

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -19,7 +19,7 @@ pluginManagement {
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
     id "com.android.application" version "8.9.1" apply false
-    id "org.jetbrains.kotlin.android" version "1.8.22" apply false
+    id "org.jetbrains.kotlin.android" version "2.1.0" apply false
     id "com.google.gms.google-services" version "4.4.2" apply false
 }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -801,26 +801,26 @@ packages:
     dependency: "direct main"
     description:
       name: image_cropper
-      sha256: f4bad5ed2dfff5a7ce0dfbad545b46a945c702bb6182a921488ef01ba7693111
+      sha256: "4e9c96c029eb5a23798da1b6af39787f964da6ffc78fd8447c140542a9f7c6fc"
       url: "https://pub.dev"
     source: hosted
-    version: "5.0.1"
+    version: "9.1.0"
   image_cropper_for_web:
     dependency: transitive
     description:
       name: image_cropper_for_web
-      sha256: "865d798b5c9d826f1185b32e5d0018c4183ddb77b7b82a931e1a06aa3b74974e"
+      sha256: fd81ebe36f636576094377aab32673c4e5d1609b32dec16fad98d2b71f1250a9
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.0"
+    version: "6.1.0"
   image_cropper_platform_interface:
     dependency: transitive
     description:
       name: image_cropper_platform_interface
-      sha256: ee160d686422272aa306125f3b6fb1c1894d9b87a5e20ed33fa008e7285da11e
+      sha256: "2d8db8f4b638e448fa89a1e77cd8f053b4547472bd3ae073169e86626d03afef"
       url: "https://pub.dev"
     source: hosted
-    version: "5.0.0"
+    version: "7.2.0"
   image_picker:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -38,7 +38,7 @@ dependencies:
   
   # Imágenes, archivos y permisos
   image_picker: ^1.0.7
-  image_cropper: ^5.0.1
+  image_cropper: ^9.0.0
   file_picker: ^8.0.0
   permission_handler: ^11.3.0
   photo_view: ^0.15.0


### PR DESCRIPTION
## Summary

Mobile Android build hardening — three coupled upgrades that were blocking the Android build chain. Originally scoped to also restore the \`build-android\` CI job (M5), but that surfaced a separate infra gap (\`google-services.json\` missing in CI) that needs its own setup. The plugin chain itself is shipped here; CI gate restoration tracked separately.

## Changes

### Android Gradle Plugin / Gradle wrapper

| | Before | After |
|---|---|---|
| AGP | 8.1.0 | **8.9.1** |
| Gradle wrapper | 8.3 | **8.11.1** |

8.9.1 is the floor for transitive deps the project pulls in:
- \`androidx.browser:1.9.0\`
- \`androidx.activity:1.12.4\`
- \`androidx.activity:activity-ktx:1.12.4\`

Gradle 8.11.1 is AGP 8.9.x's required minimum.

### Kotlin

\`1.8.22\` → **\`2.1.0\`**.

\`mobile_scanner\` plugin source no longer compiles against KGP 1.8.x — Flutter has been warning that 1.8.22 was about to be dropped. \`jvmTarget\` stays at \`JavaVersion.VERSION_1_8\` in \`android/app/build.gradle\` (Kotlin 2.x continues to support that target).

### image_cropper

\`^5.0.1\` → **\`^9.0.0\`** (resolves to 9.1.0).

The original blocker was that \`image_cropper 5.0.1\` referenced \`PluginRegistry.Registrar\` from the legacy v1 Android embedding. v9 ships v2 embedding. Dart API surface unchanged — \`cropImage()\`, \`AndroidUiSettings\`, \`IOSUiSettings\`, \`CroppedFile\` all identical between v5 and v9. Three call sites needed zero adaptation:
- \`lib/features/post_registration/presentation/views/photo_step_view.dart\`
- \`lib/features/profile/presentation/views/edit_profile_view.dart\`
- \`lib/features/profile/presentation/views/profile_view.dart\`

\`pubspec.lock\` regenerated with the new resolved package set.

## What's NOT in this PR

The \`build-android\` CI job is **not restored**. Adding it failed because the release flavor pulls in \`google-services.json\` (Firebase config, gitignored as secret). Restoring the gate requires:
1. A GitHub Actions repo secret with \`google-services.json\` base64-encoded + decoded at workflow time, OR
2. A CI-only build flavor that excludes the google-services plugin

Tracked as a separate task. Until then, analyze + test remain the CI gates; release APKs continue to build via fastlane / manual dev pipeline.

## Verification

- \`flutter analyze --no-fatal-warnings --no-fatal-infos\`: 0 errors / 0 warnings / 3 infos (pre-existing in \`lib/core/usecases/usecase.dart\`)
- \`flutter test --no-pub\`: **151 / 151** passing
- CI on this PR runs analyze + test only

## Test plan

- [ ] CI \`Analyze & Format\` pass
- [ ] CI \`Test\` pass (151/0)
- [ ] Manual: \`flutter build apk --release\` succeeds locally with \`google-services.json\` in place