### PR TITLE
refactor(roles): align role-name strings + i18n keys to hyphen convention

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -2915,7 +2915,7 @@
     }
   },
   "roles": {
-    "super_admin": {
+    "super-admin": {
       "masculine": "Super administrator",
       "feminine": "Super administrator"
     },
@@ -2923,7 +2923,7 @@
       "masculine": "Administrator",
       "feminine": "Administrator"
     },
-    "assistant_admin": {
+    "assistant-admin": {
       "masculine": "Assistant administrator",
       "feminine": "Assistant administrator"
     },
@@ -2943,7 +2943,7 @@
       "masculine": "Director",
       "feminine": "Director"
     },
-    "deputy_director": {
+    "deputy-director": {
       "masculine": "Deputy director",
       "feminine": "Deputy director"
     },

--- a/assets/translations/es.json
+++ b/assets/translations/es.json
@@ -2915,7 +2915,7 @@
     }
   },
   "roles": {
-    "super_admin": {
+    "super-admin": {
       "masculine": "Súper administrador",
       "feminine": "Súper administradora"
     },
@@ -2923,7 +2923,7 @@
       "masculine": "Administrador",
       "feminine": "Administradora"
     },
-    "assistant_admin": {
+    "assistant-admin": {
       "masculine": "Administrador asistente",
       "feminine": "Administradora asistente"
     },
@@ -2943,7 +2943,7 @@
       "masculine": "Director",
       "feminine": "Directora"
     },
-    "deputy_director": {
+    "deputy-director": {
       "masculine": "Subdirector",
       "feminine": "Subdirectora"
     },

--- a/assets/translations/fr.json
+++ b/assets/translations/fr.json
@@ -2915,7 +2915,7 @@
     }
   },
   "roles": {
-    "super_admin": {
+    "super-admin": {
       "masculine": "Super administrateur",
       "feminine": "Super administratrice"
     },
@@ -2923,7 +2923,7 @@
       "masculine": "Administrateur",
       "feminine": "Administratrice"
     },
-    "assistant_admin": {
+    "assistant-admin": {
       "masculine": "Administrateur assistant",
       "feminine": "Administratrice assistante"
     },
@@ -2943,7 +2943,7 @@
       "masculine": "Directeur",
       "feminine": "Directrice"
     },
-    "deputy_director": {
+    "deputy-director": {
       "masculine": "Directeur adjoint",
       "feminine": "Directrice adjointe"
     },

--- a/assets/translations/pt-BR.json
+++ b/assets/translations/pt-BR.json
@@ -2915,7 +2915,7 @@
     }
   },
   "roles": {
-    "super_admin": {
+    "super-admin": {
       "masculine": "Super administrador",
       "feminine": "Super administradora"
     },
@@ -2923,7 +2923,7 @@
       "masculine": "Administrador",
       "feminine": "Administradora"
     },
-    "assistant_admin": {
+    "assistant-admin": {
       "masculine": "Administrador assistente",
       "feminine": "Administradora assistente"
     },
@@ -2943,7 +2943,7 @@
       "masculine": "Diretor",
       "feminine": "Diretora"
     },
-    "deputy_director": {
+    "deputy-director": {
       "masculine": "Subdiretor",
       "feminine": "Subdiretora"
     },

--- a/lib/core/utils/role_utils.dart
+++ b/lib/core/utils/role_utils.dart
@@ -6,14 +6,14 @@ class RoleUtils {
 
   /// Conjunto de claves de rol conocidas por el sistema.
   static const _knownRoles = {
-    'super_admin',
+    'super-admin',
     'admin',
-    'assistant_admin',
+    'assistant-admin',
     'coordinator',
     'pastor',
     'user',
     'director',
-    'deputy_director',
+    'deputy-director',
     'secretary',
     'treasurer',
     'counselor',

--- a/lib/features/auth/domain/utils/authorization_utils.dart
+++ b/lib/features/auth/domain/utils/authorization_utils.dart
@@ -75,7 +75,7 @@ bool hasAnyPermission(UserEntity? user, Iterable<String> permissions) {
 
 /// Canonical role-name check against `user.authorization.resolvedRoleNames`.
 /// Use this only when the gate is genuinely role-based (global roles like
-/// `coordinator`, `admin`, `super_admin`). Prefer [hasAnyPermission] for
+/// `coordinator`, `admin`, `super-admin`). Prefer [hasAnyPermission] for
 /// anything permission-driven.
 bool hasAnyRole(UserEntity? user, Iterable<String> roles) {
   final granted = extractUserRoles(user);

--- a/lib/features/dashboard/presentation/widgets/quick_access_grid.dart
+++ b/lib/features/dashboard/presentation/widgets/quick_access_grid.dart
@@ -55,7 +55,7 @@ final List<_QuickAccessItemConfig> _quickAccessItemsConfig = [
     icon: HugeIcons.strokeRoundedAnalytics01,
     color: AppColors.info,
     route: RouteNames.coordinator,
-    requiredRoles: {'coordinator', 'admin', 'super_admin', 'assistant_admin'},
+    requiredRoles: {'coordinator', 'admin', 'super-admin', 'assistant-admin'},
   ),
   // Administrative: member list — users:read_detail is held by counselor+
   _QuickAccessItemConfig(

--- a/lib/features/enrollment/presentation/views/enrollment_form_view.dart
+++ b/lib/features/enrollment/presentation/views/enrollment_form_view.dart
@@ -210,14 +210,11 @@ class _EnrollmentFormViewState extends ConsumerState<EnrollmentFormView> {
       final role = member.clubRole?.toLowerCase().trim() ?? '';
 
       // Deputy directors (up to 2).
-      // Canonical backend value is 'deputy_director' (underscore). We also
-      // match the hyphenated form 'deputy-director' and the Spanish alias
-      // 'subdirector' / 'sub_director' as defensive fallbacks.
-      if ((role == 'deputy_director' ||
-              role == 'deputy-director' ||
+      // Canonical backend value is 'deputy-director' (hyphen). We also
+      // match the Spanish alias 'subdirector' as a defensive fallback.
+      if ((role == 'deputy-director' ||
               role.contains('deputy') ||
-              role.contains('subdirector') ||
-              role.contains('sub_director')) &&
+              role.contains('subdirector')) &&
           newDeputyIds.length < 2 &&
           !newDeputyIds.contains(member.userId)) {
         newDeputyIds.add(member.userId);

--- a/lib/features/members/data/datasources/members_remote_data_source.dart
+++ b/lib/features/members/data/datasources/members_remote_data_source.dart
@@ -87,14 +87,14 @@ class MembersRemoteDataSourceImpl implements MembersRemoteDataSource {
   }
 
   String _normalizeRoleKey(String value) {
-    return value.trim().toLowerCase().replaceAll(RegExp(r'[\s-]+'), '_');
+    return value.trim().toLowerCase().replaceAll(RegExp(r'[\s_]+'), '-');
   }
 
   List<String> _roleLookupCandidates(String role) {
     final normalized = _normalizeRoleKey(role);
     const aliases = <String, List<String>>{
-      'deputy_director': ['subdirector'],
-      'subdirector': ['deputy_director'],
+      'deputy-director': ['subdirector'],
+      'subdirector': ['deputy-director'],
       'secretary': ['secretario'],
       'treasurer': ['tesorero'],
       'counselor': ['consejero'],

--- a/lib/features/members/presentation/views/role_assignment_view.dart
+++ b/lib/features/members/presentation/views/role_assignment_view.dart
@@ -31,7 +31,7 @@ class _RoleAssignmentViewState extends ConsumerState<RoleAssignmentView> {
   /// Roles disponibles para asignar en el club
   static const _availableRoles = [
     'director',
-    'deputy_director',
+    'deputy-director',
     'secretary',
     'treasurer',
     'counselor',


### PR DESCRIPTION
## Summary
Companion PR to sacdia-backend#77. Aligns Flutter app to canonical hyphen form for ALL role names.

## Changes
- 6 Dart files: role utils, dashboard gate, enrollment form, members datasource normalizer, role assignment view, auth utils docstring
- 4 i18n files: role keys renamed (super_admin → super-admin etc.) — easy_localization resolves correctly via `.` path separator

## Validation
- rg literal underscored role names in lib/ assets/ test/ → **0 matches**
- flutter analyze → **No issues found**
- 1 deputy_director legacy fallback removed from enrollment form (canonical now)

## Test plan
- [ ] Login as super-admin user — dashboard tile gating works
- [ ] Members > Role assignment shows hyphen options
- [ ] Enrollment form deputy-director branch works
- [ ] Role labels translated correctly all 4 locales