### PR TITLE
feat(profile): edit blood type from medical info screen

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -2614,7 +2614,13 @@
       "not_registered": "Not registered",
       "load_error": "Error loading",
       "action_edit": "Edit",
-      "action_manage": "Manage"
+      "action_manage": "Manage",
+      "blood_type": "Blood type",
+      "blood_type_unset": "No blood type on file",
+      "blood_type_select_title": "Select your blood type",
+      "blood_type_select_subtitle": "This shows on your digital credential and is useful in case of emergency.",
+      "blood_type_updated": "Blood type updated to {value}",
+      "blood_type_update_failed": "Could not update blood type"
     },
     "settings": {
       "change_password_dialog_title": "Change password",

--- a/assets/translations/es.json
+++ b/assets/translations/es.json
@@ -2614,7 +2614,13 @@
       "not_registered": "No registrado",
       "load_error": "Error al cargar",
       "action_edit": "Editar",
-      "action_manage": "Administrar"
+      "action_manage": "Administrar",
+      "blood_type": "Tipo de sangre",
+      "blood_type_unset": "Sin tipo de sangre registrado",
+      "blood_type_select_title": "Seleccioná tu tipo de sangre",
+      "blood_type_select_subtitle": "Esta información aparece en tu credencial digital y es útil ante una emergencia.",
+      "blood_type_updated": "Tipo de sangre actualizado a {value}",
+      "blood_type_update_failed": "No se pudo actualizar el tipo de sangre"
     },
     "settings": {
       "change_password_dialog_title": "Cambiar contraseña",

--- a/assets/translations/fr.json
+++ b/assets/translations/fr.json
@@ -2614,7 +2614,13 @@
       "not_registered": "Non enregistré",
       "load_error": "Erreur de chargement",
       "action_edit": "Modifier",
-      "action_manage": "Gérer"
+      "action_manage": "Gérer",
+      "blood_type": "Groupe sanguin",
+      "blood_type_unset": "Aucun groupe sanguin enregistré",
+      "blood_type_select_title": "Choisissez votre groupe sanguin",
+      "blood_type_select_subtitle": "Cette information figure sur votre carte numérique et est utile en cas d'urgence.",
+      "blood_type_updated": "Groupe sanguin mis à jour : {value}",
+      "blood_type_update_failed": "Impossible de mettre à jour le groupe sanguin"
     },
     "settings": {
       "change_password_dialog_title": "Changer le mot de passe",

--- a/assets/translations/pt-BR.json
+++ b/assets/translations/pt-BR.json
@@ -2614,7 +2614,13 @@
       "not_registered": "Não registrado",
       "load_error": "Erro ao carregar",
       "action_edit": "Editar",
-      "action_manage": "Gerenciar"
+      "action_manage": "Gerenciar",
+      "blood_type": "Tipo sanguíneo",
+      "blood_type_unset": "Sem tipo sanguíneo registrado",
+      "blood_type_select_title": "Selecione seu tipo sanguíneo",
+      "blood_type_select_subtitle": "Esta informação aparece na sua credencial digital e é útil em caso de emergência.",
+      "blood_type_updated": "Tipo sanguíneo atualizado para {value}",
+      "blood_type_update_failed": "Não foi possível atualizar o tipo sanguíneo"
     },
     "settings": {
       "change_password_dialog_title": "Alterar senha",

--- a/lib/features/profile/data/models/user_detail_model.dart
+++ b/lib/features/profile/data/models/user_detail_model.dart
@@ -18,6 +18,7 @@ class UserDetailModel extends UserDetail {
     super.clubName,
     super.clubType,
     super.currentClass,
+    super.blood,
     super.roles,
     super.createdAt,
     super.lastSignInAt,
@@ -63,6 +64,7 @@ class UserDetailModel extends UserDetail {
       clubName: club?['club_name'] as String? ?? club?['name'] as String?,
       clubType: club?['club_type'] as String? ?? club?['type'] as String?,
       currentClass: json['current_class']?['name'] as String?,
+      blood: json['blood'] as String?,
       roles: roles,
       createdAt: json['created_at'] != null
           ? DateTime.tryParse(json['created_at'].toString())
@@ -88,6 +90,7 @@ class UserDetailModel extends UserDetail {
       'address': address,
       'baptism': baptized,
       'baptism_date': baptismDate?.toIso8601String(),
+      'blood': blood,
       'created_at': createdAt?.toIso8601String(),
       'last_sign_in_at': lastSignInAt?.toIso8601String(),
     };
@@ -110,6 +113,7 @@ class UserDetailModel extends UserDetail {
     String? clubName,
     String? clubType,
     String? currentClass,
+    String? blood,
     List<String>? roles,
     DateTime? createdAt,
     DateTime? lastSignInAt,
@@ -130,6 +134,7 @@ class UserDetailModel extends UserDetail {
       clubName: clubName ?? this.clubName,
       clubType: clubType ?? this.clubType,
       currentClass: currentClass ?? this.currentClass,
+      blood: blood ?? this.blood,
       roles: roles ?? this.roles,
       createdAt: createdAt ?? this.createdAt,
       lastSignInAt: lastSignInAt ?? this.lastSignInAt,

--- a/lib/features/profile/domain/entities/user_detail.dart
+++ b/lib/features/profile/domain/entities/user_detail.dart
@@ -17,6 +17,7 @@ class UserDetail extends Equatable {
   final String? clubName;
   final String? clubType;
   final String? currentClass;
+  final String? blood;
   final List<String> roles;
   final DateTime? createdAt;
   final DateTime? lastSignInAt;
@@ -37,6 +38,7 @@ class UserDetail extends Equatable {
     this.clubName,
     this.clubType,
     this.currentClass,
+    this.blood,
     this.roles = const [],
     this.createdAt,
     this.lastSignInAt,
@@ -67,6 +69,7 @@ class UserDetail extends Equatable {
         clubName,
         clubType,
         currentClass,
+        blood,
         roles,
         createdAt,
         lastSignInAt,

--- a/lib/features/profile/presentation/views/medical_info_view.dart
+++ b/lib/features/profile/presentation/views/medical_info_view.dart
@@ -12,9 +12,49 @@ import 'package:sacdia_app/features/post_registration/presentation/views/disease
 import 'package:sacdia_app/features/post_registration/presentation/views/medicines_selection_view.dart';
 import 'package:sacdia_app/features/post_registration/presentation/views/emergency_contacts_view.dart';
 import 'package:sacdia_app/features/post_registration/presentation/views/legal_representative_view.dart';
+import 'package:sacdia_app/features/profile/presentation/providers/profile_providers.dart';
+import 'package:sacdia_app/features/profile/presentation/widgets/blood_type_selector.dart';
+import 'package:sacdia_app/features/virtual_card/presentation/providers/virtual_card_providers.dart';
 
 class MedicalInfoView extends ConsumerWidget {
   const MedicalInfoView({super.key});
+
+  Future<void> _handleEditBlood(
+    BuildContext context,
+    WidgetRef ref,
+    String? currentBlood,
+  ) async {
+    final messenger = ScaffoldMessenger.of(context);
+    final selected = await showBloodTypeSelector(
+      context,
+      current: BloodType.fromDisplay(currentBlood),
+    );
+    if (selected == null) return;
+
+    final ok = await ref
+        .read(profileNotifierProvider.notifier)
+        .updateProfile({'blood': selected.apiKey});
+
+    if (ok) {
+      // Refrescar la credencial digital para que muestre el nuevo tipo
+      // de sangre sin requerir pull-to-refresh manual.
+      ref.invalidate(virtualCardFetcherProvider);
+    }
+
+    messenger.showSnackBar(
+      SnackBar(
+        content: Text(
+          ok
+              ? 'profile.medical_info.blood_type_updated'
+                  .tr(namedArgs: {'value': selected.display})
+              : 'profile.medical_info.blood_type_update_failed'.tr(),
+        ),
+        behavior: SnackBarBehavior.floating,
+        backgroundColor: ok ? null : AppColors.error,
+        duration: const Duration(seconds: 2),
+      ),
+    );
+  }
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -24,6 +64,7 @@ class MedicalInfoView extends ConsumerWidget {
     final contactsAsync = ref.watch(emergencyContactsProvider);
     final legalRepAsync = ref.watch(legalRepresentativeProvider);
     final legalRequiredAsync = ref.watch(legalRepresentativeRequiredProvider);
+    final profileAsync = ref.watch(profileNotifierProvider);
 
     final c = context.sac;
 
@@ -34,6 +75,65 @@ class MedicalInfoView extends ConsumerWidget {
       body: ListView(
         padding: const EdgeInsets.all(16),
         children: [
+          // Tipo de sangre — sección compacta antes de las alergias.
+          _MedicalSectionCard(
+            icon: HugeIcons.strokeRoundedBlood,
+            title: 'profile.medical_info.blood_type'.tr(),
+            iconColor: AppColors.error,
+            body: profileAsync.when(
+              loading: () => const Padding(
+                padding: EdgeInsets.symmetric(vertical: 8),
+                child: SacLoadingSmall(),
+              ),
+              error: (e, _) => _SectionError(
+                message: e.toString(),
+                onRetry: () =>
+                    ref.read(profileNotifierProvider.notifier).refresh(),
+              ),
+              data: (profile) {
+                final blood = profile?.blood?.trim();
+                if (blood == null || blood.isEmpty) {
+                  return Text(
+                    'profile.medical_info.blood_type_unset'.tr(),
+                    style: TextStyle(
+                      fontSize: 14,
+                      color: c.textTertiary,
+                      fontStyle: FontStyle.italic,
+                    ),
+                  );
+                }
+                return Container(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 14,
+                    vertical: 6,
+                  ),
+                  decoration: BoxDecoration(
+                    color: AppColors.errorLight,
+                    borderRadius: BorderRadius.circular(999),
+                    border: Border.all(
+                      color: AppColors.error.withValues(alpha: 0.3),
+                    ),
+                  ),
+                  child: Text(
+                    blood,
+                    style: TextStyle(
+                      fontSize: 16,
+                      fontWeight: FontWeight.w800,
+                      color: AppColors.errorDark,
+                      letterSpacing: 0.4,
+                    ),
+                  ),
+                );
+              },
+            ),
+            actionLabel: 'profile.medical_info.action_edit'.tr(),
+            onAction: () => _handleEditBlood(
+              context,
+              ref,
+              profileAsync.valueOrNull?.blood,
+            ),
+          ),
+          const SizedBox(height: 12),
           _MedicalSectionCard(
             icon: HugeIcons.strokeRoundedFirstAidKit,
             title: 'profile.medical_info.allergies'.tr(),

--- a/lib/features/profile/presentation/widgets/blood_type_selector.dart
+++ b/lib/features/profile/presentation/widgets/blood_type_selector.dart
@@ -1,0 +1,135 @@
+import 'package:easy_localization/easy_localization.dart';
+import 'package:flutter/material.dart';
+
+/// Tipos de sangre soportados por el backend (`enum blood_type` en Prisma).
+///
+/// - [display] es el valor visible al usuario y el que vuelve del backend
+///   en GET (`'A+'`, `'O-'`, etc.) — ya viene mapeado por Prisma vía `@map`.
+/// - [apiKey] es la key TypeScript del enum que el backend espera en PATCH
+///   `/users/:id` con campo `blood` (validado por `@IsEnum(blood_type)`).
+enum BloodType {
+  aPos('A+', 'A_POSITIVE'),
+  aNeg('A-', 'A_NEGATIVE'),
+  bPos('B+', 'B_POSITIVE'),
+  bNeg('B-', 'B_NEGATIVE'),
+  abPos('AB+', 'AB_POSITIVE'),
+  abNeg('AB-', 'AB_NEGATIVE'),
+  oPos('O+', 'O_POSITIVE'),
+  oNeg('O-', 'O_NEGATIVE');
+
+  const BloodType(this.display, this.apiKey);
+
+  final String display;
+  final String apiKey;
+
+  static BloodType? fromDisplay(String? value) {
+    if (value == null || value.isEmpty) return null;
+    for (final t in BloodType.values) {
+      if (t.display == value) return t;
+    }
+    return null;
+  }
+}
+
+/// Bottomsheet para elegir tipo de sangre.
+///
+/// Devuelve el [BloodType] seleccionado, o `null` si el usuario cancela.
+Future<BloodType?> showBloodTypeSelector(
+  BuildContext context, {
+  BloodType? current,
+}) {
+  return showModalBottomSheet<BloodType>(
+    context: context,
+    isScrollControlled: false,
+    showDragHandle: true,
+    builder: (ctx) => _BloodTypeSheet(current: current),
+  );
+}
+
+class _BloodTypeSheet extends StatelessWidget {
+  const _BloodTypeSheet({this.current});
+
+  final BloodType? current;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return SafeArea(
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(16, 4, 16, 16),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              'profile.medical_info.blood_type_select_title'.tr(),
+              style: theme.textTheme.titleMedium?.copyWith(
+                fontWeight: FontWeight.w700,
+              ),
+            ),
+            const SizedBox(height: 4),
+            Text(
+              'profile.medical_info.blood_type_select_subtitle'.tr(),
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+            const SizedBox(height: 12),
+            GridView.count(
+              crossAxisCount: 4,
+              shrinkWrap: true,
+              physics: const NeverScrollableScrollPhysics(),
+              mainAxisSpacing: 8,
+              crossAxisSpacing: 8,
+              childAspectRatio: 1.6,
+              children: BloodType.values.map((t) {
+                final selected = current == t;
+                return _BloodChip(
+                  label: t.display,
+                  selected: selected,
+                  onTap: () => Navigator.of(context).pop(t),
+                );
+              }).toList(),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _BloodChip extends StatelessWidget {
+  const _BloodChip({
+    required this.label,
+    required this.selected,
+    required this.onTap,
+  });
+
+  final String label;
+  final bool selected;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    return Material(
+      color: selected ? scheme.primary : scheme.surfaceContainerHigh,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(12),
+        child: Center(
+          child: Text(
+            label,
+            style: TextStyle(
+              fontSize: 16,
+              fontWeight: FontWeight.w800,
+              color: selected ? scheme.onPrimary : scheme.onSurface,
+              letterSpacing: 0.4,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
Re-aperturado limpio (reemplaza PR #44 que tenía conflictos por squash-merge de #43).

- Nueva sección "Tipo de sangre" en `MedicalInfoView` con el mismo `_MedicalSectionCard` pattern usado por alergias / enfermedades / contactos
- Bottomsheet selector 8 celdas (A+, A-, B+, B-, AB+, AB-, O+, O-) via nuevo `BloodType` enum que bridgea la asimetría del backend (GET retorna `'A+'` / `'O-'`, PATCH espera `A_POSITIVE` / `O_NEGATIVE`)
- Reusa el flow existente `ProfileNotifier.updateProfile(Map)` → `PATCH /users/:id`
- Auto-invalida `virtualCardFetcherProvider` después de update exitoso para que la credencial inmersiva refleje el nuevo valor sin pull-to-refresh manual
- i18n keys agregadas bajo `profile.medical_info.*` en es / en / fr / pt-BR

## Test plan
- [ ] Profile → Información médica → tap Editar en sección "Tipo de sangre"
- [ ] Verificar grid 8 celdas con valor actual highlighted (si está set)
- [ ] Pick valor → SnackBar "Tipo de sangre actualizado a {X}"
- [ ] Navegar a credencial → SANGRE mini-field con nuevo valor (sin refresh manual)
- [ ] Cambiar idioma app → strings nuevos en en / fr / pt-BR
- [ ] `flutter analyze` clean (verificado)
- [ ] `flutter test` 195 passed (verificado, sin regresiones)

## Notes
- Backend ya soporta `blood?: blood_type` en `update-user.dto.ts` (no se requieren cambios)
- `UserDetail` entity gana campo opcional `blood`; parseado desde `json['blood']` en `UserDetailModel.fromJson`
- Follow-up: pattern similar para `current_class` y `gender` si se decide después