### PR TITLE
build(mobile): bump Kotlin 2.1.0 → 2.3.10 to fix transitive stdlib mismatch

### DIFF
--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -19,7 +19,7 @@ pluginManagement {
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
     id "com.android.application" version "8.9.1" apply false
-    id "org.jetbrains.kotlin.android" version "2.1.0" apply false
+    id "org.jetbrains.kotlin.android" version "2.3.10" apply false
     id "com.google.gms.google-services" version "4.4.2" apply false
 }
 


### PR DESCRIPTION
## Problem

CI build APK job failed on PR #29 (run `25333598975`) with:

```
Module was compiled with an incompatible version of Kotlin.
The binary version of its metadata is 2.3.0, expected version is 2.1.0.
e: .../jetified-kotlin-stdlib-2.3.10.jar!/META-INF/kotlin-stdlib.kotlin_module
Execution failed for task ':app:compileReleaseKotlin'.
```

A transitive Flutter plugin dependency pulls `kotlin-stdlib-2.3.10` at runtime, while the project's Kotlin Gradle plugin was pinned at `2.1.0`. The two versions are binary-incompatible, causing the compile step to abort.

## Fix

Bumped `org.jetbrains.kotlin.android` plugin from `2.1.0` → `2.3.10` in `android/settings.gradle` (the single source of truth — no `ext.kotlin_version` exists in root `build.gradle`, no `libs.versions.toml`).

## Compatibility

- **AGP 8.9.1** — fully supported with Kotlin 2.3.x (AGP 8.x tracks the Kotlin 2.x release line)
- **Gradle 8.11.1** — compatible with Kotlin 2.3.x
- No AGP or Gradle version changes in this PR (scope: Kotlin plugin only)

## Files changed

| File | Change |
|------|--------|
| `android/settings.gradle` | `"org.jetbrains.kotlin.android" version "2.1.0"` → `"2.3.10"` |