### PR TITLE
ci(mobile): re-add build-android job with GH Actions secret

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,10 +63,51 @@ jobs:
       - name: Run unit tests
         run: flutter test --no-pub
 
-  # Build Android (APK) job intentionally omitted. Release APKs are produced
-  # via fastlane / manual dev pipeline, not from CI. The release flavor wires
-  # in google-services.json, which is gitignored as a Firebase secret. Adding
-  # the build to CI requires either a GitHub Actions secret with the file
-  # base64-encoded + decoded at workflow time, or a CI-only build flavor
-  # without the google-services plugin. Until that is set up, analyze + test
-  # are the meaningful gates on PRs.
+  # ──────────────────────────────────────────────────────────────────────────
+  # JOB 3: Build Android (APK smoke gate)
+  # ──────────────────────────────────────────────────────────────────────────
+  # Requires repo secret GOOGLE_SERVICES_JSON_BASE64 (base64-encoded content
+  # of android/app/google-services.json). The job is skipped cleanly when the
+  # secret is absent so forks and PRs without secret access still pass CI.
+  #
+  # One-time setup (repo admin):
+  #   base64 -i android/app/google-services.json | pbcopy   # macOS
+  #   # Paste into Settings > Secrets > Actions > GOOGLE_SERVICES_JSON_BASE64
+  # ──────────────────────────────────────────────────────────────────────────
+  build-android:
+    name: Build Android APK
+    runs-on: ubuntu-latest
+    needs: [analyze, test]
+    # Secrets cannot be evaluated directly in `if:` expressions, so we map the
+    # secret to an env var first and compare against empty string here.
+    env:
+      GOOGLE_SERVICES_JSON_BASE64: ${{ secrets.GOOGLE_SERVICES_JSON_BASE64 }}
+    if: ${{ env.GOOGLE_SERVICES_JSON_BASE64 != '' }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: '3.41.6'
+          channel: stable
+          cache: true
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Decode google-services.json
+        env:
+          GOOGLE_SERVICES_JSON_BASE64: ${{ secrets.GOOGLE_SERVICES_JSON_BASE64 }}
+        run: echo "$GOOGLE_SERVICES_JSON_BASE64" | base64 -d > android/app/google-services.json
+
+      - name: Build APK (release)
+        run: flutter build apk --release


### PR DESCRIPTION
## Summary

- Restores the `build-android` APK smoke gate that was dropped in `f7466c0` because `android/app/google-services.json` is gitignored
- Job decodes a base64-encoded GitHub Actions secret to recreate the file at build time
- Skips cleanly (does not fail) when the secret is absent — forks and PRs without secret access still pass CI

## Manual Setup Required Before Merging

> **Do this BEFORE or right after merging, or the job will be skipped every run until the secret is added.**

### Step 1 — Encode the file (macOS)

```bash
base64 -i android/app/google-services.json | pbcopy
```

This copies the base64-encoded content to your clipboard.

### Step 2 — Add the GitHub Actions secret

Go to: **sacdia-app repo → Settings → Secrets and variables → Actions → New repository secret**

- Name: `GOOGLE_SERVICES_JSON_BASE64`
- Value: paste clipboard content

---

## Behavior Without the Secret

If the secret is not set:
- The `build-android` job is **skipped** (not failed) — CI stays green
- `analyze` and `test` jobs are unaffected and continue to gate PRs

Merging without the secret is safe; the APK smoke gate simply won't run until the secret is added.

---

## Notes

- Release signing still uses debug keys (`signingConfigs.debug`) — no keystore needed for this CI gate
- Java 17 (Temurin) added to the job since AGP 8.9.1 requires it
- Same Flutter 3.41.6 pin as existing jobs