### PR TITLE
feat(mobile): add UIBackgroundModes to iOS Info.plist for push + fetch

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -105,5 +105,12 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<!-- Background modes: remote-notification keeps FCM handler alive when app is suspended;
+	     fetch enables background refresh. Both required for terminated-state push delivery. -->
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>fetch</string>
+		<string>remote-notification</string>
+	</array>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary

- Adds `UIBackgroundModes` array to `ios/Runner/Info.plist` with `fetch` and `remote-notification` strings
- Without this key the OS terminates the process before the FCM background handler runs, breaking terminated-state push delivery on iOS
- This is **GAP 2 of 2** code-side gaps from the iOS push audit (engram: `sacdia/mobile/ios-push-setup-checklist`)

## Context

**GAP 1** (Runner.entitlements `aps-environment`) is auto-written by Xcode when the developer adds the **Push Notifications** capability in the Signing & Capabilities tab — no manual file edit needed.

**GAP 2** (this PR) is the `UIBackgroundModes` plist key, which Xcode does NOT add automatically when enabling Background Modes via the checkbox — it must be committed explicitly.

## Validation

- `plutil -lint ios/Runner/Info.plist` → **OK** (exit 0)
- `rg "UIBackgroundModes"` confirmed key did not exist before this change

## Manual Xcode steps still required (not in this PR)

1. Signing & Capabilities → **+ Push Notifications** (writes `aps-environment` to Runner.entitlements)
2. Signing & Capabilities → **+ Background Modes** → check **Remote notifications** + **Background fetch**

## Test plan

- [ ] Merge PR into `development`
- [ ] Confirm `plutil -lint ios/Runner/Info.plist` still passes after merge
- [ ] Developer completes Xcode capability steps above
- [ ] Smoke test: send FCM push while app is terminated on real iOS device — verify notification arrives