### PR TITLE
chore(mobile): update Podfile.lock for image_cropper TOCropViewController bump

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -135,7 +135,7 @@ PODS:
     - GoogleUtilities/Privacy
   - image_cropper (0.0.4):
     - Flutter
-    - TOCropViewController (~> 2.6.1)
+    - TOCropViewController (~> 2.7.4)
   - image_picker_ios (0.0.1):
     - Flutter
   - local_auth_darwin (0.0.1):
@@ -172,7 +172,7 @@ PODS:
     - Flutter
     - FlutterMacOS
   - SwiftyGif (5.4.5)
-  - TOCropViewController (2.6.1)
+  - TOCropViewController (2.7.4)
   - url_launcher_ios (0.0.1):
     - Flutter
 
@@ -299,7 +299,7 @@ SPEC CHECKSUMS:
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
   GoogleMaps: 8939898920281c649150e0af74aa291c60f2e77d
   GoogleUtilities: 00c88b9a86066ef77f0da2fab05f65d7768ed8e1
-  image_cropper: 655b3ba703c9e15e3111e79151624d6154288774
+  image_cropper: c4326ea50132b1e1564499e5d32a84f01fb03537
   image_picker_ios: e0ece4aa2a75771a7de3fa735d26d90817041326
   local_auth_darwin: c3ee6cce0a8d56be34c8ccb66ba31f7f180aaebb
   mobile_scanner: 9157936403f5a0644ca3779a38ff8404c5434a93
@@ -314,7 +314,7 @@ SPEC CHECKSUMS:
   shared_preferences_foundation: 7036424c3d8ec98dfe75ff1667cb0cd531ec82bb
   sqflite_darwin: 20b2a3a3b70e43edae938624ce550a3cbf66a3d0
   SwiftyGif: 706c60cf65fa2bc5ee0313beece843c8eb8194d4
-  TOCropViewController: edfd4f25713d56905ad1e0b9f5be3fbe0f59c863
+  TOCropViewController: 80b8985ad794298fb69d3341de183f33d1853654
   url_launcher_ios: 7a95fa5b60cc718a708b8f2966718e93db0cef1b
 
 PODFILE CHECKSUM: 1959d098c91d8a792531a723c4a9d7e9f6a01e38


### PR DESCRIPTION
## Summary
- `image_cropper` Dart package was bumped (PR #25/#26 cycle) and its new iOS pod requires `TOCropViewController ~> 2.7.4`
- Stale `Podfile.lock` still pinned `2.6.1`, causing `pod install` to fail on `flutter run` for iOS simulators
- Fixed via `pod update TOCropViewController` — no `Podfile`, no `pubspec.yaml` modified

## Test plan
- [ ] Confirm `ios/Podfile.lock` now contains `TOCropViewController (2.7.4)`
- [ ] `flutter run` on iOS simulator passes pod install step without conflict errors
- [ ] `flutter pub get` exits clean