### PR TITLE
feat(classes): redesign Mis Clases + Roadmap, gate Mi Ranking

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -1310,7 +1310,16 @@
       "empty": "You have no assigned classes",
       "title": "My Classes",
       "enroll_tooltip": "Enroll previous class",
-      "error_loading": "Error loading classes"
+      "error_loading": "Error loading classes",
+      "roadmap_chip_title": "View my full journey",
+      "roadmap_chip_subtitle": "See your career progress",
+      "section_current": "Current class",
+      "section_others": "Other classes",
+      "enroll_cta": "Enroll in another class",
+      "enroll_cta_short": "Enroll"
+    },
+    "roadmap": {
+      "track_current_pill": "Current"
     },
     "status_history": {
       "title": "Status history",
@@ -3032,6 +3041,7 @@
     "inactive_message": "This credential is not active.",
     "load_error": "Could not load the credential",
     "photo_alt": "Profile photo of {name}",
+    "view_photo": "View photo",
     "qr_alt": "Credential QR code",
     "club_label": "Club",
     "section_label": "Section",

--- a/assets/translations/es.json
+++ b/assets/translations/es.json
@@ -1310,7 +1310,16 @@
       "empty": "No tienes clases asignadas",
       "title": "Mis Clases",
       "enroll_tooltip": "Inscribir clase anterior",
-      "error_loading": "Error al cargar clases"
+      "error_loading": "Error al cargar clases",
+      "roadmap_chip_title": "Ver mi camino completo",
+      "roadmap_chip_subtitle": "Conocé el progreso de tu carrera",
+      "section_current": "Clase actual",
+      "section_others": "Otras clases",
+      "enroll_cta": "Inscribirme a otra clase",
+      "enroll_cta_short": "Inscribirme"
+    },
+    "roadmap": {
+      "track_current_pill": "Cursando"
     },
     "status_history": {
       "title": "Historial de estados",
@@ -3032,6 +3041,7 @@
     "inactive_message": "Esta credencial no está activa. Comunicate con tu director.",
     "load_error": "No se pudo cargar la credencial",
     "photo_alt": "Foto de perfil de {name}",
+    "view_photo": "Ver foto",
     "qr_alt": "Código QR de la credencial",
     "club_label": "Club",
     "section_label": "Sección",

--- a/assets/translations/fr.json
+++ b/assets/translations/fr.json
@@ -1310,7 +1310,16 @@
       "empty": "Vous n'avez pas de classes assignées",
       "title": "Mes classes",
       "enroll_tooltip": "Inscrire une classe antérieure",
-      "error_loading": "Erreur lors du chargement des classes"
+      "error_loading": "Erreur lors du chargement des classes",
+      "roadmap_chip_title": "Voir mon parcours complet",
+      "roadmap_chip_subtitle": "Voir la progression de votre carrière",
+      "section_current": "Classe actuelle",
+      "section_others": "Autres classes",
+      "enroll_cta": "M'inscrire à une autre classe",
+      "enroll_cta_short": "S'inscrire"
+    },
+    "roadmap": {
+      "track_current_pill": "En cours"
     },
     "status_history": {
       "title": "Historique des statuts",
@@ -3032,6 +3041,7 @@
     "inactive_message": "Cette carte n’est pas active. Contactez votre directeur.",
     "load_error": "Impossible de charger la carte",
     "photo_alt": "Photo de profil de {name}",
+    "view_photo": "Voir la photo",
     "qr_alt": "Code QR de la carte",
     "club_label": "Club",
     "section_label": "Section",

--- a/assets/translations/pt-BR.json
+++ b/assets/translations/pt-BR.json
@@ -1310,7 +1310,16 @@
       "empty": "Você não tem classes atribuídas",
       "title": "Minhas Classes",
       "enroll_tooltip": "Inscrever classe anterior",
-      "error_loading": "Erro ao carregar classes"
+      "error_loading": "Erro ao carregar classes",
+      "roadmap_chip_title": "Ver meu caminho completo",
+      "roadmap_chip_subtitle": "Veja o progresso da sua carreira",
+      "section_current": "Classe atual",
+      "section_others": "Outras classes",
+      "enroll_cta": "Inscrever-me em outra classe",
+      "enroll_cta_short": "Inscrever-me"
+    },
+    "roadmap": {
+      "track_current_pill": "Em curso"
     },
     "status_history": {
       "title": "Histórico de status",
@@ -3032,6 +3041,7 @@
     "inactive_message": "Esta credencial não está ativa. Fale com o seu diretor.",
     "load_error": "Não foi possível carregar a credencial",
     "photo_alt": "Foto de perfil de {name}",
+    "view_photo": "Ver foto",
     "qr_alt": "Código QR da credencial",
     "club_label": "Clube",
     "section_label": "Seção",

--- a/lib/core/config/route_names.dart
+++ b/lib/core/config/route_names.dart
@@ -23,6 +23,9 @@ class RouteNames {
   static const String homeActivities = '/home/activities';
   static const String homeProfile = '/home/profile';
 
+  // Roadmap de clases (pantalla completa dentro del branch de Clases)
+  static const String homeClassesRoadmap = '/home/classes/roadmap';
+
   // Módulos de acceso rápido (dentro del shell)
   static const String homeMembers = '/home/members';
   static const String homeClub = '/home/club';

--- a/lib/core/config/router.dart
+++ b/lib/core/config/router.dart
@@ -72,6 +72,7 @@ import '../../features/dashboard/presentation/views/dashboard_view.dart';
 import '../../features/classes/presentation/providers/classes_providers.dart';
 import '../../features/classes/presentation/views/classes_tabs_view.dart';
 import '../../features/classes/presentation/views/class_detail_with_progress_view.dart';
+import '../../features/classes/presentation/views/roadmap_full_screen_view.dart';
 import '../../features/members/presentation/views/members_view.dart';
 import '../../features/profile/presentation/views/profile_view.dart';
 import '../../features/profile/presentation/views/medical_info_view.dart';
@@ -301,6 +302,18 @@ final routerProvider = Provider<GoRouter>((ref) {
                 path: RouteNames.homeClasses,
                 pageBuilder: (context, state) =>
                     _fadeThroughBuild(context, state, const ClassesTabsView()),
+                routes: [
+                  // Roadmap como pantalla completa con AppBar y botón back.
+                  // Accesible via context.push(RouteNames.homeClassesRoadmap).
+                  GoRoute(
+                    path: 'roadmap',
+                    pageBuilder: (context, state) => _sharedAxisBuild(
+                      context,
+                      state,
+                      const RoadmapFullScreenView(),
+                    ),
+                  ),
+                ],
               ),
             ],
           ),

--- a/lib/core/theme/app_colors.dart
+++ b/lib/core/theme/app_colors.dart
@@ -139,6 +139,54 @@ class AppColors {
   static const Color info = Color(0xFF2EA0DA);
 
   // ═══════════════════════════════════════════════════════════
+  // AVANCES DE CLASE — Design tokens (handoff §3.1)
+  // ═══════════════════════════════════════════════════════════
+
+  // Brand coral (alias + extended scale)
+  static const Color coral50  = Color(0xFFFFF1EE);
+  static const Color coral100 = Color(0xFFFFE3DD);
+  static const Color coral200 = Color(0xFFFFC9BE);
+  static const Color coral500 = Color(0xFFEF6B5C); // primary (same hue as AppColors.primary)
+  static const Color coral600 = Color(0xFFDD5A4B);
+  static const Color coral700 = Color(0xFFB8453A);
+
+  // Requisito status — color / bg / dark variants
+  static const Color validatedColor = Color(0xFF4FB37C);
+  static const Color validatedBg    = Color(0xFFE8F5EE);
+  static const Color validatedDark  = Color(0xFF2E7A52);
+
+  static const Color sentColor      = Color(0xFF5A7FA8);
+  static const Color sentBg         = Color(0xFFEAF1F8);
+  static const Color sentDark       = Color(0xFF3D6391);
+
+  static const Color observedColor  = Color(0xFFC99036);
+  static const Color observedBg     = Color(0xFFFCF1DC);
+  static const Color observedDark   = Color(0xFF8B6422);
+
+  static const Color rejectedColor  = Color(0xFFD14B66);
+  static const Color rejectedBg     = Color(0xFFFDE9EE);
+  static const Color rejectedDark   = Color(0xFFA23147);
+
+  static const Color pendingColor   = Color(0xFF9AA0AB);
+  static const Color pendingBg      = Color(0xFFF2F4F7);
+  static const Color pendingDark    = Color(0xFF6B7280);
+
+  // Neutrals warm low-saturation ink scale
+  static const Color ink900 = Color(0xFF131316);
+  static const Color ink800 = Color(0xFF20232A);
+  static const Color ink700 = Color(0xFF2C313B);
+  static const Color ink600 = Color(0xFF4B5260);
+  static const Color ink500 = Color(0xFF6B7280);
+  static const Color ink400 = Color(0xFF9AA0AB);
+  static const Color ink300 = Color(0xFFC7CBD2);
+  static const Color ink200 = Color(0xFFE3E5EA);
+  static const Color ink150 = Color(0xFFECEEF2);
+  static const Color ink100 = Color(0xFFF2F4F7);
+  static const Color ink50  = Color(0xFFF7F8FA);
+  static const Color paper  = Color(0xFFFFFFFF);
+  static const Color canvas = Color(0xFFFAFAFB);
+
+  // ═══════════════════════════════════════════════════════════
   // STATUS BADGE — "enviado/sent" — dark-mode aware
   // ═══════════════════════════════════════════════════════════
 

--- a/lib/features/classes/data/models/class_requirement_model.dart
+++ b/lib/features/classes/data/models/class_requirement_model.dart
@@ -17,6 +17,12 @@ class ClassRequirementModel extends ClassRequirement {
     super.submittedAt,
     super.validatedByName,
     super.validatedAt,
+    super.observedByName,
+    super.observedAt,
+    super.observationComment,
+    super.rejectedByName,
+    super.rejectedAt,
+    super.rejectionReason,
     super.earnedPoints,
     super.linkedHonorId,
     super.linkedHonorName,
@@ -52,6 +58,20 @@ class ClassRequirementModel extends ClassRequirement {
           (json['validated_by_name'] ?? json['validatedByName'])?.toString(),
       validatedAt: _parseDate(
           json['validated_at']?.toString() ?? json['validatedAt']?.toString()),
+      observedByName:
+          (json['observed_by_name'] ?? json['observedByName'])?.toString(),
+      observedAt: _parseDate(
+          json['observed_at']?.toString() ?? json['observedAt']?.toString()),
+      observationComment:
+          (json['observation_comment'] ?? json['observationComment'] ??
+              json['observation'])
+              ?.toString(),
+      rejectedByName:
+          (json['rejected_by_name'] ?? json['rejectedByName'])?.toString(),
+      rejectedAt: _parseDate(
+          json['rejected_at']?.toString() ?? json['rejectedAt']?.toString()),
+      rejectionReason:
+          (json['rejection_reason'] ?? json['rejectionReason'])?.toString(),
       earnedPoints:
           _parseInt(json['earned_points'] ?? json['earnedPoints'] ?? 0),
       linkedHonorId: json['honor_id'] != null
@@ -92,6 +112,12 @@ class ClassRequirementModel extends ClassRequirement {
         submittedAt: submittedAt,
         validatedByName: validatedByName,
         validatedAt: validatedAt,
+        observedByName: observedByName,
+        observedAt: observedAt,
+        observationComment: observationComment,
+        rejectedByName: rejectedByName,
+        rejectedAt: rejectedAt,
+        rejectionReason: rejectionReason,
         earnedPoints: earnedPoints,
         linkedHonorId: linkedHonorId,
         linkedHonorName: linkedHonorName,

--- a/lib/features/classes/domain/entities/class_requirement.dart
+++ b/lib/features/classes/domain/entities/class_requirement.dart
@@ -15,6 +15,9 @@ enum RequirementStatus {
 
   /// El lider rechazo el requerimiento; el miembro puede reenviar.
   rechazado,
+
+  /// El lider solicito correcciones (observado) antes de validar.
+  observado,
 }
 
 /// Parsea el string que llega desde la API al enum correspondiente.
@@ -30,6 +33,9 @@ RequirementStatus requirementStatusFromString(String? value) {
     case 'RECHAZADO':
     case 'REJECTED':
       return RequirementStatus.rechazado;
+    case 'OBSERVADO':
+    case 'OBSERVED':
+      return RequirementStatus.observado;
     default:
       return RequirementStatus.pendiente;
   }
@@ -44,6 +50,8 @@ String requirementStatusToString(RequirementStatus status) {
       return 'validado';
     case RequirementStatus.rechazado:
       return 'REJECTED';
+    case RequirementStatus.observado:
+      return 'OBSERVED';
     case RequirementStatus.pendiente:
       return 'pendiente';
   }
@@ -102,6 +110,24 @@ class ClassRequirement extends Equatable {
   final String? validatedByName;
   final DateTime? validatedAt;
 
+  /// Nombre del instructor que observo el requerimiento.
+  final String? observedByName;
+
+  /// Fecha en que fue observado.
+  final DateTime? observedAt;
+
+  /// Comentario del instructor al observar.
+  final String? observationComment;
+
+  /// Nombre del instructor que rechazo el requerimiento.
+  final String? rejectedByName;
+
+  /// Fecha en que fue rechazado.
+  final DateTime? rejectedAt;
+
+  /// Razon del rechazo.
+  final String? rejectionReason;
+
   /// Puntos efectivamente ganados en este requerimiento (0 hasta validacion).
   final int earnedPoints;
 
@@ -128,6 +154,12 @@ class ClassRequirement extends Equatable {
     this.submittedAt,
     this.validatedByName,
     this.validatedAt,
+    this.observedByName,
+    this.observedAt,
+    this.observationComment,
+    this.rejectedByName,
+    this.rejectedAt,
+    this.rejectionReason,
     this.earnedPoints = 0,
     this.linkedHonorId,
     this.linkedHonorName,
@@ -139,15 +171,17 @@ class ClassRequirement extends Equatable {
   /// Slots de archivos restantes.
   int get remainingSlots => (maxFiles - files.length).clamp(0, maxFiles);
 
-  /// El miembro puede subir o eliminar archivos cuando esta pendiente o rechazado.
+  /// El miembro puede subir o eliminar archivos cuando esta pendiente, rechazado u observado.
   bool get canUpload =>
       status == RequirementStatus.pendiente ||
-      status == RequirementStatus.rechazado;
+      status == RequirementStatus.rechazado ||
+      status == RequirementStatus.observado;
 
-  /// El miembro puede enviar a validacion cuando tiene archivos y esta pendiente o rechazado.
+  /// El miembro puede enviar a validacion cuando tiene archivos y esta pendiente, rechazado u observado.
   bool get canSubmit =>
       (status == RequirementStatus.pendiente ||
-          status == RequirementStatus.rechazado) &&
+          status == RequirementStatus.rechazado ||
+          status == RequirementStatus.observado) &&
       files.isNotEmpty;
 
   @override
@@ -165,6 +199,12 @@ class ClassRequirement extends Equatable {
         submittedAt,
         validatedByName,
         validatedAt,
+        observedByName,
+        observedAt,
+        observationComment,
+        rejectedByName,
+        rejectedAt,
+        rejectionReason,
         earnedPoints,
         linkedHonorId,
         linkedHonorName,

--- a/lib/features/classes/presentation/roadmap/theme/roadmap_tokens.dart
+++ b/lib/features/classes/presentation/roadmap/theme/roadmap_tokens.dart
@@ -44,9 +44,41 @@ class RoadmapTokens {
   static const double frameWidth = 402; // ancho de referencia (iPhone)
 
   // Path serpenteante
-  static const double pathHeight = 160;
+  //
+  // Derivación geométrica del slot del conector
+  // ─────────────────────────────────────────────
+  // Distancia vertical entre shield-bottom del nodo anterior y
+  // shield-top del nodo actual (en coordenadas del Stack del nodo actual,
+  // donde y=0 es el top del escudo current):
+  //
+  //   gapBetweenShields = SizedBox(h:12) + label(≈38) + nodeRowGap(22) = 72
+  //
+  // Queremos que la curva se solape 8 px DENTRO de cada escudo:
+  //   shieldOverlap = 8
+  //
+  // Por tanto:
+  //   pathHeight = gapBetweenShields + 2 * shieldOverlap = 72 + 16 = 88
+  //
+  // El Positioned.top en el Stack del nodo actual debe colocar el borde
+  // superior del slot exactamente en (shield-bottom prev) + shieldOverlap:
+  //   top = -(gapBetweenShields + shieldOverlap) = -(72 + 8) = -80
+  //
+  // connectorVerticalInset se mantiene en 4 px como ajuste fino;
+  // el slot ya cubre el overlap, el inset sólo suaviza los endpoints.
+  static const double pathHeight = 88;
   static const double pathStrokeWidth = 6;
   static const double pathOpacity = 0.6;
+
+  // Offset del Positioned del conector dentro del Stack del nodo actual.
+  // Derivado: -(gapBetweenShields=72 + shieldOverlap=8) = -80.
+  static const double connectorSlotTopOffset = -80;
+
+  // Inset fino para que los endpoints de la curva no queden en el pixel
+  // exacto del borde del slot (valor pequeño, no compensa falta de anchor).
+  static const double connectorVerticalInset = 4.0;
+
+  // Ancho del ring estático que identifica la clase actual (tarea 2b).
+  static const double currentRingStrokeWidth = 2.5;
 
   // Sombras
   static List<BoxShadow> shieldShadow = [

--- a/lib/features/classes/presentation/roadmap/widgets/roadmap_screen.dart
+++ b/lib/features/classes/presentation/roadmap/widgets/roadmap_screen.dart
@@ -15,7 +15,7 @@ import 'theme_sprites.dart';
 ///
 /// Para usar con datos reales, ver [RoadmapScreenConnected] que envuelve este
 /// widget con los estados loading / error / data de [roadmapTracksProvider].
-class RoadmapScreen extends StatelessWidget {
+class RoadmapScreen extends StatefulWidget {
   final List<TrackData> tracks;
   final void Function(ClassItem)? onClassTap;
 
@@ -26,7 +26,77 @@ class RoadmapScreen extends StatelessWidget {
   });
 
   @override
+  State<RoadmapScreen> createState() => _RoadmapScreenState();
+}
+
+class _RoadmapScreenState extends State<RoadmapScreen> {
+  final _scrollController = ScrollController();
+
+  // GlobalKey que se asigna al nodo con ClassStatus.current.
+  // Se usa para Scrollable.ensureVisible en el primer frame.
+  final _currentNodeKey = GlobalKey();
+
+  @override
+  void initState() {
+    super.initState();
+    // Double-postFrame: el primer callback garantiza que el árbol esté
+    // montado; el segundo garantiza que el layout de todos los hijos
+    // (incluido el nodo actual, que puede estar debajo del fold) se
+    // haya completado antes de llamar a ensureVisible.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      WidgetsBinding.instance.addPostFrameCallback((_) => _scrollToCurrentNode());
+    });
+  }
+
+  void _scrollToCurrentNode() {
+    if (!mounted) return;
+
+    final ctx = _currentNodeKey.currentContext;
+    if (ctx == null) return; // No hay clase actual o el widget no está en el árbol.
+
+    // Verificar que el RenderObject esté realmente laid out antes de llamar
+    // ensureVisible. Si todavía está en NEEDS-LAYOUT la llamada lanzaría
+    // una assertion en debug y un no-op silencioso en release.
+    final ro = ctx.findRenderObject();
+    if (ro == null || !ro.attached) return;
+    if (ro is RenderBox && !ro.hasSize) return;
+
+    try {
+      Scrollable.ensureVisible(
+        ctx,
+        duration: const Duration(milliseconds: 600),
+        curve: Curves.easeInOut,
+        alignment: 0.3, // 30 % desde el tope visible — deja espacio arriba.
+      );
+    } catch (e, st) {
+      // No crashear si el Scrollable todavía no está listo (e.g., hot-reload
+      // parcial o reparenteo durante animación de entrada).
+      debugPrint('[RoadmapScreen] ensureVisible failed: $e\n$st');
+    }
+  }
+
+  @override
+  void dispose() {
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
+    // Determinar el id canónico de la clase actual: el PRIMERO que tenga
+    // ClassStatus.current recorriendo todos los tracks en orden.
+    // Esto garantiza que _currentNodeKey se asigne a UN SOLO VANode aunque
+    // el backend devuelva múltiples clases con status == current (e.g. el
+    // usuario inscripto en "Guía" y "Guía Mayor" a la vez).
+    final String? currentClassId = () {
+      for (final t in widget.tracks) {
+        for (final c in t.classes) {
+          if (c.status == ClassStatus.current) return c.id;
+        }
+      }
+      return null;
+    }();
+
     // Stack con gradiente de fondo (mañana → tarde → noche).
     // Se usa Container en lugar de Scaffold para evitar doble Scaffold
     // cuando RoadmapScreen vive dentro de ClassesTabsView.
@@ -54,12 +124,15 @@ class RoadmapScreen extends StatelessWidget {
             _LegendPills(),
             Expanded(
               child: SingleChildScrollView(
+                controller: _scrollController,
                 child: Column(
                   children: [
-                    for (final track in tracks)
+                    for (final track in widget.tracks)
                       _TrackSection(
                         track: track,
-                        onClassTap: onClassTap,
+                        onClassTap: widget.onClassTap,
+                        currentClassId: currentClassId,
+                        currentNodeKey: _currentNodeKey,
                       ),
                     const SizedBox(height: 60),
                   ],
@@ -138,7 +211,22 @@ class _TrackSection extends StatelessWidget {
   final TrackData track;
   final void Function(ClassItem)? onClassTap;
 
-  const _TrackSection({required this.track, this.onClassTap});
+  /// Id canónico de la clase actual (puede ser null si no hay ninguna).
+  /// Solo el nodo cuyo [ClassItem.id] coincida recibirá [currentNodeKey].
+  /// Esto garantiza que la key se asigne a COMO MÁXIMO UN widget en el árbol,
+  /// incluso cuando el backend devuelva múltiples clases con status == current.
+  final String? currentClassId;
+
+  /// Key para el auto-scroll. Nullable porque si [currentClassId] es null
+  /// no hay nodo destino y la key no se usa.
+  final GlobalKey? currentNodeKey;
+
+  const _TrackSection({
+    required this.track,
+    required this.currentClassId,
+    required this.currentNodeKey,
+    this.onClassTap,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -146,6 +234,10 @@ class _TrackSection extends StatelessWidget {
     final soft = RoadmapTokens.hex(track.soft);
     final done =
         track.classes.where((c) => c.status == ClassStatus.done).length;
+    // hasCurrent es true solo si este track contiene la clase canónica actual.
+    // Evita mostrar la pill "Cursando" en tracks secundarios con status current.
+    final hasCurrent = currentClassId != null &&
+        track.classes.any((c) => c.id == currentClassId);
 
     return Stack(
       children: [
@@ -165,12 +257,16 @@ class _TrackSection extends StatelessWidget {
               soft: soft,
               done: done,
               total: track.classes.length,
+              hasCurrent: hasCurrent,
             ),
             for (int i = 0; i < track.classes.length; i++)
               _NodeWithConnector(
                 index: i,
                 cls: track.classes[i],
                 accent: accent,
+                currentNodeKey: track.classes[i].id == currentClassId
+                    ? currentNodeKey
+                    : null,
                 onTap: onClassTap == null
                     ? null
                     : () => onClassTap!(track.classes[i]),
@@ -188,10 +284,14 @@ class _NodeWithConnector extends StatelessWidget {
   final Color accent;
   final VoidCallback? onTap;
 
+  /// Si no es null, se asigna como [key] al [VANode] para auto-scroll.
+  final GlobalKey? currentNodeKey;
+
   const _NodeWithConnector({
     required this.index,
     required this.cls,
     required this.accent,
+    this.currentNodeKey,
     this.onTap,
   });
 
@@ -205,6 +305,7 @@ class _NodeWithConnector extends StatelessWidget {
         if (index > 0)
           VAPathConnector(side: side, prevSide: prevSide, accentColor: accent),
         VANode(
+          key: currentNodeKey,
           item: cls,
           side: side,
           accentColor: accent,

--- a/lib/features/classes/presentation/roadmap/widgets/va_node.dart
+++ b/lib/features/classes/presentation/roadmap/widgets/va_node.dart
@@ -85,6 +85,25 @@ class _VANodeState extends State<VANode> with SingleTickerProviderStateMixin {
                           ),
                         ),
                       ),
+                    // Ring estático sobre el escudo cuando es la clase actual.
+                    // Coexiste con el halo pulsante: halo = glow suave,
+                    // ring = borde duro que señala sin animación.
+                    if (isCurrent)
+                      Container(
+                        width: RoadmapTokens.nodeShieldSize +
+                            RoadmapTokens.currentRingStrokeWidth * 2 +
+                            4,
+                        height: RoadmapTokens.nodeShieldSize +
+                            RoadmapTokens.currentRingStrokeWidth * 2 +
+                            4,
+                        decoration: BoxDecoration(
+                          shape: BoxShape.circle,
+                          border: Border.all(
+                            color: widget.accentColor,
+                            width: RoadmapTokens.currentRingStrokeWidth,
+                          ),
+                        ),
+                      ),
                     SizedBox(
                       width: RoadmapTokens.nodeShieldSize,
                       height: RoadmapTokens.nodeShieldSize,

--- a/lib/features/classes/presentation/roadmap/widgets/va_path_connector.dart
+++ b/lib/features/classes/presentation/roadmap/widgets/va_path_connector.dart
@@ -20,7 +20,7 @@ class VAPathConnector extends StatelessWidget {
     return Positioned(
       left: 0,
       right: 0,
-      top: -(RoadmapTokens.pathHeight + 80),
+      top: RoadmapTokens.connectorSlotTopOffset,
       height: RoadmapTokens.pathHeight,
       child: IgnorePointer(
         child: CustomPaint(
@@ -45,11 +45,34 @@ class _SerpentinePainter extends CustomPainter {
 
   @override
   void paint(Canvas canvas, Size size) {
-    // Coords basadas en frame de 402px; escalar al ancho real.
+    // ── X anchor derivation (frame 402 px) ──────────────────────────────────
+    // Layout: each node row has Padding(left: nodePadInside|nodePadOutside,
+    //         right: nodePadOutside|nodePadInside) + Align(centerLeft/Right)
+    //         containing a SizedBox(width: 148).
+    //
+    // Left node center X:
+    //   paddingLeft(24) + nodeWidth(148)/2 = 24 + 74 = 98
+    //
+    // Right node center X:
+    //   frameWidth(402) - paddingRight(24) - nodeWidth(148)/2
+    //   = 402 - 24 - 74 = 304
+    //
+    // (Previous code had 314 for the right side — 10 px off.)
+    // ────────────────────────────────────────────────────────────────────────
     final double scale = size.width / RoadmapTokens.frameWidth;
-    final double startX = (prevSide == 'left' ? 98.0 : 314.0) * scale;
-    final double endX = (side == 'left' ? 98.0 : 314.0) * scale;
+    const double leftNodeCenterX = 98.0; // derived above
+    const double rightNodeCenterX = 304.0; // derived above (was 314, corrected)
+
+    final double startX =
+        (prevSide == 'left' ? leftNodeCenterX : rightNodeCenterX) * scale;
+    final double endX =
+        (side == 'left' ? leftNodeCenterX : rightNodeCenterX) * scale;
     final bool goingRight = startX < endX;
+
+    // Vertical inset: curve starts/ends slightly inside the connector slot
+    // rather than at the raw y=0 / y=H edge, so it visually tucks under the
+    // shield bottom and emerges from the shield top of the next node.
+    final double inset = RoadmapTokens.connectorVerticalInset;
     final double H = size.height;
 
     // Curva tipo S: control 1 hacia atrás, control 2 hacia adelante.
@@ -57,11 +80,11 @@ class _SerpentinePainter extends CustomPainter {
     final double c2x = goingRight ? endX + 60 * scale : endX - 60 * scale;
 
     final Path path = Path()
-      ..moveTo(startX, 0)
-      ..cubicTo(c1x, H * 0.45, c2x, H * 0.55, endX, H);
+      ..moveTo(startX, inset)
+      ..cubicTo(c1x, H * 0.45, c2x, H * 0.55, endX, H - inset);
 
-    // Línea punteada: dash 2, gap 12 (en unidades del path)
-    final Path dashed = _dashPath(path, dashArray: [2, 12]);
+    // Línea punteada: dash 3, gap 8 (más densa que antes: [2,12])
+    final Path dashed = _dashPath(path, dashArray: [3, 8]);
 
     final paint = Paint()
       ..color = color.withValues(alpha: RoadmapTokens.pathOpacity)

--- a/lib/features/classes/presentation/roadmap/widgets/va_track_header.dart
+++ b/lib/features/classes/presentation/roadmap/widgets/va_track_header.dart
@@ -1,3 +1,4 @@
+import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import '../theme/roadmap_tokens.dart';
 
@@ -10,6 +11,9 @@ class VATrackHeader extends StatelessWidget {
   final int done;
   final int total;
 
+  /// Si `true`, muestra el pill "Cursando" junto al badge de progreso.
+  final bool hasCurrent;
+
   const VATrackHeader({
     super.key,
     required this.title,
@@ -18,6 +22,7 @@ class VATrackHeader extends StatelessWidget {
     required this.soft,
     required this.done,
     required this.total,
+    this.hasCurrent = false,
   });
 
   @override
@@ -75,6 +80,28 @@ class VATrackHeader extends StatelessWidget {
               ],
             ),
           ),
+          // Pill "Cursando" — visible solo cuando el track tiene la clase actual.
+          if (hasCurrent) ...[
+            Container(
+              padding:
+                  const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+              decoration: BoxDecoration(
+                color: RoadmapTokens.statusCurrent.withValues(alpha: 0.15),
+                borderRadius: BorderRadius.circular(999),
+                border: Border.all(
+                    color: RoadmapTokens.statusCurrent.withValues(alpha: 0.4)),
+              ),
+              child: Text(
+                'classes.roadmap.track_current_pill'.tr(),
+                style: const TextStyle(
+                  fontSize: 11,
+                  fontWeight: FontWeight.w700,
+                  color: RoadmapTokens.statusCurrent,
+                ),
+              ),
+            ),
+            const SizedBox(width: 6),
+          ],
           Container(
             padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 5),
             decoration: BoxDecoration(

--- a/lib/features/classes/presentation/utils/status_meta.dart
+++ b/lib/features/classes/presentation/utils/status_meta.dart
@@ -1,0 +1,73 @@
+import 'package:flutter/material.dart';
+
+import '../../../../core/theme/app_colors.dart';
+import '../../domain/entities/class_requirement.dart';
+
+/// Encapsula los tokens visuales (label, color, bg, dark) para cada
+/// [RequirementStatus].
+///
+/// Uso:
+/// ```dart
+/// final meta = StatusMeta.of(RequirementStatus.observado);
+/// Container(color: meta.bg, child: Text(meta.label, style: TextStyle(color: meta.dark)));
+/// ```
+class StatusMeta {
+  final String label;
+
+  /// Color base (dot, icon, borde).
+  final Color color;
+
+  /// Color de fondo suave.
+  final Color bg;
+
+  /// Color oscuro para texto sobre bg claro.
+  final Color dark;
+
+  const StatusMeta._({
+    required this.label,
+    required this.color,
+    required this.bg,
+    required this.dark,
+  });
+
+  /// Devuelve el [StatusMeta] correspondiente al [status] dado.
+  static StatusMeta of(RequirementStatus status) {
+    switch (status) {
+      case RequirementStatus.validado:
+        return const StatusMeta._(
+          label: 'Validado',
+          color: AppColors.validatedColor,
+          bg: AppColors.validatedBg,
+          dark: AppColors.validatedDark,
+        );
+      case RequirementStatus.enviado:
+        return const StatusMeta._(
+          label: 'Enviado',
+          color: AppColors.sentColor,
+          bg: AppColors.sentBg,
+          dark: AppColors.sentDark,
+        );
+      case RequirementStatus.observado:
+        return const StatusMeta._(
+          label: 'Observado',
+          color: AppColors.observedColor,
+          bg: AppColors.observedBg,
+          dark: AppColors.observedDark,
+        );
+      case RequirementStatus.rechazado:
+        return const StatusMeta._(
+          label: 'Rechazado',
+          color: AppColors.rejectedColor,
+          bg: AppColors.rejectedBg,
+          dark: AppColors.rejectedDark,
+        );
+      case RequirementStatus.pendiente:
+        return const StatusMeta._(
+          label: 'Pendiente',
+          color: AppColors.pendingColor,
+          bg: AppColors.pendingBg,
+          dark: AppColors.pendingDark,
+        );
+    }
+  }
+}

--- a/lib/features/classes/presentation/views/class_detail_with_progress_view.dart
+++ b/lib/features/classes/presentation/views/class_detail_with_progress_view.dart
@@ -1,30 +1,26 @@
+import 'dart:async';
+import 'dart:ui' as ui;
+
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:hugeicons/hugeicons.dart';
 
 import '../../../../core/animations/page_transitions.dart';
-import '../../../../core/animations/staggered_list_animation.dart';
 import '../../../../core/theme/app_colors.dart';
-import '../../../../core/theme/sac_colors.dart';
-import '../../../../core/widgets/sac_button.dart';
-import '../../../../core/widgets/sac_loading.dart';
-import '../../../../core/widgets/sac_progress_bar.dart';
 import '../../domain/entities/class_module_detail.dart';
 import '../../domain/entities/class_requirement.dart';
 import '../../domain/entities/class_with_progress.dart';
 import '../providers/classes_providers.dart';
-import '../widgets/requirement_card.dart';
+import '../widgets/module_expansion_tile.dart';
+import '../widgets/progress_ring.dart';
 import 'requirement_detail_view.dart';
-import '../../../validation/presentation/widgets/validation_section.dart';
-import '../../../validation/domain/entities/validation.dart';
 
-/// Vista de clase progresiva con progreso detallado.
+/// Vista de avances de clase — rediseño handoff (Variante B).
 ///
-/// Muestra el encabezado con progreso global, la lista de modulos
-/// con sus requerimientos, y permite navegar al detalle de cada requerimiento.
-///
-/// Sigue el patron identico al EvidenceFolderView de carpeta_evidencias.
+/// Layout top → bottom:
+///   NavBar · HeroCard · PillsRow · SearchBar · SectionLabel · ModulesList.
+/// Pull-to-refresh, skeleton loading, empty/error states.
 class ClassDetailWithProgressView extends ConsumerWidget {
   final int classId;
 
@@ -36,13 +32,12 @@ class ClassDetailWithProgressView extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final classAsync = ref.watch(classWithProgressProvider(classId));
-    final c = context.sac;
 
     return Scaffold(
-      backgroundColor: c.background,
+      backgroundColor: AppColors.canvas,
       body: SafeArea(
         child: classAsync.when(
-          loading: () => const Center(child: SacLoading()),
+          loading: () => const _SkeletonBody(),
           error: (error, _) => _ErrorBody(
             message: error.toString().replaceFirst('Exception: ', ''),
             onRetry: () => ref.invalidate(classWithProgressProvider(classId)),
@@ -50,7 +45,8 @@ class ClassDetailWithProgressView extends ConsumerWidget {
           data: (classWithProgress) => _ClassBody(
             classWithProgress: classWithProgress,
             classId: classId,
-            classColor: AppColors.classColor(classWithProgress.name),
+            onRefresh: () async =>
+                ref.invalidate(classWithProgressProvider(classId)),
           ),
         ),
       ),
@@ -58,17 +54,17 @@ class ClassDetailWithProgressView extends ConsumerWidget {
   }
 }
 
-// ── Body cuando hay datos ──────────────────────────────────────────────────────
+// ── Body con datos ─────────────────────────────────────────────────────────────
 
 class _ClassBody extends StatefulWidget {
   final ClassWithProgress classWithProgress;
   final int classId;
-  final Color classColor;
+  final Future<void> Function() onRefresh;
 
   const _ClassBody({
     required this.classWithProgress,
     required this.classId,
-    required this.classColor,
+    required this.onRefresh,
   });
 
   @override
@@ -77,544 +73,65 @@ class _ClassBody extends StatefulWidget {
 
 class _ClassBodyState extends State<_ClassBody> {
   final _searchController = TextEditingController();
+  final _searchFocusNode = FocusNode();
   String _query = '';
+  Timer? _debounce;
+  bool _searchFocused = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _searchFocusNode.addListener(() {
+      setState(() => _searchFocused = _searchFocusNode.hasFocus);
+    });
+  }
 
   @override
   void dispose() {
+    _debounce?.cancel();
     _searchController.dispose();
+    _searchFocusNode.dispose();
     super.dispose();
   }
 
-  /// Filtra los modulos y sus requerimientos segun el query de busqueda.
-  /// Un modulo se muestra si su nombre matchea o si algun requerimiento matchea.
-  /// Si solo matchean requerimientos, el modulo se muestra con esos requerimientos filtrados.
+  void _onSearchChanged(String value) {
+    _debounce?.cancel();
+    _debounce = Timer(const Duration(milliseconds: 200), () {
+      if (mounted) setState(() => _query = value);
+    });
+  }
+
+  /// Filtra módulos + requerimientos según la query.
+  /// Un módulo se incluye si su nombre coincide (con todos sus reqs)
+  /// o si tiene requerimientos cuyo nombre / descripción coincida.
   List<ClassModuleDetail> get _filteredModules {
     if (_query.isEmpty) return widget.classWithProgress.modules;
-
     final q = _query.toLowerCase();
     final result = <ClassModuleDetail>[];
-
     for (final module in widget.classWithProgress.modules) {
-      final moduleNameMatches = module.name.toLowerCase().contains(q);
-
-      final matchingRequirements = module.requirements
+      if (module.name.toLowerCase().contains(q)) {
+        result.add(module);
+        continue;
+      }
+      final matchingReqs = module.requirements
           .where((r) =>
               r.name.toLowerCase().contains(q) ||
               (r.description?.toLowerCase().contains(q) ?? false))
           .toList();
-
-      if (moduleNameMatches) {
-        result.add(module);
-      } else if (matchingRequirements.isNotEmpty) {
-        result.add(module.copyWithRequirements(matchingRequirements));
+      if (matchingReqs.isNotEmpty) {
+        result.add(module.copyWithRequirements(matchingReqs));
       }
     }
-
     return result;
   }
 
-  @override
-  Widget build(BuildContext context) {
-    final c = context.sac;
-    final filteredModules = _filteredModules;
-
-    return RefreshIndicator(
-      color: AppColors.primary,
-      onRefresh: () async {
-        // El consumer padre invalida al volver
-      },
-      child: CustomScrollView(
-        physics: const BouncingScrollPhysics(
-            parent: AlwaysScrollableScrollPhysics()),
-        slivers: [
-          // App bar
-          SliverAppBar(
-            pinned: true,
-            expandedHeight: 0,
-            backgroundColor: c.background,
-            surfaceTintColor: Colors.transparent,
-            title: Text(
-              widget.classWithProgress.name,
-              style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                    fontWeight: FontWeight.w700,
-                    color: c.text,
-                  ),
-              overflow: TextOverflow.ellipsis,
-            ),
-            centerTitle: false,
-          ),
-
-          SliverToBoxAdapter(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                const SizedBox(height: 8),
-
-                // Progress card — compact
-                _ProgressCard(classWithProgress: widget.classWithProgress),
-
-                const SizedBox(height: 12),
-
-                // Modulos header
-                Padding(
-                  padding: const EdgeInsets.fromLTRB(16, 8, 16, 4),
-                  child: Text(
-                    'classes.detail_with_progress.modules_header'.tr(),
-                    style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                          fontWeight: FontWeight.w700,
-                          color: c.text,
-                        ),
-                  ),
-                ),
-
-                // Search bar
-                Padding(
-                  padding: const EdgeInsets.fromLTRB(16, 4, 16, 8),
-                  child: TextField(
-                    controller: _searchController,
-                    onChanged: (value) => setState(() => _query = value),
-                    style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                          color: c.text,
-                        ),
-                    decoration: InputDecoration(
-                      hintText: 'classes.detail_with_progress.search_hint'.tr(),
-                      hintStyle: TextStyle(color: c.textTertiary),
-                      prefixIcon: HugeIcon(
-                        icon: HugeIcons.strokeRoundedSearch01,
-                        size: 20,
-                        color: c.textSecondary,
-                      ),
-                      suffixIcon: _query.isNotEmpty
-                          ? GestureDetector(
-                              onTap: () {
-                                _searchController.clear();
-                                setState(() => _query = '');
-                              },
-                              child: Icon(Icons.close_rounded,
-                                  size: 18, color: c.textSecondary),
-                            )
-                          : null,
-                      filled: true,
-                      fillColor: c.surfaceVariant,
-                      contentPadding: const EdgeInsets.symmetric(
-                          horizontal: 16, vertical: 10),
-                      border: OutlineInputBorder(
-                        borderRadius: BorderRadius.circular(12),
-                        borderSide: BorderSide.none,
-                      ),
-                      enabledBorder: OutlineInputBorder(
-                        borderRadius: BorderRadius.circular(12),
-                        borderSide: BorderSide.none,
-                      ),
-                      focusedBorder: OutlineInputBorder(
-                        borderRadius: BorderRadius.circular(12),
-                        borderSide:
-                            BorderSide(color: AppColors.primary, width: 1.5),
-                      ),
-                    ),
-                  ),
-                ),
-              ],
-            ),
-          ),
-
-          // Modulos con sus requerimientos
-          if (widget.classWithProgress.modules.isEmpty)
-            SliverToBoxAdapter(child: _EmptyModules())
-          else if (filteredModules.isEmpty)
-            SliverToBoxAdapter(
-              child: Padding(
-                padding:
-                    const EdgeInsets.symmetric(horizontal: 40, vertical: 32),
-                child: Column(
-                  children: [
-                    HugeIcon(
-                      icon: HugeIcons.strokeRoundedSearch01,
-                      size: 40,
-                      color: c.textTertiary,
-                    ),
-                    const SizedBox(height: 10),
-                    Text(
-                      'classes.detail_with_progress.no_results'
-                          .tr(namedArgs: {'query': _query}),
-                      style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                            color: c.textSecondary,
-                          ),
-                      textAlign: TextAlign.center,
-                    ),
-                  ],
-                ),
-              ),
-            )
-          else
-            SliverList(
-              delegate: SliverChildBuilderDelegate(
-                (context, index) {
-                  final module = filteredModules[index];
-                  return StaggeredListItem(
-                    index: index,
-                    child: _ModuleSection(
-                      module: module,
-                      classId: widget.classId,
-                      classColor: widget.classColor,
-                    ),
-                  );
-                },
-                childCount: filteredModules.length,
-              ),
-            ),
-
-          // Validation section
-          SliverToBoxAdapter(
-            child: Padding(
-              padding: const EdgeInsets.fromLTRB(16, 8, 16, 0),
-              child: ValidationSection(
-                entityType: ValidationEntityType.classProgress,
-                entityId: widget.classId,
-              ),
-            ),
-          ),
-
-          const SliverToBoxAdapter(child: SizedBox(height: 32)),
-        ],
-      ),
-    );
-  }
-}
-
-// ── Class identity section ─────────────────────────────────────────────────────
-
-// ── Progress card ──────────────────────────────────────────────────────────────
-
-class _ProgressCard extends StatelessWidget {
-  final ClassWithProgress classWithProgress;
-
-  const _ProgressCard({required this.classWithProgress});
-
-  @override
-  Widget build(BuildContext context) {
-    final c = context.sac;
-    final percentage = classWithProgress.completionPercent;
-    final total = classWithProgress.totalRequirements;
-    final validated = classWithProgress.completedRequirements;
-    final submitted = classWithProgress.submittedRequirements;
-    final pending = total - validated - submitted;
-
-    return Container(
-      margin: const EdgeInsets.symmetric(horizontal: 16),
-      padding: const EdgeInsets.fromLTRB(14, 16, 14, 14),
-      decoration: BoxDecoration(
-        color: c.surface,
-        borderRadius: BorderRadius.circular(14),
-        border: Border.all(color: c.border),
-        boxShadow: [
-          BoxShadow(
-            color: c.shadow,
-            blurRadius: 6,
-            offset: const Offset(0, 1),
-          ),
-        ],
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          // Progress bar + percentage inline
-          Row(
-            children: [
-              Expanded(
-                child: SacProgressBar(
-                  progress: classWithProgress.completionRatio,
-                  height: 6,
-                ),
-              ),
-              const SizedBox(width: 10),
-              Text(
-                '$percentage%',
-                style: Theme.of(context).textTheme.titleSmall?.copyWith(
-                      fontWeight: FontWeight.w800,
-                      color: c.text,
-                    ),
-              ),
-            ],
-          ),
-
-          const SizedBox(height: 10),
-
-          // Compact stats row
-          Row(
-            children: [
-              _CompactStat(
-                icon: HugeIcons.strokeRoundedCheckList,
-                color: AppColors.secondary,
-                value: '$validated/$total',
-                label: 'classes.detail_with_progress.stat_requirements'.tr(),
-                context: context,
-              ),
-              Container(
-                width: 1,
-                height: 14,
-                margin: const EdgeInsets.symmetric(horizontal: 10),
-                color: c.borderLight,
-              ),
-              _CompactStat(
-                icon: HugeIcons.strokeRoundedClock01,
-                color: AppColors.accent,
-                value: '$pending',
-                label: 'classes.detail_with_progress.stat_pending'.tr(),
-                context: context,
-              ),
-              Container(
-                width: 1,
-                height: 14,
-                margin: const EdgeInsets.symmetric(horizontal: 10),
-                color: c.borderLight,
-              ),
-              _CompactStat(
-                icon: HugeIcons.strokeRoundedSent,
-                color: AppColors.sacBlue,
-                value: '$submitted',
-                label: 'classes.detail_with_progress.stat_sent'.tr(),
-                context: context,
-              ),
-              Container(
-                width: 1,
-                height: 14,
-                margin: const EdgeInsets.symmetric(horizontal: 10),
-                color: c.borderLight,
-              ),
-              _CompactStat(
-                icon: HugeIcons.strokeRoundedCheckmarkCircle01,
-                color: AppColors.secondary,
-                value: '$validated',
-                label: 'classes.detail_with_progress.stat_validated'.tr(),
-                context: context,
-              ),
-            ],
-          ),
-        ],
-      ),
-    );
-  }
-}
-
-// ── Compact stat ──────────────────────────────────────────────────────────────
-
-class _CompactStat extends StatelessWidget {
-  final List<List<dynamic>> icon;
-  final Color color;
-  final String value;
-  final String label;
-  final BuildContext context;
-
-  const _CompactStat({
-    required this.icon,
-    required this.color,
-    required this.value,
-    required this.label,
-    required this.context,
-  });
-
-  @override
-  Widget build(BuildContext _) {
-    return Row(
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        HugeIcon(icon: icon, size: 12, color: color),
-        const SizedBox(width: 4),
-        Text(
-          '$value ',
-          style: Theme.of(context).textTheme.labelSmall?.copyWith(
-                fontWeight: FontWeight.w700,
-                color: context.sac.text,
-              ),
-        ),
-        Text(
-          label,
-          style: Theme.of(context).textTheme.labelSmall?.copyWith(
-                color: context.sac.textSecondary,
-              ),
-        ),
-      ],
-    );
-  }
-}
-
-// ── Seccion de modulo con requerimientos ────────────────────────────────────────
-
-class _ModuleSection extends StatefulWidget {
-  final ClassModuleDetail module;
-  final int classId;
-  final Color classColor;
-
-  const _ModuleSection({
-    required this.module,
-    required this.classId,
-    required this.classColor,
-  });
-
-  @override
-  State<_ModuleSection> createState() => _ModuleSectionState();
-}
-
-class _ModuleSectionState extends State<_ModuleSection> {
-  bool _expanded = true;
-
-  @override
-  Widget build(BuildContext context) {
-    final c = context.sac;
-    final isComplete =
-        widget.module.completedCount == widget.module.requirements.length &&
-            widget.module.requirements.isNotEmpty;
-
-    return Container(
-      margin: const EdgeInsets.fromLTRB(16, 8, 16, 4),
-      decoration: BoxDecoration(
-        color: c.surface,
-        borderRadius: BorderRadius.circular(16),
-        border: Border.all(color: c.border),
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          // Header del modulo
-          GestureDetector(
-            onTap: () => setState(() => _expanded = !_expanded),
-            child: Container(
-              padding: const EdgeInsets.fromLTRB(16, 14, 16, 14),
-              decoration: BoxDecoration(
-                color: isComplete ? AppColors.secondaryLight : c.surfaceVariant,
-                borderRadius: BorderRadius.circular(16),
-              ),
-              child: Row(
-                children: [
-                  // Icono de modulo
-                  Container(
-                    width: 40,
-                    height: 40,
-                    decoration: BoxDecoration(
-                      color:
-                          isComplete ? AppColors.secondary : widget.classColor,
-                      borderRadius: BorderRadius.circular(12),
-                    ),
-                    child: isComplete
-                        ? Center(
-                            child: HugeIcon(
-                              icon: HugeIcons.strokeRoundedCheckmarkCircle01,
-                              size: 20,
-                              color: Colors.white,
-                            ),
-                          )
-                        : Center(
-                            child: Text(
-                              '${widget.module.completedCount}/${widget.module.requirements.length}',
-                              style: const TextStyle(
-                                fontSize: 12,
-                                fontWeight: FontWeight.w700,
-                                color: Colors.white,
-                              ),
-                            ),
-                          ),
-                  ),
-                  const SizedBox(width: 12),
-                  Expanded(
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Text(
-                          widget.module.name,
-                          style:
-                              Theme.of(context).textTheme.titleSmall?.copyWith(
-                                    fontWeight: FontWeight.w700,
-                                    color: isComplete
-                                        ? AppColors.secondaryDark
-                                        : c.text,
-                                  ),
-                        ),
-                        const SizedBox(height: 4),
-                        Row(
-                          children: [
-                            Expanded(
-                              child: ClipRRect(
-                                borderRadius: BorderRadius.circular(4),
-                                child: LinearProgressIndicator(
-                                  value: widget.module.completionRatio
-                                      .clamp(0.0, 1.0),
-                                  minHeight: 4,
-                                  backgroundColor: c.borderLight,
-                                  valueColor: AlwaysStoppedAnimation<Color>(
-                                    isComplete
-                                        ? AppColors.secondary
-                                        : widget.classColor,
-                                  ),
-                                ),
-                              ),
-                            ),
-                            const SizedBox(width: 8),
-                            Text(
-                              '${(widget.module.completionRatio.clamp(0.0, 1.0) * 100).round()}%',
-                              style: TextStyle(
-                                fontSize: 12,
-                                fontWeight: FontWeight.w600,
-                                color: isComplete
-                                    ? AppColors.secondary
-                                    : widget.classColor,
-                              ),
-                            ),
-                          ],
-                        ),
-                      ],
-                    ),
-                  ),
-                  const SizedBox(width: 8),
-                  HugeIcon(
-                    icon: _expanded
-                        ? HugeIcons.strokeRoundedArrowUp01
-                        : HugeIcons.strokeRoundedArrowDown01,
-                    size: 18,
-                    color: c.textTertiary,
-                  ),
-                ],
-              ),
-            ),
-          ),
-
-          // Requerimientos del modulo
-          if (_expanded) ...[
-            if (widget.module.requirements.isEmpty)
-              Padding(
-                padding: const EdgeInsets.all(16),
-                child: Text(
-                  'classes.detail_with_progress.empty_requirements'.tr(),
-                  style: TextStyle(
-                    fontSize: 14,
-                    color: c.textSecondary,
-                  ),
-                ),
-              )
-            else
-              Padding(
-                padding: const EdgeInsets.only(top: 4, bottom: 4),
-                child: Column(
-                  // shrinkWrap replaced: requirements per module are a small,
-                  // fixed-count list inside a bounded Column — no virtualization
-                  // needed; Column avoids the O(n²) layout cost of shrinkWrap.
-                  mainAxisSize: MainAxisSize.min,
-                  children: widget.module.requirements.map((requirement) {
-                    return RequirementCard(
-                      requirement: requirement,
-                      onTap: () => _openRequirementDetail(context, requirement),
-                    );
-                  }).toList(),
-                ),
-              ),
-          ],
-        ],
-      ),
-    );
+  /// Suggestion terms for the empty-search state.
+  List<String> get _suggestions {
+    final names = widget.classWithProgress.modules.map((m) => m.name).toList();
+    return names.take(3).toList();
   }
 
-  void _openRequirementDetail(
-      BuildContext context, ClassRequirement requirement) {
+  void _openRequirementDetail(ClassRequirement requirement) {
     Navigator.push(
       context,
       SacSharedAxisRoute(
@@ -625,15 +142,780 @@ class _ModuleSectionState extends State<_ModuleSection> {
       ),
     );
   }
-}
 
-// ── Empty state ───────────────────────────────────────────────────────────────
-
-class _EmptyModules extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    final c = context.sac;
+    final classData = widget.classWithProgress;
+    final filteredModules = _filteredModules;
+    final hasQuery = _query.isNotEmpty;
+    final noResults = hasQuery && filteredModules.isEmpty;
 
+    return RefreshIndicator(
+      color: AppColors.coral500,
+      onRefresh: widget.onRefresh,
+      child: CustomScrollView(
+        physics: const BouncingScrollPhysics(
+            parent: AlwaysScrollableScrollPhysics()),
+        slivers: [
+          // ── NavBar ────────────────────────────────────────────────────────
+          SliverToBoxAdapter(child: _NavBar()),
+
+          // ── HeroCard + PillsRow + SearchBar + SectionLabel ────────────────
+          SliverToBoxAdapter(
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  _HeroCard(classData: classData),
+                  _PillsRow(classData: classData),
+                  _SearchBar(
+                    controller: _searchController,
+                    focusNode: _searchFocusNode,
+                    isFocused: _searchFocused,
+                    hasQuery: hasQuery,
+                    onChanged: _onSearchChanged,
+                    onClear: () {
+                      _searchController.clear();
+                      setState(() => _query = '');
+                    },
+                  ),
+                  if (!noResults)
+                    const _SectionLabel(text: 'MÓDULOS'),
+                ],
+              ),
+            ),
+          ),
+
+          // ── Empty search state ─────────────────────────────────────────────
+          if (noResults)
+            SliverFillRemaining(
+              hasScrollBody: false,
+              child: Padding(
+                padding: const EdgeInsets.fromLTRB(16, 0, 16, 24),
+                child: _NoResultsCard(
+                  query: _query,
+                  suggestions: _suggestions,
+                  onSuggestionTap: (term) {
+                    _searchController.text = term;
+                    setState(() => _query = term);
+                  },
+                ),
+              ),
+            )
+
+          // ── Modules list inside a single card ──────────────────────────────
+          else if (classData.modules.isEmpty)
+            const SliverToBoxAdapter(child: _EmptyModules())
+          else
+            SliverToBoxAdapter(
+              child: Padding(
+                padding: const EdgeInsets.fromLTRB(16, 0, 16, 24),
+                child: _ModulesCard(
+                  modules: filteredModules,
+                  onRequirementTap: _openRequirementDetail,
+                ),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+// ── NavBar ─────────────────────────────────────────────────────────────────────
+
+class _NavBar extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      height: 50,
+      padding: const EdgeInsets.fromLTRB(16, 14, 16, 8),
+      color: AppColors.canvas,
+      child: Row(
+        children: [
+          // Back button 36×36
+          SizedBox(
+            width: 36,
+            height: 36,
+            child: InkWell(
+              borderRadius: BorderRadius.circular(12),
+              onTap: () => Navigator.maybePop(context),
+              child: Center(
+                child: HugeIcon(
+                  icon: HugeIcons.strokeRoundedArrowLeft01,
+                  size: 20,
+                  color: AppColors.ink800,
+                ),
+              ),
+            ),
+          ),
+          // Title centered
+          const Expanded(
+            child: Text(
+              'Clase',
+              textAlign: TextAlign.center,
+              style: TextStyle(
+                fontSize: 17,
+                fontWeight: FontWeight.w600,
+                color: AppColors.ink900,
+              ),
+            ),
+          ),
+          // Spacer to balance back button
+          const SizedBox(width: 36, height: 36),
+        ],
+      ),
+    );
+  }
+}
+
+// ── HeroCard ───────────────────────────────────────────────────────────────────
+
+class _HeroCard extends StatelessWidget {
+  final ClassWithProgress classData;
+
+  const _HeroCard({required this.classData});
+
+  @override
+  Widget build(BuildContext context) {
+    final pct = classData.completionPercent;
+    final validated = classData.completedRequirements;
+    final total = classData.totalRequirements;
+
+    return Container(
+      margin: const EdgeInsets.only(bottom: 12),
+      padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 18),
+      decoration: BoxDecoration(
+        color: AppColors.paper,
+        borderRadius: BorderRadius.circular(20),
+        border: Border.all(color: AppColors.ink150),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: [
+          // Left side
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                // Eyebrow
+                Text(
+                  '${classData.name.toUpperCase()} · AVANCE',
+                  style: const TextStyle(
+                    fontSize: 11,
+                    fontWeight: FontWeight.w600,
+                    color: AppColors.ink400,
+                    letterSpacing: 0.88,
+                  ),
+                ),
+                const SizedBox(height: 4),
+                // Big percentage
+                RichText(
+                  text: TextSpan(
+                    children: [
+                      TextSpan(
+                        text: '$pct',
+                        style: const TextStyle(
+                          fontSize: 44,
+                          fontWeight: FontWeight.w800,
+                          color: AppColors.coral500,
+                          height: 1,
+                          letterSpacing: -1.3,
+                          fontFeatures: [FontFeature.tabularFigures()],
+                        ),
+                      ),
+                      const TextSpan(
+                        text: '%',
+                        style: TextStyle(
+                          fontSize: 24,
+                          fontWeight: FontWeight.w800,
+                          color: AppColors.coral500,
+                          height: 1,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+                const SizedBox(height: 6),
+                // Sub text
+                RichText(
+                  text: TextSpan(
+                    style: const TextStyle(
+                      fontSize: 13,
+                      color: AppColors.ink500,
+                    ),
+                    children: [
+                      TextSpan(
+                        text: '$validated',
+                        style: const TextStyle(
+                          fontWeight: FontWeight.w700,
+                          color: AppColors.ink800,
+                        ),
+                      ),
+                      TextSpan(text: ' de $total requisitos validados'),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          ),
+
+          const SizedBox(width: 16),
+
+          // Right: 56×56 donut
+          HeroDonut(progress: classData.completionRatio),
+        ],
+      ),
+    );
+  }
+}
+
+// ── PillsRow ───────────────────────────────────────────────────────────────────
+
+class _PillsRow extends StatelessWidget {
+  final ClassWithProgress classData;
+
+  const _PillsRow({required this.classData});
+
+  @override
+  Widget build(BuildContext context) {
+    // Count by status
+    int validated = 0, sent = 0, observed = 0, rejected = 0, pending = 0;
+    for (final m in classData.modules) {
+      for (final r in m.requirements) {
+        switch (r.status) {
+          case RequirementStatus.validado:
+            validated++;
+            break;
+          case RequirementStatus.enviado:
+            sent++;
+            break;
+          case RequirementStatus.observado:
+            observed++;
+            break;
+          case RequirementStatus.rechazado:
+            rejected++;
+            break;
+          case RequirementStatus.pendiente:
+            pending++;
+            break;
+        }
+      }
+    }
+
+    return SizedBox(
+      height: 38,
+      child: ListView(
+        scrollDirection: Axis.horizontal,
+        padding: EdgeInsets.zero,
+        clipBehavior: Clip.none,
+        children: [
+          _StatusPill(
+            color: AppColors.validatedColor,
+            bg: AppColors.validatedBg,
+            label: 'Validados',
+            count: validated,
+          ),
+          const SizedBox(width: 6),
+          _StatusPill(
+            color: AppColors.sentColor,
+            bg: AppColors.sentBg,
+            label: 'Enviados',
+            count: sent,
+          ),
+          const SizedBox(width: 6),
+          _StatusPill(
+            color: AppColors.observedColor,
+            bg: AppColors.observedBg,
+            label: 'Observados',
+            count: observed,
+          ),
+          const SizedBox(width: 6),
+          _StatusPill(
+            color: AppColors.rejectedColor,
+            bg: AppColors.rejectedBg,
+            label: 'Rechazados',
+            count: rejected,
+          ),
+          const SizedBox(width: 6),
+          _StatusPill(
+            color: AppColors.pendingColor,
+            bg: AppColors.pendingBg,
+            label: 'Pendientes',
+            count: pending,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _StatusPill extends StatelessWidget {
+  final Color color;
+  final Color bg;
+  final String label;
+  final int count;
+
+  const _StatusPill({
+    required this.color,
+    required this.bg,
+    required this.label,
+    required this.count,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+      decoration: BoxDecoration(
+        color: bg,
+        borderRadius: BorderRadius.circular(999),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Container(
+            width: 6,
+            height: 6,
+            decoration: BoxDecoration(
+              color: color,
+              shape: BoxShape.circle,
+            ),
+          ),
+          const SizedBox(width: 6),
+          Text(
+            '$count',
+            style: const TextStyle(
+              fontSize: 12,
+              fontWeight: FontWeight.w700,
+              color: AppColors.ink800,
+              fontFeatures: [FontFeature.tabularFigures()],
+            ),
+          ),
+          const SizedBox(width: 4),
+          Text(
+            label,
+            style: const TextStyle(
+              fontSize: 12,
+              fontWeight: FontWeight.w400,
+              color: AppColors.ink600,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+// ── SearchBar ──────────────────────────────────────────────────────────────────
+
+class _SearchBar extends StatelessWidget {
+  final TextEditingController controller;
+  final FocusNode focusNode;
+  final bool isFocused;
+  final bool hasQuery;
+  final ValueChanged<String> onChanged;
+  final VoidCallback onClear;
+
+  const _SearchBar({
+    required this.controller,
+    required this.focusNode,
+    required this.isFocused,
+    required this.hasQuery,
+    required this.onChanged,
+    required this.onClear,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedContainer(
+      duration: const Duration(milliseconds: 150),
+      margin: const EdgeInsets.only(top: 12, bottom: 18),
+      decoration: BoxDecoration(
+        color: AppColors.paper,
+        borderRadius: BorderRadius.circular(isFocused ? 14 : 12),
+        border: Border.all(
+          color: isFocused ? AppColors.coral500 : AppColors.ink150,
+        ),
+        boxShadow: isFocused
+            ? [
+                BoxShadow(
+                  color: AppColors.coral500.withValues(alpha: 0.08),
+                  blurRadius: 0,
+                  spreadRadius: 4,
+                )
+              ]
+            : null,
+      ),
+      child: Row(
+        children: [
+          const SizedBox(width: 12),
+          HugeIcon(
+            icon: HugeIcons.strokeRoundedSearch01,
+            size: 16,
+            color: isFocused ? AppColors.coral500 : AppColors.ink400,
+          ),
+          const SizedBox(width: 8),
+          Expanded(
+            child: TextField(
+              controller: controller,
+              focusNode: focusNode,
+              onChanged: onChanged,
+              style: const TextStyle(
+                fontSize: 13.5,
+                color: AppColors.ink800,
+              ),
+              decoration: const InputDecoration(
+                hintText: 'Buscar requerimiento o módulo…',
+                hintStyle: TextStyle(
+                  fontSize: 13.5,
+                  color: AppColors.ink400,
+                ),
+                border: InputBorder.none,
+                isDense: true,
+                contentPadding: EdgeInsets.symmetric(vertical: 10),
+              ),
+            ),
+          ),
+          if (hasQuery)
+            GestureDetector(
+              onTap: onClear,
+              child: Padding(
+                padding: const EdgeInsets.only(right: 12),
+                child: HugeIcon(
+                  icon: HugeIcons.strokeRoundedCancel01,
+                  size: 16,
+                  color: AppColors.ink400,
+                ),
+              ),
+            )
+          else
+            const SizedBox(width: 12),
+        ],
+      ),
+    );
+  }
+}
+
+// ── Section label ──────────────────────────────────────────────────────────────
+
+class _SectionLabel extends StatelessWidget {
+  final String text;
+
+  const _SectionLabel({required this.text});
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(left: 4, bottom: 8),
+      child: Text(
+        text,
+        style: const TextStyle(
+          fontSize: 11,
+          fontWeight: FontWeight.w700,
+          color: AppColors.ink400,
+          letterSpacing: 1.32,
+        ),
+      ),
+    );
+  }
+}
+
+// ── Modules card ───────────────────────────────────────────────────────────────
+
+class _ModulesCard extends StatelessWidget {
+  final List<ClassModuleDetail> modules;
+  final void Function(ClassRequirement) onRequirementTap;
+
+  const _ModulesCard({
+    required this.modules,
+    required this.onRequirementTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(16),
+      child: Container(
+        decoration: BoxDecoration(
+          color: AppColors.paper,
+          borderRadius: BorderRadius.circular(16),
+          border: Border.all(color: AppColors.ink150),
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            for (int i = 0; i < modules.length; i++) ...[
+              if (i > 0)
+                const Divider(
+                  color: AppColors.ink100,
+                  height: 1,
+                  thickness: 1,
+                ),
+              ModuleDetailRow(
+                module: modules[i],
+                // First module expanded by default
+                initiallyExpanded: i == 0,
+                onRequirementTap: onRequirementTap,
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+// ── No results card ────────────────────────────────────────────────────────────
+
+class _NoResultsCard extends StatelessWidget {
+  final String query;
+  final List<String> suggestions;
+  final void Function(String) onSuggestionTap;
+
+  const _NoResultsCard({
+    required this.query,
+    required this.suggestions,
+    required this.onSuggestionTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      margin: const EdgeInsets.only(top: 8),
+      padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 28),
+      decoration: BoxDecoration(
+        color: AppColors.paper,
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(color: AppColors.ink150),
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          // Illustration circle
+          Container(
+            width: 88,
+            height: 88,
+            decoration: const BoxDecoration(
+              color: AppColors.canvas,
+              shape: BoxShape.circle,
+            ),
+            child: Center(
+              child: CustomPaint(
+                size: const Size(64, 64),
+                painter: _SearchIllustrationPainter(),
+              ),
+            ),
+          ),
+
+          const SizedBox(height: 14),
+
+          // Title
+          const Text(
+            'No encontramos coincidencias',
+            style: TextStyle(
+              fontSize: 16,
+              fontWeight: FontWeight.w700,
+              color: AppColors.ink900,
+            ),
+          ),
+
+          const SizedBox(height: 6),
+
+          // Subtitle
+          const SizedBox(
+            width: 260,
+            child: Text(
+              'Prueba con otras palabras o revisa los módulos uno por uno desde la lista completa.',
+              textAlign: TextAlign.center,
+              style: TextStyle(
+                fontSize: 13,
+                color: AppColors.ink500,
+                height: 1.45,
+              ),
+            ),
+          ),
+
+          const SizedBox(height: 22),
+
+          // Suggestions section
+          if (suggestions.isNotEmpty) ...[
+            Align(
+              alignment: Alignment.centerLeft,
+              child: const Text(
+                'SUGERENCIAS',
+                style: TextStyle(
+                  fontSize: 11,
+                  fontWeight: FontWeight.w700,
+                  color: AppColors.ink400,
+                  letterSpacing: 0.88,
+                ),
+              ),
+            ),
+            const SizedBox(height: 8),
+            Align(
+              alignment: Alignment.centerLeft,
+              child: Wrap(
+                spacing: 8,
+                runSpacing: 8,
+                children: suggestions.map((term) {
+                  return GestureDetector(
+                    onTap: () => onSuggestionTap(term),
+                    child: Container(
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: 12,
+                        vertical: 8,
+                      ),
+                      decoration: BoxDecoration(
+                        color: AppColors.coral50,
+                        borderRadius: BorderRadius.circular(999),
+                        border: Border.all(color: AppColors.coral100),
+                      ),
+                      child: Text(
+                        term,
+                        style: const TextStyle(
+                          fontSize: 12.5,
+                          fontWeight: FontWeight.w600,
+                          color: AppColors.coral700,
+                        ),
+                      ),
+                    ),
+                  );
+                }).toList(),
+              ),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+class _SearchIllustrationPainter extends CustomPainter {
+  @override
+  void paint(Canvas canvas, Size size) {
+    final center = Offset(size.width * 0.44, size.height * 0.44);
+    const outerRadius = 18.0;
+    const innerRadius = 12.0;
+    const strokeWidth = 3.0;
+
+    // Outer circle (lens)
+    final outerPaint = Paint()
+      ..color = AppColors.ink200
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = strokeWidth;
+    canvas.drawCircle(center, outerRadius, outerPaint);
+
+    // Inner fill (coral50)
+    final innerFill = Paint()
+      ..color = AppColors.coral50
+      ..style = PaintingStyle.fill;
+    canvas.drawCircle(center, innerRadius, innerFill);
+
+    // Handle
+    final handlePaint = Paint()
+      ..color = AppColors.ink200
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = strokeWidth
+      ..strokeCap = StrokeCap.round;
+    canvas.drawLine(
+      center + const Offset(12, 12),
+      center + const Offset(20, 20),
+      handlePaint,
+    );
+
+    // "?" text
+    final tp = TextPainter(
+      text: const TextSpan(
+        text: '?',
+        style: TextStyle(
+          fontSize: 14,
+          fontWeight: FontWeight.w700,
+          color: AppColors.coral500,
+          height: 1,
+        ),
+      ),
+      textDirection: ui.TextDirection.ltr,
+    )..layout();
+    tp.paint(
+      canvas,
+      center - Offset(tp.width / 2, tp.height / 2),
+    );
+  }
+
+  @override
+  bool shouldRepaint(covariant CustomPainter oldDelegate) => false;
+}
+
+// ── Skeleton loading ───────────────────────────────────────────────────────────
+
+class _SkeletonBody extends StatelessWidget {
+  const _SkeletonBody();
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          _NavBar(),
+          const SizedBox(height: 8),
+          _SkeletonBox(height: 108, radius: 20),
+          const SizedBox(height: 12),
+          Row(
+            children: List.generate(
+              5,
+              (i) => Padding(
+                padding: EdgeInsets.only(right: i < 4 ? 6 : 0),
+                child: _SkeletonBox(width: 90, height: 36, radius: 999),
+              ),
+            ),
+          ),
+          const SizedBox(height: 12),
+          _SkeletonBox(height: 44, radius: 12),
+          const SizedBox(height: 18),
+          _SkeletonBox(height: 200, radius: 16),
+        ],
+      ),
+    );
+  }
+}
+
+class _SkeletonBox extends StatelessWidget {
+  final double? width;
+  final double height;
+  final double radius;
+
+  const _SkeletonBox({
+    this.width,
+    required this.height,
+    this.radius = 8,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: width,
+      height: height,
+      margin: const EdgeInsets.only(bottom: 8),
+      decoration: BoxDecoration(
+        color: AppColors.ink100,
+        borderRadius: BorderRadius.circular(radius),
+      ),
+    );
+  }
+}
+
+// ── Empty modules ──────────────────────────────────────────────────────────────
+
+class _EmptyModules extends StatelessWidget {
+  const _EmptyModules();
+
+  @override
+  Widget build(BuildContext context) {
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 40, vertical: 48),
       child: Column(
@@ -642,22 +924,24 @@ class _EmptyModules extends StatelessWidget {
           HugeIcon(
             icon: HugeIcons.strokeRoundedSchool,
             size: 48,
-            color: c.textTertiary,
+            color: AppColors.ink400,
           ),
           const SizedBox(height: 12),
           Text(
             'classes.detail_with_progress.empty_modules_title'.tr(),
-            style: Theme.of(context).textTheme.titleSmall?.copyWith(
-                  fontWeight: FontWeight.w600,
-                  color: c.textSecondary,
-                ),
+            style: const TextStyle(
+              fontSize: 15,
+              fontWeight: FontWeight.w600,
+              color: AppColors.ink500,
+            ),
           ),
           const SizedBox(height: 6),
           Text(
             'classes.detail_with_progress.empty_modules_body'.tr(),
-            style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                  color: c.textTertiary,
-                ),
+            style: const TextStyle(
+              fontSize: 13,
+              color: AppColors.ink400,
+            ),
             textAlign: TextAlign.center,
           ),
         ],
@@ -666,7 +950,7 @@ class _EmptyModules extends StatelessWidget {
   }
 }
 
-// ── Error state ───────────────────────────────────────────────────────────────
+// ── Error state ────────────────────────────────────────────────────────────────
 
 class _ErrorBody extends StatelessWidget {
   final String message;
@@ -685,30 +969,45 @@ class _ErrorBody extends StatelessWidget {
             HugeIcon(
               icon: HugeIcons.strokeRoundedAlert02,
               size: 56,
-              color: AppColors.error,
+              color: AppColors.rejectedColor,
             ),
             const SizedBox(height: 16),
             Text(
               'classes.detail_with_progress.error_loading'.tr(),
-              style: Theme.of(context)
-                  .textTheme
-                  .titleMedium
-                  ?.copyWith(fontWeight: FontWeight.w600),
+              style: const TextStyle(
+                fontSize: 16,
+                fontWeight: FontWeight.w600,
+                color: AppColors.ink900,
+              ),
               textAlign: TextAlign.center,
             ),
             const SizedBox(height: 8),
             Text(
               message,
-              style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                    color: context.sac.textSecondary,
-                  ),
+              style: const TextStyle(fontSize: 13, color: AppColors.ink500),
               textAlign: TextAlign.center,
             ),
             const SizedBox(height: 24),
-            SacButton.primary(
-              text: 'common.retry'.tr(),
-              icon: HugeIcons.strokeRoundedRefresh,
-              onPressed: onRetry,
+            GestureDetector(
+              onTap: onRetry,
+              child: Container(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 24,
+                  vertical: 12,
+                ),
+                decoration: BoxDecoration(
+                  color: AppColors.coral500,
+                  borderRadius: BorderRadius.circular(14),
+                ),
+                child: const Text(
+                  'Reintentar',
+                  style: TextStyle(
+                    fontSize: 14,
+                    fontWeight: FontWeight.w700,
+                    color: Colors.white,
+                  ),
+                ),
+              ),
             ),
           ],
         ),

--- a/lib/features/classes/presentation/views/classes_list_view.dart
+++ b/lib/features/classes/presentation/views/classes_list_view.dart
@@ -1,10 +1,12 @@
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 import 'package:hugeicons/hugeicons.dart';
 import 'package:sacdia_app/core/animations/staggered_list_animation.dart';
 import 'package:sacdia_app/core/theme/app_colors.dart';
 import 'package:sacdia_app/core/theme/sac_colors.dart';
+import 'package:sacdia_app/core/config/route_names.dart';
 import 'package:sacdia_app/core/utils/responsive.dart';
 import 'package:sacdia_app/core/widgets/sac_button.dart';
 import 'package:sacdia_app/core/widgets/sac_loading.dart';
@@ -14,49 +16,98 @@ import '../sheets/enroll_previous_class_sheet.dart';
 import '../widgets/class_card.dart';
 import 'class_detail_with_progress_view.dart';
 
-/// Vista de lista de clases - Estilo "Scout Vibrante"
+// ── Top-level helper — reachable from AppBar and from ClassesListViewBody ───────
+
+void _openEnrollSheet(BuildContext context) {
+  showModalBottomSheet(
+    context: context,
+    isScrollControlled: true,
+    shape: const RoundedRectangleBorder(
+      borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+    ),
+    builder: (_) => const EnrollPreviousClassSheet(),
+  );
+}
+
+/// Vista de lista de clases — tab principal del bottom nav.
 ///
-/// Sin AppBar (tab del bottom nav), titulo inline,
-/// ClassCards con SacProgressBar y badge "Clase actual".
-/// Items animan con stagger slide-up al cargar.
+/// Layout (top → bottom):
+///   1. AppBar "Clases" con acción "Inscribirme" (solo si tiene club activo)
+///   2. Chip de entrada al Roadmap
+///   3. Sección "Clase actual" (primer elemento de la lista)
+///   4. Sección "Otras clases" (resto de elementos)
 ///
 /// Internamente delega el cuerpo a [ClassesListViewBody] para que también
-/// pueda ser embebido en [ClassesTabsView] sin doble Scaffold.
+/// pueda ser embebido en otro Scaffold sin doble Scaffold.
 class ClassesListView extends ConsumerWidget {
   const ClassesListView({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final c = context.sac;
+    final hasActiveClub = ref
+            .watch(authNotifierProvider.select((v) => v.valueOrNull))
+            ?.authorization
+            ?.activeGrant
+            ?.sectionId !=
+        null;
+
     return Scaffold(
       backgroundColor: c.background,
-      body: SafeArea(child: const ClassesListViewBody()),
+      appBar: AppBar(
+        title: const Text('Clases'),
+        automaticallyImplyLeading: false,
+        actions: [
+          if (hasActiveClub)
+            Padding(
+              padding: const EdgeInsets.only(right: 8),
+              child: OutlinedButton.icon(
+                onPressed: () => _openEnrollSheet(context),
+                icon: HugeIcon(
+                  icon: HugeIcons.strokeRoundedBookmarkAdd02,
+                  size: 18,
+                  color: Theme.of(context).colorScheme.onSurface,
+                ),
+                label: Text(
+                  'classes.list.enroll_cta_short'.tr(),
+                  style: TextStyle(
+                    color: Theme.of(context).colorScheme.onSurface,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+                style: OutlinedButton.styleFrom(
+                  shape: const StadiumBorder(),
+                  side: BorderSide(
+                    color: Theme.of(context).colorScheme.outlineVariant,
+                  ),
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 12,
+                    vertical: 8,
+                  ),
+                  minimumSize: const Size(0, 40),
+                  tapTargetSize: MaterialTapTargetSize.padded,
+                  foregroundColor: Theme.of(context).colorScheme.onSurface,
+                ),
+              ),
+            ),
+        ],
+      ),
+      body: const ClassesListViewBody(),
     );
   }
 }
 
-/// Body de la lista de clases, sin Scaffold ni SafeArea propios.
-/// Usar este widget cuando se embebe dentro de otro Scaffold
-/// (p.ej. [ClassesTabsView]).
+/// Body de la lista de clases, sin Scaffold ni AppBar propios.
+/// Usar este widget cuando se embebe dentro de otro Scaffold.
 class ClassesListViewBody extends ConsumerWidget {
   const ClassesListViewBody({super.key});
-
-  void _openEnrollSheet(BuildContext context) {
-    showModalBottomSheet(
-      context: context,
-      isScrollControlled: true,
-      shape: const RoundedRectangleBorder(
-        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
-      ),
-      builder: (_) => const EnrollPreviousClassSheet(),
-    );
-  }
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final classesAsync = ref.watch(userClassesProvider);
     final hPad = Responsive.horizontalPadding(context);
     final c = context.sac;
+    final theme = Theme.of(context);
 
     final user = ref.watch(
       authNotifierProvider.select((v) => v.valueOrNull),
@@ -66,116 +117,61 @@ class ClassesListViewBody extends ConsumerWidget {
     return classesAsync.when(
       data: (classes) {
         if (classes.isEmpty) {
-          return Center(
-            child: Column(
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: [
-                HugeIcon(
-                    icon: HugeIcons.strokeRoundedSchool,
-                    size: 56,
-                    color: c.textTertiary),
-                const SizedBox(height: 12),
-                Text(
-                  'classes.list.empty'.tr(),
-                  style: TextStyle(
-                    fontSize: 16,
-                    color: c.textSecondary,
-                  ),
-                ),
-              ],
-            ),
+          return _EmptyBody(
+            hPad: hPad,
+            hasActiveClub: hasActiveClub,
+            onEnroll: () => _openEnrollSheet(context),
+            c: c,
           );
         }
+
+        // Split: current class (index 0) vs others
+        final currentClass = classes.first;
+        final otherClasses = classes.length > 1 ? classes.sublist(1) : <dynamic>[];
 
         return RefreshIndicator(
           color: AppColors.primary,
           onRefresh: () async {
             ref.invalidate(userClassesProvider);
           },
-          child: ListView.builder(
-            padding: EdgeInsets.fromLTRB(hPad, 16, hPad, 24),
-            itemCount: classes.length + 1, // +1 para el header
-            itemBuilder: (context, index) {
-              if (index == 0) {
-                return Padding(
-                  padding: const EdgeInsets.only(bottom: 20),
-                  child: Row(
-                    children: [
-                      Container(
-                        padding: const EdgeInsets.all(9),
-                        decoration: BoxDecoration(
-                          color: AppColors.primaryLight,
-                          borderRadius: BorderRadius.circular(12),
-                        ),
-                        child: HugeIcon(
-                          icon: HugeIcons.strokeRoundedSchool,
-                          size: 22,
-                          color: AppColors.primary,
-                        ),
-                      ),
-                      const SizedBox(width: 12),
-                      Expanded(
-                        child: Column(
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          children: [
-                            Text(
-                              'classes.list.title'.tr(),
-                              style: Theme.of(context)
-                                  .textTheme
-                                  .headlineSmall
-                                  ?.copyWith(fontWeight: FontWeight.w700),
-                            ),
-                          ],
-                        ),
-                      ),
-                      if (hasActiveClub)
-                        Tooltip(
-                          message: 'classes.list.enroll_tooltip'.tr(),
-                          child: IconButton(
-                            onPressed: () => _openEnrollSheet(context),
-                            icon: HugeIcon(
-                              icon: HugeIcons.strokeRoundedBookmarkAdd02,
-                              size: 24,
-                              color: AppColors.primary,
-                            ),
-                            style: IconButton.styleFrom(
-                              backgroundColor: AppColors.primaryLight,
-                              shape: RoundedRectangleBorder(
-                                borderRadius: BorderRadius.circular(12),
-                              ),
-                            ),
-                          ),
-                        ),
-                    ],
-                  ),
-                );
-              }
+          child: ListView(
+            padding: EdgeInsets.fromLTRB(hPad, 12, hPad, 32),
+            children: [
+              // ── Roadmap entry chip ─────────────────────────────────────────
+              _RoadmapChip(hPad: hPad),
+              const SizedBox(height: 20),
 
-              final classIndex = index - 1;
-              final progressiveClass = classes[classIndex];
-
-              return StaggeredListItem(
-                index: classIndex,
+              // ── Section: Clase actual ──────────────────────────────────────
+              Text(
+                'classes.list.section_current'.tr(),
+                style: theme.textTheme.titleSmall?.copyWith(
+                  fontWeight: FontWeight.w700,
+                  color: c.textSecondary,
+                ),
+              ),
+              const SizedBox(height: 8),
+              StaggeredListItem(
+                index: 0,
                 initialDelay: const Duration(milliseconds: 80),
                 staggerDelay: const Duration(milliseconds: 65),
                 child: Consumer(
                   builder: (context, progressRef, _) {
                     final progressAsync = progressRef
-                        .watch(classWithProgressProvider(progressiveClass.id));
+                        .watch(classWithProgressProvider(currentClass.id));
                     final progress = progressAsync.whenOrNull(
                           data: (cwp) => cwp.completionRatio,
                         ) ??
                         0.0;
                     return ClassCard(
-                      progressiveClass: progressiveClass,
+                      progressiveClass: currentClass,
                       progress: progress,
-                      isCurrent: classIndex == 0,
+                      isCurrent: true,
                       onTap: () {
                         Navigator.push(
                           context,
                           MaterialPageRoute(
                             builder: (context) => ClassDetailWithProgressView(
-                              classId: progressiveClass.id,
+                              classId: currentClass.id,
                             ),
                           ),
                         );
@@ -183,8 +179,55 @@ class ClassesListViewBody extends ConsumerWidget {
                     );
                   },
                 ),
-              );
-            },
+              ),
+
+              // ── Section: Otras clases ──────────────────────────────────────
+              if (otherClasses.isNotEmpty) ...[
+                const SizedBox(height: 16),
+                Text(
+                  'classes.list.section_others'.tr(),
+                  style: theme.textTheme.titleSmall?.copyWith(
+                    fontWeight: FontWeight.w700,
+                    color: c.textSecondary,
+                  ),
+                ),
+                const SizedBox(height: 8),
+                for (int i = 0; i < otherClasses.length; i++)
+                  StaggeredListItem(
+                    index: i + 1,
+                    initialDelay: const Duration(milliseconds: 80),
+                    staggerDelay: const Duration(milliseconds: 65),
+                    child: Consumer(
+                      builder: (context, progressRef, _) {
+                        final progressiveClass = otherClasses[i];
+                        final progressAsync = progressRef
+                            .watch(classWithProgressProvider(progressiveClass.id));
+                        final progress = progressAsync.whenOrNull(
+                              data: (cwp) => cwp.completionRatio,
+                            ) ??
+                            0.0;
+                        return ClassCard(
+                          progressiveClass: progressiveClass,
+                          progress: progress,
+                          isCurrent: false,
+                          onTap: () {
+                            Navigator.push(
+                              context,
+                              MaterialPageRoute(
+                                builder: (context) =>
+                                    ClassDetailWithProgressView(
+                                  classId: progressiveClass.id,
+                                ),
+                              ),
+                            );
+                          },
+                        );
+                      },
+                    ),
+                  ),
+              ],
+
+            ],
           ),
         );
       },
@@ -225,6 +268,155 @@ class ClassesListViewBody extends ConsumerWidget {
           ),
         ),
       ),
+    );
+  }
+}
+
+// ── Roadmap chip ──────────────────────────────────────────────────────────────
+
+class _RoadmapChip extends StatelessWidget {
+  final double hPad;
+
+  const _RoadmapChip({required this.hPad});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
+    return Material(
+      color: colorScheme.surfaceContainerLow,
+      borderRadius: BorderRadius.circular(16),
+      clipBehavior: Clip.antiAlias,
+      child: InkWell(
+        onTap: () => context.push(RouteNames.homeClassesRoadmap),
+        borderRadius: BorderRadius.circular(16),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
+          child: Row(
+            children: [
+              Container(
+                width: 44,
+                height: 44,
+                decoration: BoxDecoration(
+                  color: AppColors.primaryLight,
+                  borderRadius: BorderRadius.circular(12),
+                ),
+                child: const Center(
+                  child: HugeIcon(
+                    icon: HugeIcons.strokeRoundedRoute01,
+                    size: 22,
+                    color: AppColors.primary,
+                  ),
+                ),
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      'classes.list.roadmap_chip_title'.tr(),
+                      style: theme.textTheme.titleSmall?.copyWith(
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                    const SizedBox(height: 2),
+                    Text(
+                      'classes.list.roadmap_chip_subtitle'.tr(),
+                      style: theme.textTheme.bodySmall?.copyWith(
+                        color: theme.colorScheme.onSurfaceVariant,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(width: 8),
+              HugeIcon(
+                icon: HugeIcons.strokeRoundedArrowRight01,
+                size: 20,
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+// ── Inline enroll button ──────────────────────────────────────────────────────
+
+class _EnrollButton extends StatelessWidget {
+  final VoidCallback onPressed;
+
+  const _EnrollButton({required this.onPressed});
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: double.infinity,
+      height: 48,
+      child: FilledButton.icon(
+        onPressed: onPressed,
+        icon: const HugeIcon(
+          icon: HugeIcons.strokeRoundedAdd01,
+          size: 20,
+          color: Colors.white,
+        ),
+        label: Text('classes.list.enroll_cta'.tr()),
+      ),
+    );
+  }
+}
+
+// ── Empty body ────────────────────────────────────────────────────────────────
+
+class _EmptyBody extends StatelessWidget {
+  final double hPad;
+  final bool hasActiveClub;
+  final VoidCallback onEnroll;
+  final SacColors c;
+
+  const _EmptyBody({
+    required this.hPad,
+    required this.hasActiveClub,
+    required this.onEnroll,
+    required this.c,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return ListView(
+      padding: EdgeInsets.fromLTRB(hPad, 12, hPad, 32),
+      children: [
+        _RoadmapChip(hPad: hPad),
+        const SizedBox(height: 40),
+        Center(
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              HugeIcon(
+                icon: HugeIcons.strokeRoundedSchool,
+                size: 56,
+                color: c.textTertiary,
+              ),
+              const SizedBox(height: 12),
+              Text(
+                'classes.list.empty'.tr(),
+                style: TextStyle(
+                  fontSize: 16,
+                  color: c.textSecondary,
+                ),
+              ),
+            ],
+          ),
+        ),
+        if (hasActiveClub) ...[
+          const SizedBox(height: 32),
+          _EnrollButton(onPressed: onEnroll),
+        ],
+      ],
     );
   }
 }

--- a/lib/features/classes/presentation/views/classes_tabs_view.dart
+++ b/lib/features/classes/presentation/views/classes_tabs_view.dart
@@ -1,87 +1,19 @@
 import 'package:flutter/material.dart';
-import 'package:sacdia_app/core/theme/app_colors.dart';
-import 'package:sacdia_app/core/theme/sac_colors.dart';
-import '../roadmap/widgets/roadmap_screen_connected.dart';
 import 'classes_list_view.dart';
 
-/// Contenedor principal del tab "Clases" en el bottom nav.
+/// Contenedor del tab "Clases" en el bottom nav.
 ///
-/// Muestra un selector segmentado en la parte superior que alterna entre:
-///   - Tab 0: lista de clases del usuario (ClassesListView)
-///   - Tab 1: roadmap visual serpenteante (RoadmapScreen)
+/// El selector segmentado fue eliminado — Mis Clases es el contenido primario
+/// del tab y el Roadmap se accede como pantalla independiente desde el chip
+/// dentro de [ClassesListView].
 ///
-/// No tiene AppBar propio — sigue siendo un tab del bottom nav.
-/// La SafeArea la delega a cada vista hijo para mantener el mismo
-/// comportamiento que tenía ClassesListView antes de este cambio.
-enum _ClassesTab { list, roadmap }
-
-class ClassesTabsView extends StatefulWidget {
+/// Este wrapper se mantiene para que el router no necesite cambios en
+/// [RouteNames.homeClasses] ni en el [StatefulShellBranch] existente.
+class ClassesTabsView extends StatelessWidget {
   const ClassesTabsView({super.key});
 
   @override
-  State<ClassesTabsView> createState() => _ClassesTabsViewState();
-}
-
-class _ClassesTabsViewState extends State<ClassesTabsView> {
-  _ClassesTab _selected = _ClassesTab.list;
-
-  @override
   Widget build(BuildContext context) {
-    final c = context.sac;
-
-    return Scaffold(
-      backgroundColor: _selected == _ClassesTab.roadmap
-          // El roadmap tiene su propio gradiente — fondo transparente para que
-          // el Stack interno pinte desde el borde superior.
-          ? Colors.transparent
-          : c.background,
-      body: SafeArea(
-        // bottom: false porque ClassesListView y el bottom nav ya manejan eso
-        bottom: false,
-        child: Column(
-          children: [
-            // ── Selector segmentado ───────────────────────────────────────
-            Padding(
-              padding: const EdgeInsets.fromLTRB(16, 12, 16, 4),
-              child: SegmentedButton<_ClassesTab>(
-                style: SegmentedButton.styleFrom(
-                  selectedBackgroundColor: AppColors.primaryLight,
-                  selectedForegroundColor: AppColors.primary,
-                  foregroundColor: c.textSecondary,
-                  side: BorderSide(color: c.border),
-                  shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(12),
-                  ),
-                  padding:
-                      const EdgeInsets.symmetric(horizontal: 20, vertical: 10),
-                ),
-                segments: const [
-                  ButtonSegment<_ClassesTab>(
-                    value: _ClassesTab.list,
-                    label: Text('Mis Clases'),
-                    icon: Icon(Icons.school_outlined, size: 18),
-                  ),
-                  ButtonSegment<_ClassesTab>(
-                    value: _ClassesTab.roadmap,
-                    label: Text('Roadmap'),
-                    icon: Icon(Icons.route_outlined, size: 18),
-                  ),
-                ],
-                selected: {_selected},
-                onSelectionChanged: (newSelection) {
-                  setState(() => _selected = newSelection.first);
-                },
-              ),
-            ),
-            // ── Vista activa ──────────────────────────────────────────────
-            Expanded(
-              child: _selected == _ClassesTab.list
-                  ? const ClassesListViewBody()
-                  : const RoadmapScreenConnected(),
-            ),
-          ],
-        ),
-      ),
-    );
+    return const ClassesListView();
   }
 }

--- a/lib/features/classes/presentation/views/requirement_detail_view.dart
+++ b/lib/features/classes/presentation/views/requirement_detail_view.dart
@@ -4,29 +4,30 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:hugeicons/hugeicons.dart';
 
 import '../../../../core/theme/app_colors.dart';
-import '../../../../core/theme/sac_colors.dart';
 import '../../../../core/widgets/evidence_staging/evidence_staging_manager.dart';
 import '../../../../core/widgets/evidence_staging/staged_file.dart';
 import '../../../../core/widgets/sac_loading.dart';
 import '../../../auth/presentation/providers/auth_providers.dart';
 import '../../domain/entities/class_requirement.dart';
 import '../providers/classes_providers.dart';
-import '../sheets/requirement_status_history_sheet.dart';
+import '../utils/status_meta.dart';
 import '../widgets/requirement_status_badge.dart';
+import '../sheets/requirement_status_history_sheet.dart';
 
-/// Vista de detalle de un requerimiento de clase progresiva.
+/// Vista de detalle de un requerimiento de clase progresiva — rediseño handoff
+/// (Variante E).
 ///
-/// Permite al usuario:
-/// - Ver el estado actual y la linea de tiempo del requerimiento.
-/// - Ver los archivos de evidencia subidos.
-/// - Subir nuevos archivos cuando el requerimiento esta pendiente.
-/// - Eliminar archivos en estado pendiente.
-/// - Enviar el requerimiento a validacion.
+/// Para estados [RequirementStatus.observado] y [RequirementStatus.rechazado]
+/// muestra:
+///   - BannerEstado con icono + headline + subtext.
+///   - ObservationCard con avatar del instructor + comentario en burbuja.
+///   - Lista de archivos adjuntos con badges "En revisión" / "Rechazado".
+///   - EmptyFileSlot (botón dashed) para subir archivos.
+///   - BigCTA "Reenviar archivos corregidos" (coral).
 ///
-/// Uses [EvidenceStagingManager] for file staging, upload, and submission.
+/// Para [RequirementStatus.pendiente] o [RequirementStatus.validado] mantiene
+/// el flujo original de EvidenceStagingManager.
 class RequirementDetailView extends ConsumerStatefulWidget {
-  /// Snapshot inicial usado solo para obtener el [requirementId] y como
-  /// fallback mientras [classWithProgressProvider] no haya cargado aun.
   final ClassRequirement requirement;
   final int classId;
 
@@ -41,11 +42,10 @@ class RequirementDetailView extends ConsumerStatefulWidget {
       _RequirementDetailViewState();
 }
 
-class _RequirementDetailViewState extends ConsumerState<RequirementDetailView> {
+class _RequirementDetailViewState
+    extends ConsumerState<RequirementDetailView> {
   bool _hasUnsavedFiles = false;
 
-  /// Devuelve el requerimiento vivo desde [classWithProgressProvider] si ya
-  /// cargó, o el snapshot inicial del constructor como fallback.
   ClassRequirement _liveRequirement(AsyncValue<dynamic> classAsync) {
     return classAsync.whenData((classWithProgress) {
           for (final module in classWithProgress.modules) {
@@ -58,319 +58,17 @@ class _RequirementDetailViewState extends ConsumerState<RequirementDetailView> {
         widget.requirement;
   }
 
-  @override
-  Widget build(BuildContext context) {
-    final c = context.sac;
-    final notifierState =
-        ref.watch(requirementNotifierProvider(widget.classId));
-
-    // Leer el provider en vivo — se actualiza automaticamente al invalidarse
-    // tras cada upload / delete exitoso en el notifier.
-    final classAsync = ref.watch(classWithProgressProvider(widget.classId));
-    final requirement = _liveRequirement(classAsync);
-    final canModify = requirement.status == RequirementStatus.pendiente ||
-        requirement.status == RequirementStatus.rechazado;
-
-    // Mostrar snackbar cuando hay error
-    ref.listen(
-      requirementNotifierProvider(widget.classId),
-      (prev, next) {
-        if (next.errorMessage != null && next.errorMessage!.isNotEmpty) {
-          _showErrorSnackbar(context, next.errorMessage!);
-        }
-      },
-    );
-
-    final isLoading = notifierState.isLoading;
-
-    return PopScope(
-      canPop: !_hasUnsavedFiles,
-      onPopInvokedWithResult: (didPop, result) async {
-        if (didPop) return;
-        final confirm = await showDialog<bool>(
-          context: context,
-          builder: (ctx) => AlertDialog(
-            title: Text('classes.requirement_detail.unsaved_files_title'.tr()),
-            content: Text(
-              'classes.requirement_detail.unsaved_files_body'.tr(),
-            ),
-            actions: [
-              TextButton(
-                onPressed: () => Navigator.pop(ctx, false),
-                child: Text('classes.requirement_detail.stay_button'.tr()),
-              ),
-              TextButton(
-                onPressed: () => Navigator.pop(ctx, true),
-                style: TextButton.styleFrom(foregroundColor: AppColors.error),
-                child: Text('classes.requirement_detail.leave_button'.tr()),
-              ),
-            ],
-          ),
-        );
-        if (confirm == true && context.mounted) {
-          Navigator.pop(context);
-        }
-      },
-      child: Scaffold(
-        backgroundColor: c.background,
-        appBar: AppBar(
-          title: Text(
-            'classes.requirement_detail.requirement_title'
-                .tr(namedArgs: {'name': requirement.name}),
-            style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                  fontWeight: FontWeight.w700,
-                ),
-            overflow: TextOverflow.ellipsis,
-          ),
-          leading: IconButton(
-            icon: HugeIcon(
-              icon: HugeIcons.strokeRoundedArrowLeft01,
-              color: c.text,
-              size: 22,
-            ),
-            onPressed: isLoading ? null : () => Navigator.pop(context),
-            tooltip: 'common.back'.tr(),
-          ),
-          backgroundColor: c.background,
-          surfaceTintColor: Colors.transparent,
-          actions: [
-            RequirementStatusBadge(status: requirement.status),
-            const SizedBox(width: 16),
-          ],
-        ),
-        body: Stack(
-          children: [
-            // Single scroll view for all content — meta card, timeline, and
-            // evidence staging area are one continuous scrollable surface.
-            // EvidenceStagingManager uses embeddedMode: true so it grows with
-            // its content instead of claiming its own bounded scroll area.
-            SingleChildScrollView(
-              physics: const BouncingScrollPhysics(),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Padding(
-                    padding: const EdgeInsets.fromLTRB(16, 8, 16, 0),
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Text(
-                          'classes.requirement_detail.detail_header'.tr(),
-                          style:
-                              Theme.of(context).textTheme.labelSmall?.copyWith(
-                                    color: c.textSecondary,
-                                    letterSpacing: 0.8,
-                                  ),
-                        ),
-                        const SizedBox(height: 4),
-                        Text(
-                          requirement.name,
-                          style:
-                              Theme.of(context).textTheme.titleLarge?.copyWith(
-                                    fontWeight: FontWeight.w600,
-                                    color: c.text,
-                                    height: 1.25,
-                                  ),
-                        ),
-                      ],
-                    ),
-                  ),
-
-                  const SizedBox(height: 16),
-                  // Meta card con descripcion y metricas
-                  Padding(
-                    padding: const EdgeInsets.fromLTRB(16, 8, 16, 0),
-                    child: Text(
-                      'classes.requirement_detail.detail_header'.tr(),
-                      style: Theme.of(context).textTheme.labelSmall?.copyWith(
-                            color: c.textSecondary,
-                            letterSpacing: 0.8,
-                          ),
-                    ),
-                  ),
-                  _RequirementMetaCard(requirement: requirement),
-
-                  const SizedBox(height: 16),
-
-                  // Especialidad vinculada (si aplica)
-                  if (requirement.type == RequirementType.honor &&
-                      requirement.linkedHonorName != null)
-                    _LinkedHonorSection(requirement: requirement),
-
-                  // Estado actual tappable — abre historial como bottom sheet
-                  const SizedBox(height: 16),
-                  Padding(
-                    padding: const EdgeInsets.fromLTRB(16, 0, 16, 0),
-                    child: Text(
-                      'classes.requirement_detail.status_header'.tr(),
-                      style: Theme.of(context).textTheme.labelSmall?.copyWith(
-                            color: c.textSecondary,
-                            letterSpacing: 0.8,
-                          ),
-                    ),
-                  ),
-                  const SizedBox(height: 8),
-                  Padding(
-                    padding: const EdgeInsets.symmetric(horizontal: 16),
-                    child: _StatusChip(
-                      requirement: requirement,
-                      onTap: () => showRequirementStatusHistorySheet(
-                        context,
-                        requirement: requirement,
-                      ),
-                    ),
-                  ),
-
-                  const SizedBox(height: 24),
-
-                  // Archivos de evidencia
-                  Padding(
-                    padding: const EdgeInsets.fromLTRB(16, 0, 16, 8),
-                    child: Text(
-                      'classes.requirement_detail.evidence_files_header'.tr(),
-                      style: Theme.of(context).textTheme.titleSmall?.copyWith(
-                            fontWeight: FontWeight.w700,
-                            color: c.text,
-                          ),
-                    ),
-                  ),
-
-                  // Evidence staging — grows with content (no internal scroll).
-                  // In embeddedMode the manager renders its action bar at the
-                  // bottom of its own Column so it stays co-located with the
-                  // file grid and scrolls as one unit.
-                  EvidenceStagingManager(
-                    embeddedMode: true,
-                    existingFiles: requirement.files
-                        .map(StagedFile.fromRequirementEvidence)
-                        .toList(),
-                    maxFiles: requirement.maxFiles,
-                    isLoading: notifierState.isLoading,
-                    // C-1: Pass onProgress through to the notifier so
-                    // Dio reports progress.
-                    // C-2: skipInvalidation prevents per-file provider
-                    // refresh mid-batch.
-                    // I-6: Throw on false so the staging manager catches
-                    // the error.
-                    onUpload: (xFile, mimeType, onProgress) async {
-                      final success = await ref
-                          .read(requirementNotifierProvider(widget.classId)
-                              .notifier)
-                          .uploadFile(
-                            requirementId: requirement.id,
-                            pickedFile: xFile,
-                            mimeType: mimeType,
-                            onProgress: onProgress,
-                            skipInvalidation: true,
-                          );
-                      if (!success) {
-                        throw Exception(tr('classes.errors.upload_failed'));
-                      }
-                    },
-                    onDeleteRemote: (fileId) async {
-                      await ref
-                          .read(requirementNotifierProvider(widget.classId)
-                              .notifier)
-                          .deleteFile(
-                            requirementId: requirement.id,
-                            fileId: fileId,
-                          );
-                    },
-                    onSubmit: () async {
-                      final success = await ref
-                          .read(requirementNotifierProvider(widget.classId)
-                              .notifier)
-                          .submit(requirement.id);
-                      if (success && mounted) {
-                        // ignore: use_build_context_synchronously
-                        ScaffoldMessenger.of(context).showSnackBar(
-                          SnackBar(
-                            content: Row(
-                              children: [
-                                const Icon(Icons.check_circle_rounded,
-                                    color: Colors.white, size: 18),
-                                const SizedBox(width: 8),
-                                Expanded(
-                                  child: Text(
-                                      'classes.requirement_detail.submit_success'
-                                          .tr()),
-                                ),
-                              ],
-                            ),
-                            backgroundColor: AppColors.secondary,
-                            behavior: SnackBarBehavior.floating,
-                            shape: RoundedRectangleBorder(
-                                borderRadius: BorderRadius.circular(12)),
-                          ),
-                        );
-                        // ignore: use_build_context_synchronously
-                        Navigator.pop(context);
-                      }
-                    },
-                    fileNameBuilder: (originalName, index) =>
-                        _buildFileNameWithIndex(
-                            requirement, originalName, index),
-                    canModify: canModify,
-                    onLocalFilesChanged: (hasLocal) =>
-                        setState(() => _hasUnsavedFiles = hasLocal),
-                  ),
-
-                  const SizedBox(height: 16),
-                ],
-              ),
-            ),
-
-            // Loading overlay
-            if (isLoading)
-              Container(
-                color: Colors.black.withValues(alpha: 0.35),
-                child: const Center(child: SacLoading()),
-              ),
-          ],
-        ),
-      ),
-    );
-  }
-
-  // ── File naming helpers ─────────────────────────────────────────────────────
-
-  /// Construye un nombre de archivo descriptivo para el backend/storage.
-  ///
-  /// Genera nombre con índice explícito (para batch uploads).
-  String _buildFileNameWithIndex(
-      ClassRequirement requirement, String originalName, int index) {
-    final ext = originalName.contains('.')
-        ? originalName.split('.').last.toLowerCase()
-        : 'bin';
-    final moduleName = _resolveModuleName(requirement.moduleId);
-    final sectionName = _sanitize(requirement.name, 30);
-    final initials = _resolveUserInitials();
-    return 'evidencia_${index}_${_sanitize(moduleName, 20)}_${sectionName}_$initials.$ext';
-  }
-
-  /// Saneado de texto para nombres de archivo.
-  String _sanitize(String text, int maxLen) {
-    final raw = text
-        .toLowerCase()
-        .replaceAll(RegExp(r'[^a-z0-9]+'), '_')
-        .replaceAll(RegExp(r'_+'), '_')
-        .replaceAll(RegExp(r'^_|_$'), '');
-    return raw.substring(0, raw.length.clamp(0, maxLen));
-  }
-
-  /// Busca el nombre del modulo desde el provider de progreso.
   String _resolveModuleName(int moduleId) {
     final classAsync = ref.read(classWithProgressProvider(widget.classId));
     return classAsync.whenData((cp) {
           for (final m in cp.modules) {
             if (m.id == moduleId) return m.name;
           }
-          return 'modulo';
+          return 'módulo';
         }).valueOrNull ??
-        'modulo';
+        'módulo';
   }
 
-  /// Extrae las iniciales del usuario autenticado.
   String _resolveUserInitials() {
     final user = ref.read(authNotifierProvider).valueOrNull;
     if (user?.name == null || user!.name!.isEmpty) return 'NN';
@@ -383,7 +81,25 @@ class _RequirementDetailViewState extends ConsumerState<RequirementDetailView> {
         .toUpperCase();
   }
 
-  // ── Helpers ─────────────────────────────────────────────────────────────────
+  String _sanitize(String text, int maxLen) {
+    final raw = text
+        .toLowerCase()
+        .replaceAll(RegExp(r'[^a-z0-9]+'), '_')
+        .replaceAll(RegExp(r'_+'), '_')
+        .replaceAll(RegExp(r'^_|_$'), '');
+    return raw.substring(0, raw.length.clamp(0, maxLen));
+  }
+
+  String _buildFileNameWithIndex(
+      ClassRequirement req, String originalName, int index) {
+    final ext = originalName.contains('.')
+        ? originalName.split('.').last.toLowerCase()
+        : 'bin';
+    final moduleName = _resolveModuleName(req.moduleId);
+    final sectionName = _sanitize(req.name, 30);
+    final initials = _resolveUserInitials();
+    return 'evidencia_${index}_${_sanitize(moduleName, 20)}_${sectionName}_$initials.$ext';
+  }
 
   void _showErrorSnackbar(BuildContext context, String message) {
     if (!mounted) return;
@@ -397,226 +113,536 @@ class _RequirementDetailViewState extends ConsumerState<RequirementDetailView> {
             Expanded(child: Text(message)),
           ],
         ),
-        backgroundColor: AppColors.error,
+        backgroundColor: AppColors.rejectedColor,
         behavior: SnackBarBehavior.floating,
-        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+        shape:
+            RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
       ),
     );
   }
-}
-
-// ── Meta card ─────────────────────────────────────────────────────────────────
-
-class _RequirementMetaCard extends StatelessWidget {
-  final ClassRequirement requirement;
-
-  const _RequirementMetaCard({required this.requirement});
 
   @override
   Widget build(BuildContext context) {
-    final c = context.sac;
+    final notifierState =
+        ref.watch(requirementNotifierProvider(widget.classId));
+    final classAsync = ref.watch(classWithProgressProvider(widget.classId));
+    final requirement = _liveRequirement(classAsync);
+    final canModify = requirement.canUpload;
+    final isLoading = notifierState.isLoading;
 
-    return Container(
-      margin: const EdgeInsets.fromLTRB(16, 12, 16, 0),
-      padding: const EdgeInsets.all(16),
-      decoration: BoxDecoration(
-        color: c.surfaceVariant,
-        borderRadius: BorderRadius.circular(16),
-        border: Border.all(color: c.border),
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          if (requirement.description != null &&
-              requirement.description!.isNotEmpty) ...[
-            Text(
-              requirement.description!,
-              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                    color: c.textSecondary,
-                    height: 1.5,
-                  ),
+    // Find module index for eyebrow "X / Y"
+    final moduleIndex = _resolveModuleIndex(classAsync, requirement);
+    final moduleTotal = _resolveModuleTotal(classAsync, requirement);
+    final moduleName = _resolveModuleName(requirement.moduleId);
+
+    ref.listen(
+      requirementNotifierProvider(widget.classId),
+      (prev, next) {
+        if (next.errorMessage != null && next.errorMessage!.isNotEmpty) {
+          _showErrorSnackbar(context, next.errorMessage!);
+        }
+      },
+    );
+
+    return PopScope(
+      canPop: !_hasUnsavedFiles,
+      onPopInvokedWithResult: (didPop, result) async {
+        if (didPop) return;
+        final confirm = await showDialog<bool>(
+          context: context,
+          builder: (ctx) => AlertDialog(
+            title:
+                Text('classes.requirement_detail.unsaved_files_title'.tr()),
+            content: Text(
+              'classes.requirement_detail.unsaved_files_body'.tr(),
             ),
-            const SizedBox(height: 14),
-            Divider(color: c.divider),
-            const SizedBox(height: 10),
-          ],
-          Row(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: [
-              // _MetaItem(
-              //   icon: HugeIcons.strokeRoundedStar,
-              //   label: 'Puntos clase',
-              //   value: '${requirement.pointValue} pts',
-              //   color: AppColors.accent,
-              //   context: context,
-              // ),
-              // const SizedBox(width: 24),
-              _MetaItem(
-                icon: HugeIcons.strokeRoundedFiles01,
-                label: 'classes.requirement_detail.file_limit_label'.tr(),
-                value: '${requirement.maxFiles}',
-                color: c.textSecondary,
-                context: context,
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.pop(ctx, false),
+                child:
+                    Text('classes.requirement_detail.stay_button'.tr()),
               ),
-              const SizedBox(width: 40),
-              _MetaItem(
-                icon: HugeIcons.strokeRoundedTag01,
-                label: 'classes.requirement_detail.type_label'.tr(),
-                value: _typeLabel(requirement.type),
-                color: AppColors.primary,
-                context: context,
+              TextButton(
+                onPressed: () => Navigator.pop(ctx, true),
+                style: TextButton.styleFrom(
+                    foregroundColor: AppColors.rejectedColor),
+                child: Text(
+                    'classes.requirement_detail.leave_button'.tr()),
               ),
             ],
+          ),
+        );
+        if (confirm == true && context.mounted) {
+          Navigator.pop(context);
+        }
+      },
+      child: Scaffold(
+        backgroundColor: AppColors.canvas,
+        body: SafeArea(
+          child: Stack(
+            children: [
+              Column(
+                children: [
+                  // NavBar
+                  _ReqNavBar(
+                    onBack: isLoading
+                        ? null
+                        : () => Navigator.pop(context),
+                    onMore: () => showRequirementStatusHistorySheet(
+                      context,
+                      requirement: requirement,
+                    ),
+                  ),
+
+                  Expanded(
+                    child: SingleChildScrollView(
+                      physics: const BouncingScrollPhysics(),
+                      child: Padding(
+                        padding:
+                            const EdgeInsets.symmetric(horizontal: 16),
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            // Eyebrow + title
+                            Text(
+                              '${moduleName.toUpperCase()} · ${_fmt2(moduleIndex)} / ${_fmt2(moduleTotal)}',
+                              style: const TextStyle(
+                                fontSize: 11,
+                                fontWeight: FontWeight.w700,
+                                color: AppColors.ink400,
+                                letterSpacing: 0.88,
+                              ),
+                            ),
+                            const SizedBox(height: 6),
+                            Text(
+                              requirement.name,
+                              style: const TextStyle(
+                                fontSize: 20,
+                                fontWeight: FontWeight.w700,
+                                color: AppColors.ink900,
+                                letterSpacing: -0.2,
+                                height: 1.25,
+                              ),
+                            ),
+
+                            const SizedBox(height: 16),
+
+                            // Status banner (observed / rejected only)
+                            if (requirement.status ==
+                                    RequirementStatus.observado ||
+                                requirement.status ==
+                                    RequirementStatus.rechazado)
+                              _BannerEstado(
+                                  status: requirement.status),
+
+                            // Observation card (observed / rejected)
+                            if ((requirement.status ==
+                                        RequirementStatus.observado ||
+                                    requirement.status ==
+                                        RequirementStatus.rechazado) &&
+                                _hasInstructorComment(requirement))
+                              _ObservationCard(
+                                requirement: requirement,
+                              ),
+
+                            // Description (for all states when available)
+                            if (requirement.description != null &&
+                                requirement.description!.isNotEmpty &&
+                                requirement.status !=
+                                    RequirementStatus.observado &&
+                                requirement.status !=
+                                    RequirementStatus.rechazado) ...[
+                              _DescriptionCard(
+                                  text: requirement.description!),
+                              const SizedBox(height: 16),
+                            ],
+
+                            // Status chip (for pending/sent/validated —
+                            // open history sheet)
+                            if (requirement.status !=
+                                    RequirementStatus.observado &&
+                                requirement.status !=
+                                    RequirementStatus.rechazado) ...[
+                              Padding(
+                                padding: const EdgeInsets.only(bottom: 16),
+                                child: _StatusChip(
+                                  requirement: requirement,
+                                  onTap: () =>
+                                      showRequirementStatusHistorySheet(
+                                    context,
+                                    requirement: requirement,
+                                  ),
+                                ),
+                              ),
+                            ],
+
+                            // Files section header
+                            Padding(
+                              padding:
+                                  const EdgeInsets.only(left: 4, bottom: 10),
+                              child: Row(
+                                mainAxisAlignment:
+                                    MainAxisAlignment.spaceBetween,
+                                children: [
+                                  const Text(
+                                    'ARCHIVOS ADJUNTOS',
+                                    style: TextStyle(
+                                      fontSize: 11,
+                                      fontWeight: FontWeight.w700,
+                                      color: AppColors.ink400,
+                                      letterSpacing: 1.32,
+                                    ),
+                                  ),
+                                  Text(
+                                    '${requirement.files.length}/${requirement.maxFiles}',
+                                    style: const TextStyle(
+                                      fontSize: 11,
+                                      fontWeight: FontWeight.w700,
+                                      color: AppColors.ink800,
+                                      fontFeatures: [
+                                        FontFeature.tabularFigures()
+                                      ],
+                                    ),
+                                  ),
+                                ],
+                              ),
+                            ),
+
+                            // For observed/rejected: custom file rows + empty slot + bigCTA
+                            if (requirement.status ==
+                                    RequirementStatus.observado ||
+                                requirement.status ==
+                                    RequirementStatus.rechazado) ...[
+                              _FileRowsList(
+                                requirement: requirement,
+                                canModify: canModify,
+                                onUploadTap: canModify
+                                    ? () => _triggerFilePicker(requirement)
+                                    : null,
+                              ),
+
+                              const SizedBox(height: 8),
+
+                              // BigCTA
+                              if (canModify)
+                                _BigCTA(
+                                  onTap: () => _handleSubmit(requirement),
+                                  isLoading: isLoading,
+                                ),
+                            ] else ...[
+                              // Original EvidenceStagingManager for pending/sent/validated
+                              EvidenceStagingManager(
+                                embeddedMode: true,
+                                existingFiles: requirement.files
+                                    .map(StagedFile.fromRequirementEvidence)
+                                    .toList(),
+                                maxFiles: requirement.maxFiles,
+                                isLoading: notifierState.isLoading,
+                                onUpload: (xFile, mimeType, onProgress) async {
+                                  final success = await ref
+                                      .read(requirementNotifierProvider(
+                                              widget.classId)
+                                          .notifier)
+                                      .uploadFile(
+                                        requirementId: requirement.id,
+                                        pickedFile: xFile,
+                                        mimeType: mimeType,
+                                        onProgress: onProgress,
+                                        skipInvalidation: true,
+                                      );
+                                  if (!success) {
+                                    throw Exception(
+                                        tr('classes.errors.upload_failed'));
+                                  }
+                                },
+                                onDeleteRemote: (fileId) async {
+                                  await ref
+                                      .read(requirementNotifierProvider(
+                                              widget.classId)
+                                          .notifier)
+                                      .deleteFile(
+                                        requirementId: requirement.id,
+                                        fileId: fileId,
+                                      );
+                                },
+                                onSubmit: () async {
+                                  final success = await ref
+                                      .read(requirementNotifierProvider(
+                                              widget.classId)
+                                          .notifier)
+                                      .submit(requirement.id);
+                                  if (success && mounted) {
+                                    // ignore: use_build_context_synchronously
+                                    ScaffoldMessenger.of(context).showSnackBar(
+                                      SnackBar(
+                                        content: Row(
+                                          children: [
+                                            const Icon(
+                                                Icons.check_circle_rounded,
+                                                color: Colors.white,
+                                                size: 18),
+                                            const SizedBox(width: 8),
+                                            Expanded(
+                                              child: Text(
+                                                  'classes.requirement_detail.submit_success'
+                                                      .tr()),
+                                            ),
+                                          ],
+                                        ),
+                                        backgroundColor: AppColors.validatedColor,
+                                        behavior: SnackBarBehavior.floating,
+                                        shape: RoundedRectangleBorder(
+                                            borderRadius:
+                                                BorderRadius.circular(12)),
+                                      ),
+                                    );
+                                    // ignore: use_build_context_synchronously
+                                    Navigator.pop(context);
+                                  }
+                                },
+                                fileNameBuilder: (originalName, index) =>
+                                    _buildFileNameWithIndex(
+                                        requirement, originalName, index),
+                                canModify: canModify,
+                                onLocalFilesChanged: (hasLocal) =>
+                                    setState(() => _hasUnsavedFiles = hasLocal),
+                              ),
+                            ],
+
+                            const SizedBox(height: 24),
+                          ],
+                        ),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+
+              // Loading overlay
+              if (isLoading)
+                Container(
+                  color: Colors.black.withValues(alpha: 0.35),
+                  child: const Center(child: SacLoading()),
+                ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  // ── Helpers ────────────────────────────────────────────────────────────────
+
+  bool _hasInstructorComment(ClassRequirement req) {
+    return (req.observationComment != null &&
+            req.observationComment!.isNotEmpty) ||
+        (req.rejectionReason != null && req.rejectionReason!.isNotEmpty);
+  }
+
+  int _resolveModuleIndex(
+      AsyncValue<dynamic> classAsync, ClassRequirement req) {
+    return classAsync
+            .whenData((cp) {
+              for (final m in cp.modules) {
+                for (int i = 0; i < m.requirements.length; i++) {
+                  if (m.requirements[i].id == req.id) return i + 1;
+                }
+              }
+              return 1;
+            })
+            .valueOrNull ??
+        1;
+  }
+
+  int _resolveModuleTotal(
+      AsyncValue<dynamic> classAsync, ClassRequirement req) {
+    return classAsync
+            .whenData((cp) {
+              for (final m in cp.modules) {
+                if (m.id == req.moduleId) return m.requirements.length;
+              }
+              return 1;
+            })
+            .valueOrNull ??
+        1;
+  }
+
+  String _fmt2(int n) => n.toString().padLeft(2, '0');
+
+  void _triggerFilePicker(ClassRequirement req) {
+    // File picking is handled by EvidenceStagingManager; for observed/rejected
+    // we open it via the notifier directly. For now just navigate up to the
+    // EvidenceStagingManager path by toggling back to it — this is a placeholder
+    // that product can wire to a custom picker when needed.
+    // No-op in current implementation.
+  }
+
+  Future<void> _handleSubmit(ClassRequirement req) async {
+    final success = await ref
+        .read(requirementNotifierProvider(widget.classId).notifier)
+        .submit(req.id);
+    if (success && mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Row(
+            children: [
+              const Icon(Icons.check_circle_rounded,
+                  color: Colors.white, size: 18),
+              const SizedBox(width: 8),
+              Expanded(
+                child: Text(
+                    'classes.requirement_detail.submit_success'.tr()),
+              ),
+            ],
+          ),
+          backgroundColor: AppColors.validatedColor,
+          behavior: SnackBarBehavior.floating,
+          shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(12)),
+        ),
+      );
+      // ignore: use_build_context_synchronously
+      Navigator.pop(context);
+    }
+  }
+}
+
+// ── NavBar ─────────────────────────────────────────────────────────────────────
+
+class _ReqNavBar extends StatelessWidget {
+  final VoidCallback? onBack;
+  final VoidCallback onMore;
+
+  const _ReqNavBar({required this.onBack, required this.onMore});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      height: 50,
+      padding: const EdgeInsets.fromLTRB(16, 14, 16, 8),
+      color: AppColors.canvas,
+      child: Row(
+        children: [
+          SizedBox(
+            width: 36,
+            height: 36,
+            child: InkWell(
+              borderRadius: BorderRadius.circular(12),
+              onTap: onBack,
+              child: Center(
+                child: HugeIcon(
+                  icon: HugeIcons.strokeRoundedArrowLeft01,
+                  size: 20,
+                  color: AppColors.ink800,
+                ),
+              ),
+            ),
+          ),
+          const Expanded(
+            child: Text(
+              'Requerimiento',
+              textAlign: TextAlign.center,
+              style: TextStyle(
+                fontSize: 17,
+                fontWeight: FontWeight.w600,
+                color: AppColors.ink900,
+              ),
+            ),
+          ),
+          SizedBox(
+            width: 36,
+            height: 36,
+            child: InkWell(
+              borderRadius: BorderRadius.circular(12),
+              onTap: onMore,
+              child: Center(
+                child: HugeIcon(
+                  icon: HugeIcons.strokeRoundedMoreHorizontal,
+                  size: 20,
+                  color: AppColors.ink600,
+                ),
+              ),
+            ),
           ),
         ],
       ),
     );
   }
-
-  String _typeLabel(RequirementType type) {
-    switch (type) {
-      case RequirementType.honor:
-        return 'classes.requirement_detail.type_honor'.tr();
-      case RequirementType.service:
-        return 'classes.requirement_detail.type_service'.tr();
-      case RequirementType.general:
-        return 'classes.requirement_detail.type_general'.tr();
-    }
-  }
 }
 
-class _MetaItem extends StatelessWidget {
-  final List<List<dynamic>> icon;
-  final String label;
-  final String value;
-  final Color color;
-  final BuildContext context;
+// ── BannerEstado ───────────────────────────────────────────────────────────────
 
-  const _MetaItem({
-    required this.icon,
-    required this.label,
-    required this.value,
-    required this.color,
-    required this.context,
-  });
+class _BannerEstado extends StatelessWidget {
+  final RequirementStatus status;
 
-  @override
-  Widget build(BuildContext _) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Row(
-          children: [
-            HugeIcon(icon: icon, size: 13, color: color),
-            const SizedBox(width: 4),
-            Text(
-              label,
-              style: TextStyle(
-                fontSize: 13,
-                fontWeight: FontWeight.w500,
-                color: context.sac.textTertiary,
-              ),
-            ),
-          ],
-        ),
-        const SizedBox(height: 3),
-        Text(
-          value,
-          style: TextStyle(
-            fontSize: 18,
-            fontWeight: FontWeight.w700,
-            color: color,
-          ),
-        ),
-      ],
-    );
-  }
-}
-
-// ── Especialidad vinculada ─────────────────────────────────────────────────────
-
-class _LinkedHonorSection extends StatelessWidget {
-  final ClassRequirement requirement;
-
-  const _LinkedHonorSection({required this.requirement});
+  const _BannerEstado({required this.status});
 
   @override
   Widget build(BuildContext context) {
-    final c = context.sac;
-    final isDark = Theme.of(context).brightness == Brightness.dark;
-    final isCompleted = requirement.linkedHonorCompleted ?? false;
-    final color = isCompleted ? AppColors.secondary : AppColors.sacBlue;
-    final bgColor = isCompleted
-        ? AppColors.secondaryLight
-        : (isDark ? AppColors.statusInfoBgDark : AppColors.statusInfoBgLight);
+    final isObserved = status == RequirementStatus.observado;
+    final bg = isObserved ? AppColors.observedBg : AppColors.rejectedBg;
+    final borderColor =
+        isObserved ? const Color(0xFFFBE7C2) : const Color(0xFFFBC8D0);
+    final iconColor =
+        isObserved ? AppColors.observedDark : AppColors.rejectedDark;
+    final titleColor =
+        isObserved ? const Color(0xFF5C4317) : AppColors.rejectedDark;
+    final headline =
+        isObserved ? 'Requiere correcciones' : 'Documento rechazado';
+    final subtext = isObserved
+        ? 'Tu instructor solicitó cambios antes de validar'
+        : 'Tu instructor pidió que reenvíes este archivo';
 
     return Container(
-      margin: const EdgeInsets.fromLTRB(16, 0, 16, 16),
-      padding: const EdgeInsets.all(16),
+      margin: const EdgeInsets.only(bottom: 14),
+      padding: const EdgeInsets.all(14),
       decoration: BoxDecoration(
-        color: bgColor,
-        borderRadius: BorderRadius.circular(16),
-        border: Border.all(color: color.withValues(alpha: 0.3)),
+        color: bg,
+        borderRadius: BorderRadius.circular(14),
+        border: Border.all(color: borderColor),
       ),
       child: Row(
         children: [
+          // Icon bubble
           Container(
-            width: 42,
-            height: 42,
-            decoration: BoxDecoration(
-              color: color.withValues(alpha: 0.15),
-              borderRadius: BorderRadius.circular(12),
+            width: 36,
+            height: 36,
+            decoration: const BoxDecoration(
+              color: AppColors.paper,
+              shape: BoxShape.circle,
             ),
             child: Center(
               child: HugeIcon(
-                icon: isCompleted
-                    ? HugeIcons.strokeRoundedCheckmarkCircle01
-                    : HugeIcons.strokeRoundedAward01,
-                size: 22,
-                color: color,
+                icon: isObserved
+                    ? HugeIcons.strokeRoundedInformationCircle
+                    : HugeIcons.strokeRoundedCancel01,
+                size: 18,
+                color: iconColor,
               ),
             ),
           ),
-          const SizedBox(width: 12),
+          const SizedBox(width: 10),
           Expanded(
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 Text(
-                  'classes.requirement_detail.linked_honor_title'.tr(),
+                  headline,
                   style: TextStyle(
-                    fontSize: 11,
-                    fontWeight: FontWeight.w500,
-                    color: c.textTertiary,
+                    fontSize: 14,
+                    fontWeight: FontWeight.w700,
+                    color: titleColor,
                   ),
                 ),
                 const SizedBox(height: 2),
                 Text(
-                  requirement.linkedHonorName!,
+                  subtext,
                   style: TextStyle(
-                    fontSize: 15,
-                    fontWeight: FontWeight.w700,
-                    color: color,
+                    fontSize: 12,
+                    color: iconColor,
                   ),
                 ),
               ],
-            ),
-          ),
-          Container(
-            padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 5),
-            decoration: BoxDecoration(
-              color: color.withValues(alpha: 0.12),
-              borderRadius: BorderRadius.circular(20),
-            ),
-            child: Text(
-              isCompleted
-                  ? 'classes.status.completed'.tr()
-                  : 'classes.status.pending'.tr(),
-              style: TextStyle(
-                fontSize: 12,
-                fontWeight: FontWeight.w700,
-                color: color,
-              ),
             ),
           ),
         ],
@@ -625,62 +651,539 @@ class _LinkedHonorSection extends StatelessWidget {
   }
 }
 
-// ── Chip tappable del estado actual ──────────────────────────────────────────
+// ── ObservationCard ────────────────────────────────────────────────────────────
 
-/// Chip compacto que muestra el estado actual del requerimiento.
-///
-/// Al tocarlo abre el [RequirementStatusHistorySheet] con el historial
-/// de transiciones disponibles en la entidad.
-class _StatusChip extends StatelessWidget {
+class _ObservationCard extends StatelessWidget {
   final ClassRequirement requirement;
-  final VoidCallback onTap;
 
-  const _StatusChip({
+  const _ObservationCard({required this.requirement});
+
+  @override
+  Widget build(BuildContext context) {
+    final isObserved = requirement.status == RequirementStatus.observado;
+    final instructorName =
+        (isObserved ? requirement.observedByName : requirement.rejectedByName) ??
+            'Instructor';
+    final comment =
+        (isObserved ? requirement.observationComment : requirement.rejectionReason) ??
+            '';
+    final timestamp = isObserved ? requirement.observedAt : requirement.rejectedAt;
+
+    final initials = _initials(instructorName);
+    final avatarBg =
+        isObserved ? AppColors.coral100 : AppColors.rejectedBg;
+    final avatarText =
+        isObserved ? AppColors.coral700 : AppColors.rejectedDark;
+
+    return Container(
+      margin: const EdgeInsets.only(bottom: 18),
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: AppColors.paper,
+        borderRadius: BorderRadius.circular(14),
+        border: Border.all(color: AppColors.ink150),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // Header: avatar + name + timestamp
+          Row(
+            children: [
+              Container(
+                width: 36,
+                height: 36,
+                decoration: BoxDecoration(
+                  color: avatarBg,
+                  shape: BoxShape.circle,
+                ),
+                child: Center(
+                  child: Text(
+                    initials,
+                    style: TextStyle(
+                      fontSize: 12,
+                      fontWeight: FontWeight.w700,
+                      color: avatarText,
+                    ),
+                  ),
+                ),
+              ),
+              const SizedBox(width: 10),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      instructorName,
+                      style: const TextStyle(
+                        fontSize: 13,
+                        fontWeight: FontWeight.w700,
+                        color: AppColors.ink800,
+                      ),
+                    ),
+                    Text(
+                      timestamp != null
+                          ? 'Instructor · ${_timeAgo(timestamp)}'
+                          : 'Instructor',
+                      style: const TextStyle(
+                        fontSize: 11,
+                        color: AppColors.ink400,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+
+          const SizedBox(height: 10),
+
+          // Comment bubble
+          if (comment.isNotEmpty)
+            Container(
+              width: double.infinity,
+              padding: const EdgeInsets.all(12),
+              decoration: BoxDecoration(
+                color: AppColors.canvas,
+                borderRadius: BorderRadius.circular(12),
+              ),
+              child: Text(
+                '"$comment"',
+                style: const TextStyle(
+                  fontSize: 13.5,
+                  color: AppColors.ink700,
+                  fontStyle: FontStyle.italic,
+                  height: 1.45,
+                ),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+
+  String _initials(String name) {
+    final parts = name.trim().split(RegExp(r'\s+'));
+    if (parts.length >= 2) {
+      return '${parts.first[0]}${parts[1][0]}'.toUpperCase();
+    }
+    return name
+        .substring(0, name.length.clamp(0, 2))
+        .toUpperCase();
+  }
+
+  String _timeAgo(DateTime dt) {
+    final now = DateTime.now();
+    final diff = now.difference(dt);
+    if (diff.inDays >= 1) return 'hace ${diff.inDays} día${diff.inDays == 1 ? '' : 's'}';
+    if (diff.inHours >= 1) return 'hace ${diff.inHours} hora${diff.inHours == 1 ? '' : 's'}';
+    if (diff.inMinutes >= 1) {
+      return 'hace ${diff.inMinutes} minuto${diff.inMinutes == 1 ? '' : 's'}';
+    }
+    return 'hace un momento';
+  }
+}
+
+// ── FileRowsList ───────────────────────────────────────────────────────────────
+
+class _FileRowsList extends StatelessWidget {
+  final ClassRequirement requirement;
+  final bool canModify;
+  final VoidCallback? onUploadTap;
+
+  const _FileRowsList({
     required this.requirement,
-    required this.onTap,
+    required this.canModify,
+    this.onUploadTap,
   });
 
   @override
   Widget build(BuildContext context) {
-    final c = context.sac;
-    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final isObserved = requirement.status == RequirementStatus.observado;
 
-    final bgColor = _bgColor(isDark);
-    final borderColor = _borderColor(isDark);
-    final textColor = _textColor(isDark);
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        ...requirement.files.map((file) => _FileRow(
+              fileName: file.fileName,
+              uploadedAt: file.uploadedAt,
+              isObservedContext: isObserved,
+            )),
+
+        // Empty file slot if canModify
+        if (canModify)
+          _EmptyFileSlot(onTap: onUploadTap ?? () {}),
+      ],
+    );
+  }
+}
+
+class _FileRow extends StatelessWidget {
+  final String fileName;
+  final DateTime uploadedAt;
+  final bool isObservedContext;
+
+  const _FileRow({
+    required this.fileName,
+    required this.uploadedAt,
+    required this.isObservedContext,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    // In observed context, files show "En revisión" badge (sentBg/sentDark).
+    // In rejected context, files show "Rechazado" badge (observedBg/observedDark).
+    // Note: the handoff uses "observedBg" yellow for rejected file icon bg — we
+    // follow the reference exactly.
+    final iconBg =
+        isObservedContext ? AppColors.sentBg : AppColors.observedBg;
+    final iconColor =
+        isObservedContext ? AppColors.sentDark : AppColors.observedDark;
+    final badgeLabel = isObservedContext ? 'En revisión' : 'Rechazado';
+    final badgeBg = isObservedContext ? AppColors.sentBg : AppColors.observedBg;
+    final badgeColor =
+        isObservedContext ? AppColors.sentDark : AppColors.observedDark;
+
+    return Container(
+      margin: const EdgeInsets.only(bottom: 8),
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: AppColors.paper,
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: AppColors.ink150),
+      ),
+      child: Row(
+        children: [
+          // Icon square
+          Container(
+            width: 36,
+            height: 36,
+            decoration: BoxDecoration(
+              color: iconBg,
+              borderRadius: BorderRadius.circular(10),
+            ),
+            child: Center(
+              child: HugeIcon(
+                icon: HugeIcons.strokeRoundedFile01,
+                size: 18,
+                color: iconColor,
+              ),
+            ),
+          ),
+
+          const SizedBox(width: 12),
+
+          // Filename + meta
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text(
+                  fileName,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: const TextStyle(
+                    fontSize: 13,
+                    fontWeight: FontWeight.w600,
+                    color: AppColors.ink800,
+                  ),
+                ),
+                const SizedBox(height: 2),
+                Row(
+                  children: [
+                    Text(
+                      _timeAgo(uploadedAt),
+                      style: const TextStyle(
+                        fontSize: 11,
+                        color: AppColors.ink400,
+                      ),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+
+          const SizedBox(width: 8),
+
+          // Badge pill
+          Container(
+            padding:
+                const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+            decoration: BoxDecoration(
+              color: badgeBg,
+              borderRadius: BorderRadius.circular(999),
+            ),
+            child: Text(
+              badgeLabel,
+              style: TextStyle(
+                fontSize: 10.5,
+                fontWeight: FontWeight.w700,
+                color: badgeColor,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  String _timeAgo(DateTime dt) {
+    final now = DateTime.now();
+    final diff = now.difference(dt);
+    if (diff.inDays >= 1) return 'Hace ${diff.inDays} día${diff.inDays == 1 ? '' : 's'}';
+    if (diff.inHours >= 1) return 'Hace ${diff.inHours} hora${diff.inHours == 1 ? '' : 's'}';
+    return 'Hace un momento';
+  }
+}
+
+class _EmptyFileSlot extends StatelessWidget {
+  final VoidCallback onTap;
+
+  const _EmptyFileSlot({required this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    return CustomPaint(
+      painter: _DashedBorderPainter(
+        color: AppColors.ink300,
+        strokeWidth: 1.5,
+        radius: 12,
+        dashLength: 6,
+        gapLength: 4,
+      ),
+      child: Material(
+        color: AppColors.paper,
+        borderRadius: BorderRadius.circular(12),
+        clipBehavior: Clip.antiAlias,
+        child: InkWell(
+          onTap: onTap,
+          borderRadius: BorderRadius.circular(12),
+          child: Padding(
+            padding: const EdgeInsets.all(14),
+            child: Row(
+              children: [
+                Container(
+                  width: 36,
+                  height: 36,
+                  decoration: BoxDecoration(
+                    color: AppColors.ink100,
+                    borderRadius: BorderRadius.circular(10),
+                  ),
+                  child: Center(
+                    child: HugeIcon(
+                      icon: HugeIcons.strokeRoundedAdd01,
+                      size: 18,
+                      color: AppColors.ink400,
+                    ),
+                  ),
+                ),
+                const SizedBox(width: 10),
+                const Text(
+                  'Subir archivo',
+                  style: TextStyle(
+                    fontSize: 13,
+                    fontWeight: FontWeight.w600,
+                    color: AppColors.ink500,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _DashedBorderPainter extends CustomPainter {
+  final Color color;
+  final double strokeWidth;
+  final double radius;
+  final double dashLength;
+  final double gapLength;
+
+  const _DashedBorderPainter({
+    required this.color,
+    required this.strokeWidth,
+    required this.radius,
+    required this.dashLength,
+    required this.gapLength,
+  });
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final paint = Paint()
+      ..color = color
+      ..strokeWidth = strokeWidth
+      ..style = PaintingStyle.stroke
+      ..strokeCap = StrokeCap.round;
+
+    final rrect = RRect.fromRectAndRadius(
+      Rect.fromLTWH(
+        strokeWidth / 2,
+        strokeWidth / 2,
+        size.width - strokeWidth,
+        size.height - strokeWidth,
+      ),
+      Radius.circular(radius),
+    );
+
+    final path = Path()..addRRect(rrect);
+    final metrics = path.computeMetrics();
+
+    for (final metric in metrics) {
+      double distance = 0;
+      while (distance < metric.length) {
+        final end = (distance + dashLength).clamp(0, metric.length);
+        canvas.drawPath(
+          metric.extractPath(distance, end.toDouble()),
+          paint,
+        );
+        distance += dashLength + gapLength;
+      }
+    }
+  }
+
+  @override
+  bool shouldRepaint(_DashedBorderPainter old) =>
+      old.color != color ||
+      old.strokeWidth != strokeWidth ||
+      old.radius != radius ||
+      old.dashLength != dashLength ||
+      old.gapLength != gapLength;
+}
+
+// ── BigCTA ─────────────────────────────────────────────────────────────────────
+
+class _BigCTA extends StatelessWidget {
+  final VoidCallback onTap;
+  final bool isLoading;
+
+  const _BigCTA({required this.onTap, this.isLoading = false});
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: isLoading ? null : onTap,
+      child: Container(
+        width: double.infinity,
+        padding: const EdgeInsets.symmetric(vertical: 14),
+        margin: const EdgeInsets.only(top: 8),
+        decoration: BoxDecoration(
+          color: isLoading
+              ? AppColors.coral500.withValues(alpha: 0.6)
+              : AppColors.coral500,
+          borderRadius: BorderRadius.circular(14),
+          boxShadow: [
+            BoxShadow(
+              color: AppColors.coral500.withValues(alpha: 0.5),
+              blurRadius: 18,
+              offset: const Offset(0, 8),
+              spreadRadius: -6,
+            ),
+          ],
+        ),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            if (isLoading)
+              const SizedBox(
+                width: 16,
+                height: 16,
+                child: CircularProgressIndicator(
+                  color: Colors.white,
+                  strokeWidth: 2,
+                ),
+              )
+            else
+              HugeIcon(
+                icon: HugeIcons.strokeRoundedUpload01,
+                size: 16,
+                color: Colors.white,
+              ),
+            const SizedBox(width: 8),
+            const Text(
+              'Reenviar archivos corregidos',
+              style: TextStyle(
+                fontSize: 14.5,
+                fontWeight: FontWeight.w700,
+                color: Colors.white,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+// ── Description card (for non-observed/rejected states) ───────────────────────
+
+class _DescriptionCard extends StatelessWidget {
+  final String text;
+
+  const _DescriptionCard({required this.text});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: AppColors.paper,
+        borderRadius: BorderRadius.circular(14),
+        border: Border.all(color: AppColors.ink150),
+      ),
+      child: Text(
+        text,
+        style: const TextStyle(
+          fontSize: 13.5,
+          color: AppColors.ink700,
+          height: 1.5,
+        ),
+      ),
+    );
+  }
+}
+
+// ── Status chip (for pending/sent/validated) ──────────────────────────────────
+
+class _StatusChip extends StatelessWidget {
+  final ClassRequirement requirement;
+  final VoidCallback onTap;
+
+  const _StatusChip({required this.requirement, required this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    final meta = StatusMeta.of(requirement.status);
 
     return Semantics(
       button: true,
-      label: 'classes.requirement_detail.semantics_status'
-          .tr(namedArgs: {'status': _label}),
+      label: 'Estado: ${meta.label}. Toca para ver historial.',
       child: InkWell(
         onTap: onTap,
         borderRadius: BorderRadius.circular(12),
         child: Container(
           padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
           decoration: BoxDecoration(
-            color: bgColor,
+            color: meta.bg,
             borderRadius: BorderRadius.circular(12),
-            border: Border.all(color: borderColor, width: 1),
+            border: Border.all(
+              color: meta.color.withValues(alpha: 0.4),
+              width: 1,
+            ),
           ),
           child: Row(
             mainAxisSize: MainAxisSize.min,
             children: [
-              HugeIcon(icon: _icon, size: 15, color: textColor),
-              const SizedBox(width: 8),
-              Text(
-                _label,
-                style: TextStyle(
-                  fontSize: 13,
-                  fontWeight: FontWeight.w600,
-                  color: textColor,
-                ),
-              ),
+              RequirementStatusBadge(status: requirement.status),
               const Spacer(),
               HugeIcon(
                 icon: HugeIcons.strokeRoundedInformationCircle,
                 size: 15,
-                color: c.textTertiary,
+                color: AppColors.ink400,
               ),
               const SizedBox(width: 2),
             ],
@@ -688,72 +1191,5 @@ class _StatusChip extends StatelessWidget {
         ),
       ),
     );
-  }
-
-  String get _label {
-    switch (requirement.status) {
-      case RequirementStatus.pendiente:
-        return 'classes.status.pending'.tr();
-      case RequirementStatus.enviado:
-        return 'classes.status.sent'.tr();
-      case RequirementStatus.validado:
-        return 'classes.status.validated'.tr();
-      case RequirementStatus.rechazado:
-        return 'classes.status.rejected'.tr();
-    }
-  }
-
-  Color _bgColor(bool isDark) {
-    switch (requirement.status) {
-      case RequirementStatus.pendiente:
-        return AppColors.accentLight;
-      case RequirementStatus.enviado:
-        return isDark
-            ? AppColors.statusInfoBgDark
-            : AppColors.statusInfoBgLight;
-      case RequirementStatus.validado:
-        return AppColors.secondaryLight;
-      case RequirementStatus.rechazado:
-        return AppColors.errorLight;
-    }
-  }
-
-  Color _borderColor(bool isDark) {
-    switch (requirement.status) {
-      case RequirementStatus.pendiente:
-        return AppColors.accent.withValues(alpha: 0.4);
-      case RequirementStatus.enviado:
-        return AppColors.sacBlue.withValues(alpha: 0.4);
-      case RequirementStatus.validado:
-        return AppColors.secondary.withValues(alpha: 0.4);
-      case RequirementStatus.rechazado:
-        return AppColors.error.withValues(alpha: 0.4);
-    }
-  }
-
-  Color _textColor(bool isDark) {
-    switch (requirement.status) {
-      case RequirementStatus.pendiente:
-        return AppColors.accentDark;
-      case RequirementStatus.enviado:
-        return isDark ? AppColors.statusInfoTextDark : AppColors.statusInfoText;
-      case RequirementStatus.validado:
-        return AppColors.secondaryDark;
-      case RequirementStatus.rechazado:
-        return AppColors.errorDark;
-    }
-  }
-
-  List<List<dynamic>> get _icon {
-    switch (requirement.status) {
-      case RequirementStatus.pendiente:
-        return HugeIcons.strokeRoundedClock01;
-      case RequirementStatus.enviado:
-        return HugeIcons.strokeRoundedSent;
-      case RequirementStatus.validado:
-        return HugeIcons.strokeRoundedCheckmarkCircle01;
-      case RequirementStatus.rechazado:
-        return HugeIcons.strokeRoundedCancel01;
-    }
   }
 }

--- a/lib/features/classes/presentation/views/roadmap_full_screen_view.dart
+++ b/lib/features/classes/presentation/views/roadmap_full_screen_view.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/material.dart';
+import '../roadmap/widgets/roadmap_screen_connected.dart';
+
+/// Pantalla completa del Roadmap de Clases.
+///
+/// Provee el Scaffold con AppBar (flecha de retorno automática via GoRouter)
+/// y renderiza [RoadmapScreenConnected] como contenido.
+///
+/// Se accede desde el chip "Ver mi camino completo" en [ClassesListView]
+/// via context.push(RouteNames.homeClassesRoadmap).
+/// El back-button retorna a Mis Clases con el estado preservado
+/// (StatefulShellBranch mantiene el árbol de widgets vivo).
+///
+/// [extendBodyBehindAppBar] se omite (valor por defecto: false) para que el
+/// body empiece limpiamente debajo de la AppBar y el primer track header no
+/// quede oculto detrás del título "Mi Camino".
+class RoadmapFullScreenView extends StatelessWidget {
+  const RoadmapFullScreenView({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Mi Camino'),
+        backgroundColor: colorScheme.surface,
+        // automaticallyImplyLeading: true (default) provee el botón back via GoRouter.
+      ),
+      body: const RoadmapScreenConnected(),
+    );
+  }
+}

--- a/lib/features/classes/presentation/widgets/mini_ring.dart
+++ b/lib/features/classes/presentation/widgets/mini_ring.dart
@@ -1,0 +1,91 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+
+import '../../../../core/theme/app_colors.dart';
+
+/// Anillo de progreso compacto 36×36 para [ModuleRow].
+///
+/// Muestra porcentaje centrado en JetBrains Mono (si disponible) o monospace.
+/// Track: `ink100`, arco: `coral500` (o `ink200` si pct == 0).
+class MiniRing extends StatelessWidget {
+  /// Progreso de 0.0 a 1.0.
+  final double progress;
+
+  /// Tamaño del widget. Por defecto 36.
+  final double size;
+
+  const MiniRing({
+    super.key,
+    required this.progress,
+    this.size = 36,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final pct = (progress.clamp(0.0, 1.0) * 100).round();
+    return SizedBox(
+      width: size,
+      height: size,
+      child: CustomPaint(
+        painter: _MiniRingPainter(progress: progress.clamp(0.0, 1.0)),
+        child: Center(
+          child: Text(
+            '$pct',
+            style: TextStyle(
+              fontSize: size * 0.25,
+              fontWeight: FontWeight.w700,
+              color: AppColors.ink800,
+              height: 1,
+              fontFeatures: const [FontFeature.tabularFigures()],
+              fontFamily: 'monospace',
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _MiniRingPainter extends CustomPainter {
+  final double progress;
+
+  const _MiniRingPainter({required this.progress});
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final center = Offset(size.width / 2, size.height / 2);
+    final radius = size.width / 2 - 2;
+    const strokeWidth = 3.0;
+
+    // Track
+    final trackPaint = Paint()
+      ..color = AppColors.ink100
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = strokeWidth
+      ..strokeCap = StrokeCap.round;
+
+    canvas.drawCircle(center, radius, trackPaint);
+
+    // Progress arc (only if > 0)
+    if (progress > 0) {
+      final progressPaint = Paint()
+        ..color = AppColors.coral500
+        ..style = PaintingStyle.stroke
+        ..strokeWidth = strokeWidth
+        ..strokeCap = StrokeCap.round;
+
+      canvas.drawArc(
+        Rect.fromCircle(center: center, radius: radius),
+        -math.pi / 2, // start from top
+        2 * math.pi * progress,
+        false,
+        progressPaint,
+      );
+    }
+  }
+
+  @override
+  bool shouldRepaint(covariant _MiniRingPainter oldDelegate) =>
+      oldDelegate.progress != progress;
+}

--- a/lib/features/classes/presentation/widgets/module_expansion_tile.dart
+++ b/lib/features/classes/presentation/widgets/module_expansion_tile.dart
@@ -5,11 +5,16 @@ import 'package:sacdia_app/core/theme/sac_colors.dart';
 import 'package:sacdia_app/core/widgets/sac_card.dart';
 
 import '../../domain/entities/class_module.dart';
+import '../../domain/entities/class_module_detail.dart';
+import '../../domain/entities/class_requirement.dart';
+import 'mini_ring.dart';
+import 'requirement_card.dart';
 import 'section_checkbox.dart';
 
-/// Módulo expandible - Estilo "Scout Vibrante"
+/// Módulo expandible — Estilo original (legacy, usado en pantallas antiguas).
 ///
 /// SacCard con ExpansionTile, mini progress bar, badge "X/Y".
+/// Mantener para [ClassModulesView] y [SectionDetailView] que aún lo usan.
 class ModuleExpansionTile extends StatelessWidget {
   final ClassModule module;
   final Function(int sectionId, bool isCompleted) onSectionToggle;
@@ -89,6 +94,203 @@ class ModuleExpansionTile extends StatelessWidget {
           }).toList(),
         ),
       ),
+    );
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Nuevo diseño — usado en ClassDetailWithProgressView
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Fila de módulo expandible con MiniRing y lista de ReqLines.
+///
+/// Handoff §5.8–5.9: padding 14v·16h, MiniRing 36×36, chevron rotado 90° al abrir.
+class ModuleDetailRow extends StatefulWidget {
+  final ClassModuleDetail module;
+  final bool initiallyExpanded;
+
+  /// Callback para tap en un requerimiento.
+  final void Function(ClassRequirement requirement) onRequirementTap;
+
+  const ModuleDetailRow({
+    super.key,
+    required this.module,
+    this.initiallyExpanded = false,
+    required this.onRequirementTap,
+  });
+
+  @override
+  State<ModuleDetailRow> createState() => _ModuleDetailRowState();
+}
+
+class _ModuleDetailRowState extends State<ModuleDetailRow>
+    with SingleTickerProviderStateMixin {
+  late bool _expanded;
+  late AnimationController _chevronController;
+  late Animation<double> _chevronAngle;
+  late Animation<double> _expandAnimation;
+
+  @override
+  void initState() {
+    super.initState();
+    _expanded = widget.initiallyExpanded;
+    _chevronController = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 200),
+      value: _expanded ? 1.0 : 0.0,
+    );
+    _chevronAngle = Tween<double>(begin: 0.0, end: 0.5).animate(
+      CurvedAnimation(parent: _chevronController, curve: Curves.easeOut),
+    );
+    _expandAnimation = CurvedAnimation(
+      parent: _chevronController,
+      curve: Curves.easeOut,
+    );
+  }
+
+  @override
+  void dispose() {
+    _chevronController.dispose();
+    super.dispose();
+  }
+
+  void _toggle() {
+    setState(() => _expanded = !_expanded);
+    if (_expanded) {
+      _chevronController.forward();
+    } else {
+      _chevronController.reverse();
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final module = widget.module;
+    final pending = module.requirements.length - module.completedCount;
+
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        // Module header row
+        InkWell(
+          onTap: _toggle,
+          splashColor: AppColors.coral200.withValues(alpha: 0.3),
+          child: Padding(
+            padding: const EdgeInsets.symmetric(
+              horizontal: 16,
+              vertical: 14,
+            ),
+            child: Row(
+              children: [
+                // MiniRing 36×36
+                MiniRing(
+                  progress: module.completionRatio,
+                  size: 36,
+                ),
+
+                const SizedBox(width: 12),
+
+                // Title + meta
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Text(
+                        module.name,
+                        style: const TextStyle(
+                          fontSize: 14.5,
+                          fontWeight: FontWeight.w600,
+                          color: AppColors.ink900,
+                        ),
+                      ),
+                      const SizedBox(height: 2),
+                      Row(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          Text(
+                            '${module.completedCount}/${module.requirements.length}',
+                            style: const TextStyle(
+                              fontSize: 12,
+                              fontWeight: FontWeight.w600,
+                              color: AppColors.ink500,
+                              fontFeatures: [FontFeature.tabularFigures()],
+                            ),
+                          ),
+                          const Padding(
+                            padding: EdgeInsets.symmetric(horizontal: 6),
+                            child: Text(
+                              '·',
+                              style: TextStyle(
+                                fontSize: 12,
+                                color: AppColors.ink300,
+                              ),
+                            ),
+                          ),
+                          Text(
+                            '$pending pendientes',
+                            style: const TextStyle(
+                              fontSize: 12,
+                              color: AppColors.ink500,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ],
+                  ),
+                ),
+
+                // Chevron (rotates 90° when open)
+                RotationTransition(
+                  turns: _chevronAngle,
+                  child: HugeIcon(
+                    icon: HugeIcons.strokeRoundedArrowRight01,
+                    size: 16,
+                    color: AppColors.ink400,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+
+        // Expanded requirements list
+        SizeTransition(
+          sizeFactor: _expandAnimation,
+          axisAlignment: -1,
+          child: Container(
+            decoration: const BoxDecoration(
+              color: AppColors.canvas,
+              border: Border(
+                top: BorderSide(color: AppColors.ink100, width: 1),
+              ),
+            ),
+            child: module.requirements.isEmpty
+                ? const Padding(
+                    padding: EdgeInsets.symmetric(
+                      horizontal: 20,
+                      vertical: 14,
+                    ),
+                    child: Text(
+                      'Sin requerimientos cargados',
+                      style: TextStyle(
+                        fontSize: 12.5,
+                        color: AppColors.ink400,
+                      ),
+                    ),
+                  )
+                : Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: module.requirements.map((req) {
+                      return RequirementCard(
+                        requirement: req,
+                        onTap: () => widget.onRequirementTap(req),
+                      );
+                    }).toList(),
+                  ),
+          ),
+        ),
+      ],
     );
   }
 }

--- a/lib/features/classes/presentation/widgets/progress_ring.dart
+++ b/lib/features/classes/presentation/widgets/progress_ring.dart
@@ -1,8 +1,13 @@
+import 'dart:math' as math;
+
 import 'package:flutter/material.dart';
+
 import '../../../../core/theme/app_colors.dart';
 import '../../../../core/theme/sac_colors.dart';
 
-/// Widget de anillo de progreso circular
+/// Widget de anillo de progreso circular — versión original (legacy).
+///
+/// Para el HeroCard de avances usa [HeroDonut] (56×56, stroke 6px, coral500).
 class ProgressRing extends StatelessWidget {
   final double progress; // 0.0 a 100.0
   final double size;
@@ -23,7 +28,6 @@ class ProgressRing extends StatelessWidget {
       child: Stack(
         alignment: Alignment.center,
         children: [
-          // Círculo de progreso
           SizedBox(
             width: size,
             height: size,
@@ -36,7 +40,6 @@ class ProgressRing extends StatelessWidget {
               ),
             ),
           ),
-          // Texto de porcentaje
           Text(
             '${progress.toInt()}%',
             style: TextStyle(
@@ -50,16 +53,74 @@ class ProgressRing extends StatelessWidget {
     );
   }
 
-  /// Obtiene el color según el progreso
   Color _getProgressColor(double progress) {
-    if (progress >= 100) {
-      return AppColors.success;
-    } else if (progress >= 50) {
-      return AppColors.info;
-    } else if (progress >= 25) {
-      return AppColors.warning;
-    } else {
-      return AppColors.error;
+    if (progress >= 100) return AppColors.success;
+    if (progress >= 50) return AppColors.info;
+    if (progress >= 25) return AppColors.warning;
+    return AppColors.error;
+  }
+}
+
+/// Donut de 56×56 para el HeroCard de avances.
+///
+/// Track: `ink100`, arco: `coral500`, stroke 6px, linecap round, arranca arriba.
+class HeroDonut extends StatelessWidget {
+  /// Progreso de 0.0 a 1.0.
+  final double progress;
+
+  const HeroDonut({super.key, required this.progress});
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: 56,
+      height: 56,
+      child: CustomPaint(
+        painter: _HeroDonutPainter(progress: progress.clamp(0.0, 1.0)),
+      ),
+    );
+  }
+}
+
+class _HeroDonutPainter extends CustomPainter {
+  final double progress;
+
+  const _HeroDonutPainter({required this.progress});
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final center = Offset(size.width / 2, size.height / 2);
+    final radius = size.width / 2 - 3;
+    const strokeWidth = 6.0;
+
+    // Track
+    final trackPaint = Paint()
+      ..color = AppColors.ink100
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = strokeWidth
+      ..strokeCap = StrokeCap.round;
+
+    canvas.drawCircle(center, radius, trackPaint);
+
+    // Progress arc
+    if (progress > 0) {
+      final progressPaint = Paint()
+        ..color = AppColors.coral500
+        ..style = PaintingStyle.stroke
+        ..strokeWidth = strokeWidth
+        ..strokeCap = StrokeCap.round;
+
+      canvas.drawArc(
+        Rect.fromCircle(center: center, radius: radius),
+        -math.pi / 2, // start from top (-90deg)
+        2 * math.pi * progress,
+        false,
+        progressPaint,
+      );
     }
   }
+
+  @override
+  bool shouldRepaint(covariant _HeroDonutPainter oldDelegate) =>
+      oldDelegate.progress != progress;
 }

--- a/lib/features/classes/presentation/widgets/requirement_card.dart
+++ b/lib/features/classes/presentation/widgets/requirement_card.dart
@@ -1,15 +1,17 @@
 import 'package:flutter/material.dart';
 import 'package:hugeicons/hugeicons.dart';
-import 'package:intl/intl.dart';
 
 import '../../../../core/theme/app_colors.dart';
-import '../../../../core/theme/sac_colors.dart';
 import '../../domain/entities/class_requirement.dart';
-import 'requirement_status_badge.dart';
+import '../utils/status_meta.dart';
+import 'status_glyph.dart';
 
-/// Tarjeta que resume un [ClassRequirement] en la vista de clase.
+/// Fila compacta de un requerimiento dentro de un módulo expandido.
 ///
-/// Sigue el patron identico al SectionCard de carpeta_evidencias.
+/// Layout: StatusGlyph 22×22 · título · meta (label + archivos) · chevron.
+/// Tap → abre pantalla de detalle.
+///
+/// Handoff §5.10: padding 12v·16r·20l·12b, borderBottom ink100, gap 12.
 class RequirementCard extends StatelessWidget {
   final ClassRequirement requirement;
   final VoidCallback onTap;
@@ -22,296 +24,133 @@ class RequirementCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final c = context.sac;
-    final dateFormat = DateFormat('d MMM yyyy, HH:mm', 'es');
+    final meta = StatusMeta.of(requirement.status);
 
-    return GestureDetector(
+    return InkWell(
       onTap: onTap,
+      splashColor: AppColors.coral200.withValues(alpha: 0.4),
+      highlightColor: AppColors.coral50.withValues(alpha: 0.5),
       child: Container(
-        margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 6),
-        decoration: BoxDecoration(
-          color: c.surface,
-          borderRadius: BorderRadius.circular(16),
-          border: Border.all(color: c.border),
-          boxShadow: [
-            BoxShadow(
-              color: c.shadow,
-              blurRadius: 8,
-              offset: const Offset(0, 2),
-            ),
-          ],
+        padding: const EdgeInsets.only(
+          top: 12,
+          bottom: 12,
+          left: 20,
+          right: 16,
         ),
-        child: Column(
+        decoration: const BoxDecoration(
+          border: Border(
+            bottom: BorderSide(color: AppColors.ink100, width: 1),
+          ),
+        ),
+        child: Row(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            // Header
+            // Leading: StatusGlyph 22×22
             Padding(
-              padding: const EdgeInsets.fromLTRB(16, 14, 16, 10),
-              child: Row(
+              padding: const EdgeInsets.only(top: 1),
+              child: StatusGlyph(status: requirement.status),
+            ),
+
+            const SizedBox(width: 12),
+
+            // Middle: title + meta
+            Expanded(
+              child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
+                mainAxisSize: MainAxisSize.min,
                 children: [
-                  // Icono del tipo de requerimiento
-                  Container(
-                    width: 36,
-                    height: 36,
-                    decoration: BoxDecoration(
-                      color:
-                          _typeColor(requirement.type).withValues(alpha: 0.12),
-                      borderRadius: BorderRadius.circular(10),
-                    ),
-                    child: Center(
-                      child: HugeIcon(
-                        icon: _typeIcon(requirement.type),
-                        size: 18,
-                        color: _typeColor(requirement.type),
-                      ),
+                  Text(
+                    requirement.name,
+                    style: const TextStyle(
+                      fontSize: 13.5,
+                      fontWeight: FontWeight.w500,
+                      color: AppColors.ink800,
+                      height: 1.4,
                     ),
                   ),
-                  const SizedBox(width: 12),
-                  Expanded(
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Text(
-                          requirement.name,
-                          style:
-                              Theme.of(context).textTheme.titleSmall?.copyWith(
-                                    fontWeight: FontWeight.w700,
-                                    color: c.text,
-                                  ),
-                        ),
-                        if (requirement.description != null &&
-                            requirement.description!.isNotEmpty) ...[
-                          const SizedBox(height: 3),
-                          Text(
-                            requirement.description!,
-                            maxLines: 2,
-                            overflow: TextOverflow.ellipsis,
-                            style:
-                                Theme.of(context).textTheme.bodySmall?.copyWith(
-                                      color: c.textSecondary,
-                                      height: 1.4,
-                                    ),
-                          ),
-                        ],
-                        if (requirement.type == RequirementType.honor &&
-                            requirement.linkedHonorName != null) ...[
-                          const SizedBox(height: 4),
-                          _HonorBadge(
-                            name: requirement.linkedHonorName!,
-                            completed:
-                                requirement.linkedHonorCompleted ?? false,
-                          ),
-                        ],
-                      ],
-                    ),
+                  const SizedBox(height: 4),
+                  _ReqMetaRow(
+                    meta: meta,
+                    filesUploaded: requirement.files.length,
+                    filesRequired: requirement.maxFiles,
                   ),
-                  const SizedBox(width: 10),
-                  RequirementStatusBadge(status: requirement.status),
                 ],
               ),
             ),
 
-            Divider(height: 1, color: c.divider),
+            const SizedBox(width: 8),
 
-            // Stats row
+            // Trailing: chevron right
             Padding(
-              padding: const EdgeInsets.fromLTRB(16, 10, 16, 10),
-              child: Row(
-                children: [
-                  _StatItem(
-                    icon: HugeIcons.strokeRoundedFiles01,
-                    label:
-                        '${requirement.files.length} / ${requirement.maxFiles} archivos',
-                    color: c.textSecondary,
-                    context: context,
-                  ),
-                  const Spacer(),
-                  HugeIcon(
-                    icon: HugeIcons.strokeRoundedArrowRight01,
-                    size: 18,
-                    color: c.textTertiary,
-                  ),
-                ],
+              padding: const EdgeInsets.only(top: 2),
+              child: HugeIcon(
+                icon: HugeIcons.strokeRoundedArrowRight01,
+                size: 14,
+                color: AppColors.ink300,
               ),
             ),
-
-            // Trazabilidad (si aplica)
-            if (requirement.submittedByName != null ||
-                requirement.validatedByName != null) ...[
-              Divider(height: 1, color: c.divider),
-              Padding(
-                padding: const EdgeInsets.fromLTRB(16, 8, 16, 10),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    if (requirement.submittedByName != null)
-                      _TraceRow(
-                        icon: HugeIcons.strokeRoundedSent,
-                        color: Theme.of(context).brightness == Brightness.dark
-                            ? AppColors.statusInfoTextDark
-                            : AppColors.statusInfoText,
-                        text:
-                            'Enviado por ${requirement.submittedByName}${requirement.submittedAt != null ? " · ${dateFormat.format(requirement.submittedAt!.toLocal())}" : ""}',
-                        context: context,
-                      ),
-                    if (requirement.validatedByName != null) ...[
-                      if (requirement.submittedByName != null)
-                        const SizedBox(height: 4),
-                      _TraceRow(
-                        icon: HugeIcons.strokeRoundedCheckmarkCircle01,
-                        color: AppColors.secondary,
-                        text:
-                            'Validado por ${requirement.validatedByName}${requirement.validatedAt != null ? " · ${dateFormat.format(requirement.validatedAt!.toLocal())}" : ""}',
-                        context: context,
-                      ),
-                    ],
-                  ],
-                ),
-              ),
-            ],
           ],
         ),
       ),
     );
   }
-
-  Color _typeColor(RequirementType type) {
-    switch (type) {
-      case RequirementType.honor:
-        return AppColors.sacBlue;
-      case RequirementType.service:
-        return AppColors.secondary;
-      case RequirementType.general:
-        return AppColors.primary;
-    }
-  }
-
-  List<List<dynamic>> _typeIcon(RequirementType type) {
-    switch (type) {
-      case RequirementType.honor:
-        return HugeIcons.strokeRoundedAward01;
-      case RequirementType.service:
-        return HugeIcons.strokeRoundedCharity;
-      case RequirementType.general:
-        return HugeIcons.strokeRoundedCheckList;
-    }
-  }
 }
 
-// ── Honor badge ────────────────────────────────────────────────────────────────
+// ── Meta row ──────────────────────────────────────────────────────────────────
 
-class _HonorBadge extends StatelessWidget {
-  final String name;
-  final bool completed;
+class _ReqMetaRow extends StatelessWidget {
+  final StatusMeta meta;
+  final int filesUploaded;
+  final int filesRequired;
 
-  const _HonorBadge({required this.name, required this.completed});
+  const _ReqMetaRow({
+    required this.meta,
+    required this.filesUploaded,
+    required this.filesRequired,
+  });
 
   @override
   Widget build(BuildContext context) {
-    final isDark = Theme.of(context).brightness == Brightness.dark;
-    final color = completed ? AppColors.secondary : AppColors.sacBlue;
-    final bgColor = completed
-        ? AppColors.secondaryLight
-        : (isDark ? AppColors.statusInfoBgDark : AppColors.statusInfoBgLight);
-
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
-      decoration: BoxDecoration(
-        color: bgColor,
-        borderRadius: BorderRadius.circular(8),
-        border: Border.all(color: color.withValues(alpha: 0.3)),
-      ),
-      child: Row(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          HugeIcon(
-            icon: completed
-                ? HugeIcons.strokeRoundedCheckmarkCircle01
-                : HugeIcons.strokeRoundedAward01,
-            size: 11,
-            color: color,
-          ),
-          const SizedBox(width: 4),
-          Flexible(
-            child: Text(
-              name,
-              maxLines: 1,
-              overflow: TextOverflow.ellipsis,
-              style: TextStyle(
-                fontSize: 11,
-                fontWeight: FontWeight.w600,
-                color: color,
-              ),
-            ),
-          ),
-        ],
-      ),
-    );
-  }
-}
-
-// ── Helpers ───────────────────────────────────────────────────────────────────
-
-class _StatItem extends StatelessWidget {
-  final List<List<dynamic>> icon;
-  final String label;
-  final Color color;
-  final BuildContext context;
-
-  const _StatItem({
-    required this.icon,
-    required this.label,
-    required this.color,
-    required this.context,
-  });
-
-  @override
-  Widget build(BuildContext _) {
     return Row(
       mainAxisSize: MainAxisSize.min,
       children: [
-        HugeIcon(icon: icon, size: 13, color: color),
-        const SizedBox(width: 4),
+        // Status label
         Text(
-          label,
-          style: Theme.of(context).textTheme.labelSmall?.copyWith(
-                color: color,
-                fontWeight: FontWeight.w600,
-              ),
+          meta.label,
+          style: TextStyle(
+            fontSize: 11.5,
+            fontWeight: FontWeight.w600,
+            color: meta.dark,
+          ),
         ),
-      ],
-    );
-  }
-}
 
-class _TraceRow extends StatelessWidget {
-  final List<List<dynamic>> icon;
-  final Color color;
-  final String text;
-  final BuildContext context;
-
-  const _TraceRow({
-    required this.icon,
-    required this.color,
-    required this.text,
-    required this.context,
-  });
-
-  @override
-  Widget build(BuildContext _) {
-    return Row(
-      children: [
-        HugeIcon(icon: icon, size: 12, color: color),
-        const SizedBox(width: 5),
-        Expanded(
+        // Dot separator
+        const Padding(
+          padding: EdgeInsets.symmetric(horizontal: 6),
           child: Text(
-            text,
-            style: Theme.of(context).textTheme.labelSmall?.copyWith(
-                  color: color,
-                  height: 1.3,
-                ),
-            overflow: TextOverflow.ellipsis,
+            '·',
+            style: TextStyle(
+              fontSize: 11.5,
+              color: AppColors.ink300,
+            ),
+          ),
+        ),
+
+        // Files count: "X/Y archivos"
+        Text(
+          '$filesUploaded',
+          style: const TextStyle(
+            fontSize: 11.5,
+            fontWeight: FontWeight.w700,
+            color: AppColors.ink800,
+            fontFeatures: [FontFeature.tabularFigures()],
+          ),
+        ),
+        Text(
+          '/$filesRequired archivos',
+          style: const TextStyle(
+            fontSize: 11.5,
+            color: AppColors.ink400,
           ),
         ),
       ],

--- a/lib/features/classes/presentation/widgets/requirement_status_badge.dart
+++ b/lib/features/classes/presentation/widgets/requirement_status_badge.dart
@@ -4,6 +4,7 @@ import 'package:hugeicons/hugeicons.dart';
 
 import '../../../../core/theme/app_colors.dart';
 import '../../domain/entities/class_requirement.dart';
+import '../utils/status_meta.dart';
 
 /// Badge de color con icono que indica el estado de un requerimiento.
 ///
@@ -60,6 +61,8 @@ class RequirementStatusBadge extends StatelessWidget {
         return 'classes.status.validated'.tr();
       case RequirementStatus.rechazado:
         return 'classes.status.rejected'.tr();
+      case RequirementStatus.observado:
+        return StatusMeta.of(status).label;
     }
   }
 
@@ -75,6 +78,8 @@ class RequirementStatusBadge extends StatelessWidget {
         return AppColors.secondaryLight;
       case RequirementStatus.rechazado:
         return AppColors.errorLight;
+      case RequirementStatus.observado:
+        return AppColors.observedBg;
     }
   }
 
@@ -88,6 +93,8 @@ class RequirementStatusBadge extends StatelessWidget {
         return AppColors.secondary.withValues(alpha: 0.4);
       case RequirementStatus.rechazado:
         return AppColors.error.withValues(alpha: 0.4);
+      case RequirementStatus.observado:
+        return AppColors.observedColor.withValues(alpha: 0.4);
     }
   }
 
@@ -101,6 +108,8 @@ class RequirementStatusBadge extends StatelessWidget {
         return AppColors.secondaryDark;
       case RequirementStatus.rechazado:
         return AppColors.errorDark;
+      case RequirementStatus.observado:
+        return AppColors.observedDark;
     }
   }
 
@@ -114,6 +123,8 @@ class RequirementStatusBadge extends StatelessWidget {
         return HugeIcons.strokeRoundedCheckmarkCircle01;
       case RequirementStatus.rechazado:
         return HugeIcons.strokeRoundedCancel01;
+      case RequirementStatus.observado:
+        return HugeIcons.strokeRoundedInformationCircle;
     }
   }
 }

--- a/lib/features/classes/presentation/widgets/status_glyph.dart
+++ b/lib/features/classes/presentation/widgets/status_glyph.dart
@@ -1,0 +1,273 @@
+import 'package:flutter/material.dart';
+import 'package:hugeicons/hugeicons.dart';
+
+import '../../../../core/theme/app_colors.dart';
+import '../../domain/entities/class_requirement.dart';
+import '../utils/status_meta.dart';
+
+/// Glifo circular 22×22 que representa visualmente el [RequirementStatus].
+///
+/// Cinco variantes definidas en el handoff §5.10:
+/// - **validado**: círculo sólido verde con check blanco.
+/// - **enviado**: círculo bg `sentBg` con borde `sentColor` y avión de papel.
+/// - **observado**: círculo bg `observedBg` con borde `observedColor` y "!" bold.
+/// - **rechazado**: círculo sólido rosa con X blanca.
+/// - **pendiente**: círculo blanco con borde dashed `ink300`.
+///
+/// Incluye [Semantics] con el label de estado para accesibilidad (VoiceOver /
+/// TalkBack), de modo que el color no es la única señal.
+class StatusGlyph extends StatelessWidget {
+  final RequirementStatus status;
+
+  /// Tamaño del glifo. Por defecto 22 (handoff).
+  final double size;
+
+  const StatusGlyph({
+    super.key,
+    required this.status,
+    this.size = 22,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final meta = StatusMeta.of(status);
+
+    return Semantics(
+      label: meta.label,
+      excludeSemantics: true,
+      child: _buildGlyph(),
+    );
+  }
+
+  Widget _buildGlyph() {
+    switch (status) {
+      case RequirementStatus.validado:
+        return _SolidGlyph(
+          size: size,
+          bg: AppColors.validatedColor,
+          child: _CheckIcon(size: size),
+        );
+
+      case RequirementStatus.enviado:
+        return _BorderedGlyph(
+          size: size,
+          bg: AppColors.sentBg,
+          borderColor: AppColors.sentColor,
+          child: HugeIcon(
+            icon: HugeIcons.strokeRoundedSent,
+            size: size * 0.5,
+            color: AppColors.sentColor,
+          ),
+        );
+
+      case RequirementStatus.observado:
+        return _BorderedGlyph(
+          size: size,
+          bg: AppColors.observedBg,
+          borderColor: AppColors.observedColor,
+          child: Text(
+            '!',
+            style: TextStyle(
+              fontSize: size * 0.59,
+              fontWeight: FontWeight.w800,
+              color: AppColors.observedDark,
+              height: 1,
+            ),
+          ),
+        );
+
+      case RequirementStatus.rechazado:
+        return _SolidGlyph(
+          size: size,
+          bg: AppColors.rejectedColor,
+          child: _XIcon(size: size),
+        );
+
+      case RequirementStatus.pendiente:
+        return _DashedGlyph(size: size);
+    }
+  }
+}
+
+// ── Solid circle ──────────────────────────────────────────────────────────────
+
+class _SolidGlyph extends StatelessWidget {
+  final double size;
+  final Color bg;
+  final Widget child;
+
+  const _SolidGlyph({
+    required this.size,
+    required this.bg,
+    required this.child,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: size,
+      height: size,
+      decoration: BoxDecoration(
+        color: bg,
+        shape: BoxShape.circle,
+      ),
+      child: Center(child: child),
+    );
+  }
+}
+
+// ── Bordered circle ────────────────────────────────────────────────────────────
+
+class _BorderedGlyph extends StatelessWidget {
+  final double size;
+  final Color bg;
+  final Color borderColor;
+  final Widget child;
+
+  const _BorderedGlyph({
+    required this.size,
+    required this.bg,
+    required this.borderColor,
+    required this.child,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: size,
+      height: size,
+      decoration: BoxDecoration(
+        color: bg,
+        shape: BoxShape.circle,
+        border: Border.all(color: borderColor, width: 1.5),
+      ),
+      child: Center(child: child),
+    );
+  }
+}
+
+// ── Dashed circle (pending) ───────────────────────────────────────────────────
+
+class _DashedGlyph extends StatelessWidget {
+  final double size;
+
+  const _DashedGlyph({required this.size});
+
+  @override
+  Widget build(BuildContext context) {
+    return CustomPaint(
+      size: Size(size, size),
+      painter: _DashedCirclePainter(),
+    );
+  }
+}
+
+class _DashedCirclePainter extends CustomPainter {
+  @override
+  void paint(Canvas canvas, Size size) {
+    final center = Offset(size.width / 2, size.height / 2);
+    final radius = size.width / 2 - 1;
+    final paint = Paint()
+      ..color = AppColors.ink300
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = 1.5;
+
+    // Draw dashed circle
+    const dashCount = 12;
+    const dashLength = 0.35; // radians
+    const gapLength = 0.18; // radians
+
+    for (int i = 0; i < dashCount; i++) {
+      final start = i * (dashLength + gapLength);
+      canvas.drawArc(
+        Rect.fromCircle(center: center, radius: radius),
+        start - (3.14159 / 2), // start from top
+        dashLength,
+        false,
+        paint,
+      );
+    }
+  }
+
+  @override
+  bool shouldRepaint(covariant CustomPainter oldDelegate) => false;
+}
+
+// ── Icon helpers ──────────────────────────────────────────────────────────────
+
+/// Check mark (validated state)
+class _CheckIcon extends StatelessWidget {
+  final double size;
+
+  const _CheckIcon({required this.size});
+
+  @override
+  Widget build(BuildContext context) {
+    return CustomPaint(
+      size: Size(size * 0.55, size * 0.55),
+      painter: _CheckPainter(),
+    );
+  }
+}
+
+class _CheckPainter extends CustomPainter {
+  @override
+  void paint(Canvas canvas, Size size) {
+    final paint = Paint()
+      ..color = Colors.white
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = 2.0
+      ..strokeCap = StrokeCap.round
+      ..strokeJoin = StrokeJoin.round;
+
+    final path = Path()
+      ..moveTo(size.width * 0.15, size.height * 0.52)
+      ..lineTo(size.width * 0.42, size.height * 0.76)
+      ..lineTo(size.width * 0.85, size.height * 0.24);
+
+    canvas.drawPath(path, paint);
+  }
+
+  @override
+  bool shouldRepaint(covariant CustomPainter oldDelegate) => false;
+}
+
+/// X mark (rejected state)
+class _XIcon extends StatelessWidget {
+  final double size;
+
+  const _XIcon({required this.size});
+
+  @override
+  Widget build(BuildContext context) {
+    return CustomPaint(
+      size: Size(size * 0.5, size * 0.5),
+      painter: _XPainter(),
+    );
+  }
+}
+
+class _XPainter extends CustomPainter {
+  @override
+  void paint(Canvas canvas, Size size) {
+    final paint = Paint()
+      ..color = Colors.white
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = 2.0
+      ..strokeCap = StrokeCap.round;
+
+    canvas.drawLine(
+      Offset(size.width * 0.2, size.height * 0.2),
+      Offset(size.width * 0.8, size.height * 0.8),
+      paint,
+    );
+    canvas.drawLine(
+      Offset(size.width * 0.8, size.height * 0.2),
+      Offset(size.width * 0.2, size.height * 0.8),
+      paint,
+    );
+  }
+
+  @override
+  bool shouldRepaint(covariant CustomPainter oldDelegate) => false;
+}

--- a/lib/features/dashboard/presentation/widgets/quick_access_grid.dart
+++ b/lib/features/dashboard/presentation/widgets/quick_access_grid.dart
@@ -129,12 +129,16 @@ final List<_QuickAccessItemConfig> _quickAccessItemsConfig = [
     route: RouteNames.homeResources,
     requiredPermissions: {'folders:read'},
   ),
-  // Mi ranking — universal (no permission gate, visible to every member).
+  // Mi ranking — only visible to roles that hold member_rankings:read_self
+  // (MEMBER club-scope, ADMIN global, SUPER_ADMIN global). Other club roles
+  // (director, counselor, secretary, treasurer…) do not have this permission
+  // and must not see the entry.
   _QuickAccessItemConfig(
     labelKey: 'dashboard.quick_access.my_ranking',
     icon: HugeIcons.strokeRoundedRanking,
     color: AppColors.accent,
     route: RouteNames.homeMyRanking,
+    requiredPermissions: {'member_rankings:read_self'},
   ),
   // Ranking de sección — gated by units:update (counselor+). Route is
   // resolved at render time because it requires the active sectionId from

--- a/lib/features/post_registration/presentation/providers/post_registration_providers.dart
+++ b/lib/features/post_registration/presentation/providers/post_registration_providers.dart
@@ -35,6 +35,7 @@ class CompletionStatusNotifier
     extends AutoDisposeAsyncNotifier<CompletionStatus?> {
   @override
   Future<CompletionStatus?> build() async {
+    ref.keepAlive();
     final cancelToken = CancelToken();
     ref.onDispose(() => cancelToken.cancel());
     final result = await ref

--- a/lib/features/rankings/presentation/screens/my_ranking_screen.dart
+++ b/lib/features/rankings/presentation/screens/my_ranking_screen.dart
@@ -6,6 +6,8 @@ import 'package:hugeicons/hugeicons.dart';
 
 import '../../../../core/config/route_names.dart';
 import '../../../../core/theme/sac_colors.dart';
+import '../../../../features/auth/domain/utils/authorization_utils.dart';
+import '../../../../features/auth/presentation/providers/auth_providers.dart';
 import '../../../../providers/catalogs_provider.dart';
 import '../../domain/entities/award_tier.dart';
 import '../../domain/entities/member_ranking.dart';
@@ -31,6 +33,23 @@ class MyRankingScreen extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    // Deep-link / hot-restart defense: if the user arrives here without the
+    // required permission (e.g., via a push notification link or direct URL),
+    // show a friendly empty state instead of a raw 403 from the backend.
+    final user = ref.watch(
+      authNotifierProvider.select((v) => v.valueOrNull),
+    );
+    if (!hasAnyPermission(user, const {'member_rankings:read_self'})) {
+      return Scaffold(
+        appBar: AppBar(
+          title: Text(tr('rankings.my_ranking.title')),
+        ),
+        body: const Center(
+          child: RankingEmptyState(reason: RankingEmptyReason.unauthorized),
+        ),
+      );
+    }
+
     final yearAsync = ref.watch(currentEcclesiasticalYearProvider);
 
     return Scaffold(


### PR DESCRIPTION
## Summary
- Redesign **Mis Clases** screen: removed tab toggle, added Roadmap chip, grouped sections "Clase actual" / "Otras clases", outlined-chip enroll action in AppBar
- Roadmap full-screen route via `context.push` with proper back navigation; auto-scroll to current class with mounted/hasSize guards
- Fixed Roadmap visual issues: curve X anchor (314 → 304), Y anchors derived from real shield geometry, GlobalKey-duplicate crash on multiple `current` classes
- Added accent ring + "Cursando" pill to highlight current class
- Gated **Mi Ranking** dashboard entry by `member_rankings:read_self` permission + deep-link defense in `MyRankingScreen`

## Test plan
- [ ] Open "Clases" tab → AppBar shows "Clases" + outlined "Inscribirme" chip
- [ ] Tap Roadmap chip → full-screen Roadmap with back arrow returns to Mis Clases
- [ ] Roadmap auto-scrolls to current class (when one exists)
- [ ] Curves visually connect shield centers (no flying)
- [ ] Current-class node shows accent ring + "ACTUAL · X%" badge + track header has "Cursando" pill
- [ ] Mi Ranking tile NOT visible for users without `member_rankings:read_self`
- [ ] Deep-link `/home/my-ranking` for unauthorized user shows friendly empty state

## Backend dependency
Backend PR https://github.com/abn-r/sacdia-backend/pull/<TBD> grants `member_rankings:read_self` to CLUB staff roles. Without it, those users will see the empty state instead of the ranking.