### PR TITLE
fix(mobile): remove double-hyphens from AndroidManifest.xml comment

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -54,7 +54,8 @@
                    https://sacdia-backend.onrender.com/.well-known/assetlinks.json
                  with the app's SHA-256 release certificate fingerprint before this filter
                  can be auto-verified by Android.
-                 Test with: adb shell pm get-app-links --user cur com.sacdia.app
+                 Test with: adb shell pm get-app-links -user cur com.sacdia.app
+                 (NOTE: real adb command uses two hyphens before user; XML comments cannot contain double-hyphens)
                  See: https://developer.android.com/training/app-links/verify-android-applinks -->
             <intent-filter android:autoVerify="true">
                 <action android:name="android.intent.action.VIEW" />


### PR DESCRIPTION
## Problem

AGP 8.9.1 tightened manifest merger XML validation, now strictly enforcing the XML 1.0 spec rule that `--` (double-hyphen) is **not allowed** inside XML comment text. The comment at line 57 of `android/app/src/main/AndroidManifest.xml` contained:

```
Test with: adb shell pm get-app-links --user cur com.sacdia.app
```

This caused the following `xmllint` parse error (and AGP build failure seen in PR #30 build APK log):

```
parser error : Double hyphen within comment: <!-- REQUIRED: Publish assetlinks.json at:
             Test with: adb shell pm get-app-links --user cur com.sacdia.app
                                                   ^
```

## Fix

Changed `--user` → `-user` in the comment text (documentation only — no runtime code affected), and added a parenthetical note explaining why:

```xml
Test with: adb shell pm get-app-links -user cur com.sacdia.app
(NOTE: real adb command uses two hyphens before user; XML comments cannot contain double-hyphens)
```

No XML tags, attributes, or actual manifest behavior were changed.

## Verification

```
$ xmllint --noout android/app/src/main/AndroidManifest.xml
$ echo $?
0
```

Exit code 0 — no errors.

## Instances fixed

1 occurrence (`--user` on line 57).