### PR TITLE
fix(mobile): rename UseCase generic param Type → T

### DIFF
--- a/lib/core/usecases/usecase.dart
+++ b/lib/core/usecases/usecase.dart
@@ -2,18 +2,18 @@ import 'package:dartz/dartz.dart';
 import '../errors/failures.dart';
 
 /// Caso de uso base abstracto para operaciones que retornan un solo resultado
-abstract class UseCase<Type, Params> {
-  Future<Either<Failure, Type>> call(Params params);
+abstract class UseCase<T, Params> {
+  Future<Either<Failure, T>> call(Params params);
 }
 
 /// Caso de uso base abstracto para operaciones que retornan un stream
-abstract class StreamUseCase<Type, Params> {
-  Stream<Either<Failure, Type>> call(Params params);
+abstract class StreamUseCase<T, Params> {
+  Stream<Either<Failure, T>> call(Params params);
 }
 
 /// Caso de uso base abstracto para operaciones sin parámetros
-abstract class NoParamsUseCase<Type> {
-  Future<Either<Failure, Type>> call();
+abstract class NoParamsUseCase<T> {
+  Future<Either<Failure, T>> call();
 }
 
 /// Parámetros vacíos para casos de uso que no necesitan parámetros


### PR DESCRIPTION
## Summary

- Renames the `Type` generic type parameter to `T` in all three abstract base classes in `lib/core/usecases/usecase.dart`: `UseCase`, `StreamUseCase`, and `NoParamsUseCase`.
- `Type` is a Dart built-in identifier (`dart:core`); using it as a generic parameter name shadows the built-in and triggers `avoid_types_as_parameter_names` analyzer infos on lines 5, 10, and 15.
- All call-sites (`implements UseCase<ConcreteType, Params>`) are unaffected — the rename is purely internal to the type parameter declaration.

## Analyze before / after

| State | Issues |
|-------|--------|
| Before | 3 infos (`avoid_types_as_parameter_names` × 3) |
| After  | **0 issues** |

## Test plan

- [x] `flutter analyze` → `No issues found!`
- [x] `dart format --set-exit-if-changed --output=none lib/core/usecases/usecase.dart` → 0 changes
- [x] All `UseCase<…>` call-sites verified via `rg "UseCase<" lib/` — no changes needed