### PR TITLE
fix(mobile): keep post-registration completion status provider alive

### DIFF
--- a/lib/features/post_registration/presentation/providers/post_registration_providers.dart
+++ b/lib/features/post_registration/presentation/providers/post_registration_providers.dart
@@ -35,6 +35,7 @@ class CompletionStatusNotifier
     extends AutoDisposeAsyncNotifier<CompletionStatus?> {
   @override
   Future<CompletionStatus?> build() async {
+    ref.keepAlive();
     final cancelToken = CancelToken();
     ref.onDispose(() => cancelToken.cancel());
     final result = await ref


### PR DESCRIPTION
## Summary
- `CompletionStatusNotifier.build()` now calls `ref.keepAlive()` so the AutoDisposeAsyncNotifier survives router-driven rebuilds while the initial `GET /auth/profile/completion-status` request is in flight.

## Root cause
`completionStatusProvider` is `AsyncNotifierProvider.autoDispose`. The `routerProvider` listens to `authNotifierProvider` and `appBootstrapProvider`, both of which call `router.refresh()` shortly after a successful register. The refresh re-evaluates redirects and rebuilds `PostRegistrationShell`, which disposes the provider mid-flight. The `onDispose` callback cancels the `CancelToken`, so `ref.read(completionStatusProvider.future)` from `_loadCompletionStatus` never resolves. `_statusLoaded` stays `false` and the screen stays on `CircularProgressIndicator` forever.

`ref.keepAlive()` keeps the provider alive past the rebuild so the request can complete and `_loadCompletionStatus` returns normally.

## Test plan
- [x] Register a new user, verify the post-registration screen loads (no infinite spinner).
- [x] Hot restart after the fix; verify navigation `/register → /post-registration` continues into the wizard step.
- [ ] Optional: re-register and check logs no longer show `cancel GET /api/v1/auth/profile/completion-status` from `ProviderElementBase.dispose`.