### PR TITLE
feat(post-registration): capture blood type in personal info step

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -735,6 +735,10 @@
         "label": "Baptism date",
         "date_picker_help": "Select your baptism date"
       },
+      "blood": {
+        "label": "Blood type",
+        "empty": "Select blood type"
+      },
       "emergency_contacts": {
         "section_title": "Emergency contacts",
         "hint": "Add at least one emergency contact",

--- a/assets/translations/es.json
+++ b/assets/translations/es.json
@@ -735,6 +735,10 @@
         "label": "Fecha de bautismo",
         "date_picker_help": "Seleccioná tu fecha de bautismo"
       },
+      "blood": {
+        "label": "Tipo de sangre",
+        "empty": "Seleccionar tipo de sangre"
+      },
       "emergency_contacts": {
         "section_title": "Contactos de emergencia",
         "hint": "Registrá al menos un contacto de emergencia",

--- a/assets/translations/fr.json
+++ b/assets/translations/fr.json
@@ -735,6 +735,10 @@
         "label": "Date de baptême",
         "date_picker_help": "Sélectionnez votre date de baptême"
       },
+      "blood": {
+        "label": "Groupe sanguin",
+        "empty": "Sélectionner un groupe sanguin"
+      },
       "emergency_contacts": {
         "section_title": "Contacts d’urgence",
         "hint": "Enregistrez au moins un contact d’urgence",

--- a/assets/translations/pt-BR.json
+++ b/assets/translations/pt-BR.json
@@ -735,6 +735,10 @@
         "label": "Data de batismo",
         "date_picker_help": "Selecione sua data de batismo"
       },
+      "blood": {
+        "label": "Tipo sanguíneo",
+        "empty": "Selecionar tipo sanguíneo"
+      },
       "emergency_contacts": {
         "section_title": "Contatos de emergência",
         "hint": "Registre pelo menos um contato de emergência",

--- a/lib/core/theme/app_colors.dart
+++ b/lib/core/theme/app_colors.dart
@@ -143,33 +143,34 @@ class AppColors {
   // ═══════════════════════════════════════════════════════════
 
   // Brand coral (alias + extended scale)
-  static const Color coral50  = Color(0xFFFFF1EE);
+  static const Color coral50 = Color(0xFFFFF1EE);
   static const Color coral100 = Color(0xFFFFE3DD);
   static const Color coral200 = Color(0xFFFFC9BE);
-  static const Color coral500 = Color(0xFFEF6B5C); // primary (same hue as AppColors.primary)
+  static const Color coral500 =
+      Color(0xFFEF6B5C); // primary (same hue as AppColors.primary)
   static const Color coral600 = Color(0xFFDD5A4B);
   static const Color coral700 = Color(0xFFB8453A);
 
   // Requisito status — color / bg / dark variants
   static const Color validatedColor = Color(0xFF4FB37C);
-  static const Color validatedBg    = Color(0xFFE8F5EE);
-  static const Color validatedDark  = Color(0xFF2E7A52);
+  static const Color validatedBg = Color(0xFFE8F5EE);
+  static const Color validatedDark = Color(0xFF2E7A52);
 
-  static const Color sentColor      = Color(0xFF5A7FA8);
-  static const Color sentBg         = Color(0xFFEAF1F8);
-  static const Color sentDark       = Color(0xFF3D6391);
+  static const Color sentColor = Color(0xFF5A7FA8);
+  static const Color sentBg = Color(0xFFEAF1F8);
+  static const Color sentDark = Color(0xFF3D6391);
 
-  static const Color observedColor  = Color(0xFFC99036);
-  static const Color observedBg     = Color(0xFFFCF1DC);
-  static const Color observedDark   = Color(0xFF8B6422);
+  static const Color observedColor = Color(0xFFC99036);
+  static const Color observedBg = Color(0xFFFCF1DC);
+  static const Color observedDark = Color(0xFF8B6422);
 
-  static const Color rejectedColor  = Color(0xFFD14B66);
-  static const Color rejectedBg     = Color(0xFFFDE9EE);
-  static const Color rejectedDark   = Color(0xFFA23147);
+  static const Color rejectedColor = Color(0xFFD14B66);
+  static const Color rejectedBg = Color(0xFFFDE9EE);
+  static const Color rejectedDark = Color(0xFFA23147);
 
-  static const Color pendingColor   = Color(0xFF9AA0AB);
-  static const Color pendingBg      = Color(0xFFF2F4F7);
-  static const Color pendingDark    = Color(0xFF6B7280);
+  static const Color pendingColor = Color(0xFF9AA0AB);
+  static const Color pendingBg = Color(0xFFF2F4F7);
+  static const Color pendingDark = Color(0xFF6B7280);
 
   // Neutrals warm low-saturation ink scale
   static const Color ink900 = Color(0xFF131316);
@@ -182,8 +183,8 @@ class AppColors {
   static const Color ink200 = Color(0xFFE3E5EA);
   static const Color ink150 = Color(0xFFECEEF2);
   static const Color ink100 = Color(0xFFF2F4F7);
-  static const Color ink50  = Color(0xFFF7F8FA);
-  static const Color paper  = Color(0xFFFFFFFF);
+  static const Color ink50 = Color(0xFFF7F8FA);
+  static const Color paper = Color(0xFFFFFFFF);
   static const Color canvas = Color(0xFFFAFAFB);
 
   // ═══════════════════════════════════════════════════════════

--- a/lib/features/classes/data/models/class_requirement_model.dart
+++ b/lib/features/classes/data/models/class_requirement_model.dart
@@ -62,10 +62,10 @@ class ClassRequirementModel extends ClassRequirement {
           (json['observed_by_name'] ?? json['observedByName'])?.toString(),
       observedAt: _parseDate(
           json['observed_at']?.toString() ?? json['observedAt']?.toString()),
-      observationComment:
-          (json['observation_comment'] ?? json['observationComment'] ??
+      observationComment: (json['observation_comment'] ??
+              json['observationComment'] ??
               json['observation'])
-              ?.toString(),
+          ?.toString(),
       rejectedByName:
           (json['rejected_by_name'] ?? json['rejectedByName'])?.toString(),
       rejectedAt: _parseDate(

--- a/lib/features/classes/presentation/roadmap/widgets/roadmap_screen.dart
+++ b/lib/features/classes/presentation/roadmap/widgets/roadmap_screen.dart
@@ -44,7 +44,8 @@ class _RoadmapScreenState extends State<RoadmapScreen> {
     // (incluido el nodo actual, que puede estar debajo del fold) se
     // haya completado antes de llamar a ensureVisible.
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      WidgetsBinding.instance.addPostFrameCallback((_) => _scrollToCurrentNode());
+      WidgetsBinding.instance
+          .addPostFrameCallback((_) => _scrollToCurrentNode());
     });
   }
 
@@ -52,7 +53,8 @@ class _RoadmapScreenState extends State<RoadmapScreen> {
     if (!mounted) return;
 
     final ctx = _currentNodeKey.currentContext;
-    if (ctx == null) return; // No hay clase actual o el widget no está en el árbol.
+    if (ctx == null)
+      return; // No hay clase actual o el widget no está en el árbol.
 
     // Verificar que el RenderObject esté realmente laid out antes de llamar
     // ensureVisible. Si todavía está en NEEDS-LAYOUT la llamada lanzaría

--- a/lib/features/classes/presentation/roadmap/widgets/va_track_header.dart
+++ b/lib/features/classes/presentation/roadmap/widgets/va_track_header.dart
@@ -83,8 +83,7 @@ class VATrackHeader extends StatelessWidget {
           // Pill "Cursando" — visible solo cuando el track tiene la clase actual.
           if (hasCurrent) ...[
             Container(
-              padding:
-                  const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+              padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
               decoration: BoxDecoration(
                 color: RoadmapTokens.statusCurrent.withValues(alpha: 0.15),
                 borderRadius: BorderRadius.circular(999),

--- a/lib/features/classes/presentation/views/class_detail_with_progress_view.dart
+++ b/lib/features/classes/presentation/views/class_detail_with_progress_view.dart
@@ -180,8 +180,7 @@ class _ClassBodyState extends State<_ClassBody> {
                       setState(() => _query = '');
                     },
                   ),
-                  if (!noResults)
-                    const _SectionLabel(text: 'MÓDULOS'),
+                  if (!noResults) const _SectionLabel(text: 'MÓDULOS'),
                 ],
               ),
             ),

--- a/lib/features/classes/presentation/views/classes_list_view.dart
+++ b/lib/features/classes/presentation/views/classes_list_view.dart
@@ -127,7 +127,8 @@ class ClassesListViewBody extends ConsumerWidget {
 
         // Split: current class (index 0) vs others
         final currentClass = classes.first;
-        final otherClasses = classes.length > 1 ? classes.sublist(1) : <dynamic>[];
+        final otherClasses =
+            classes.length > 1 ? classes.sublist(1) : <dynamic>[];
 
         return RefreshIndicator(
           color: AppColors.primary,
@@ -200,8 +201,8 @@ class ClassesListViewBody extends ConsumerWidget {
                     child: Consumer(
                       builder: (context, progressRef, _) {
                         final progressiveClass = otherClasses[i];
-                        final progressAsync = progressRef
-                            .watch(classWithProgressProvider(progressiveClass.id));
+                        final progressAsync = progressRef.watch(
+                            classWithProgressProvider(progressiveClass.id));
                         final progress = progressAsync.whenOrNull(
                               data: (cwp) => cwp.completionRatio,
                             ) ??
@@ -226,7 +227,6 @@ class ClassesListViewBody extends ConsumerWidget {
                     ),
                   ),
               ],
-
             ],
           ),
         );

--- a/lib/features/classes/presentation/views/requirement_detail_view.dart
+++ b/lib/features/classes/presentation/views/requirement_detail_view.dart
@@ -42,8 +42,7 @@ class RequirementDetailView extends ConsumerStatefulWidget {
       _RequirementDetailViewState();
 }
 
-class _RequirementDetailViewState
-    extends ConsumerState<RequirementDetailView> {
+class _RequirementDetailViewState extends ConsumerState<RequirementDetailView> {
   bool _hasUnsavedFiles = false;
 
   ClassRequirement _liveRequirement(AsyncValue<dynamic> classAsync) {
@@ -115,8 +114,7 @@ class _RequirementDetailViewState
         ),
         backgroundColor: AppColors.rejectedColor,
         behavior: SnackBarBehavior.floating,
-        shape:
-            RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
       ),
     );
   }
@@ -151,23 +149,20 @@ class _RequirementDetailViewState
         final confirm = await showDialog<bool>(
           context: context,
           builder: (ctx) => AlertDialog(
-            title:
-                Text('classes.requirement_detail.unsaved_files_title'.tr()),
+            title: Text('classes.requirement_detail.unsaved_files_title'.tr()),
             content: Text(
               'classes.requirement_detail.unsaved_files_body'.tr(),
             ),
             actions: [
               TextButton(
                 onPressed: () => Navigator.pop(ctx, false),
-                child:
-                    Text('classes.requirement_detail.stay_button'.tr()),
+                child: Text('classes.requirement_detail.stay_button'.tr()),
               ),
               TextButton(
                 onPressed: () => Navigator.pop(ctx, true),
                 style: TextButton.styleFrom(
                     foregroundColor: AppColors.rejectedColor),
-                child: Text(
-                    'classes.requirement_detail.leave_button'.tr()),
+                child: Text('classes.requirement_detail.leave_button'.tr()),
               ),
             ],
           ),
@@ -185,9 +180,7 @@ class _RequirementDetailViewState
                 children: [
                   // NavBar
                   _ReqNavBar(
-                    onBack: isLoading
-                        ? null
-                        : () => Navigator.pop(context),
+                    onBack: isLoading ? null : () => Navigator.pop(context),
                     onMore: () => showRequirementStatusHistorySheet(
                       context,
                       requirement: requirement,
@@ -198,8 +191,7 @@ class _RequirementDetailViewState
                     child: SingleChildScrollView(
                       physics: const BouncingScrollPhysics(),
                       child: Padding(
-                        padding:
-                            const EdgeInsets.symmetric(horizontal: 16),
+                        padding: const EdgeInsets.symmetric(horizontal: 16),
                         child: Column(
                           crossAxisAlignment: CrossAxisAlignment.start,
                           children: [
@@ -232,8 +224,7 @@ class _RequirementDetailViewState
                                     RequirementStatus.observado ||
                                 requirement.status ==
                                     RequirementStatus.rechazado)
-                              _BannerEstado(
-                                  status: requirement.status),
+                              _BannerEstado(status: requirement.status),
 
                             // Observation card (observed / rejected)
                             if ((requirement.status ==
@@ -252,8 +243,7 @@ class _RequirementDetailViewState
                                     RequirementStatus.observado &&
                                 requirement.status !=
                                     RequirementStatus.rechazado) ...[
-                              _DescriptionCard(
-                                  text: requirement.description!),
+                              _DescriptionCard(text: requirement.description!),
                               const SizedBox(height: 16),
                             ],
 
@@ -389,7 +379,8 @@ class _RequirementDetailViewState
                                             ),
                                           ],
                                         ),
-                                        backgroundColor: AppColors.validatedColor,
+                                        backgroundColor:
+                                            AppColors.validatedColor,
                                         behavior: SnackBarBehavior.floating,
                                         shape: RoundedRectangleBorder(
                                             borderRadius:
@@ -441,29 +432,25 @@ class _RequirementDetailViewState
 
   int _resolveModuleIndex(
       AsyncValue<dynamic> classAsync, ClassRequirement req) {
-    return classAsync
-            .whenData((cp) {
-              for (final m in cp.modules) {
-                for (int i = 0; i < m.requirements.length; i++) {
-                  if (m.requirements[i].id == req.id) return i + 1;
-                }
-              }
-              return 1;
-            })
-            .valueOrNull ??
+    return classAsync.whenData((cp) {
+          for (final m in cp.modules) {
+            for (int i = 0; i < m.requirements.length; i++) {
+              if (m.requirements[i].id == req.id) return i + 1;
+            }
+          }
+          return 1;
+        }).valueOrNull ??
         1;
   }
 
   int _resolveModuleTotal(
       AsyncValue<dynamic> classAsync, ClassRequirement req) {
-    return classAsync
-            .whenData((cp) {
-              for (final m in cp.modules) {
-                if (m.id == req.moduleId) return m.requirements.length;
-              }
-              return 1;
-            })
-            .valueOrNull ??
+    return classAsync.whenData((cp) {
+          for (final m in cp.modules) {
+            if (m.id == req.moduleId) return m.requirements.length;
+          }
+          return 1;
+        }).valueOrNull ??
         1;
   }
 
@@ -490,15 +477,14 @@ class _RequirementDetailViewState
                   color: Colors.white, size: 18),
               const SizedBox(width: 8),
               Expanded(
-                child: Text(
-                    'classes.requirement_detail.submit_success'.tr()),
+                child: Text('classes.requirement_detail.submit_success'.tr()),
               ),
             ],
           ),
           backgroundColor: AppColors.validatedColor,
           behavior: SnackBarBehavior.floating,
-          shape: RoundedRectangleBorder(
-              borderRadius: BorderRadius.circular(12)),
+          shape:
+              RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
         ),
       );
       // ignore: use_build_context_synchronously
@@ -661,19 +647,20 @@ class _ObservationCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final isObserved = requirement.status == RequirementStatus.observado;
-    final instructorName =
-        (isObserved ? requirement.observedByName : requirement.rejectedByName) ??
-            'Instructor';
-    final comment =
-        (isObserved ? requirement.observationComment : requirement.rejectionReason) ??
-            '';
-    final timestamp = isObserved ? requirement.observedAt : requirement.rejectedAt;
+    final instructorName = (isObserved
+            ? requirement.observedByName
+            : requirement.rejectedByName) ??
+        'Instructor';
+    final comment = (isObserved
+            ? requirement.observationComment
+            : requirement.rejectionReason) ??
+        '';
+    final timestamp =
+        isObserved ? requirement.observedAt : requirement.rejectedAt;
 
     final initials = _initials(instructorName);
-    final avatarBg =
-        isObserved ? AppColors.coral100 : AppColors.rejectedBg;
-    final avatarText =
-        isObserved ? AppColors.coral700 : AppColors.rejectedDark;
+    final avatarBg = isObserved ? AppColors.coral100 : AppColors.rejectedBg;
+    final avatarText = isObserved ? AppColors.coral700 : AppColors.rejectedDark;
 
     return Container(
       margin: const EdgeInsets.only(bottom: 18),
@@ -766,16 +753,16 @@ class _ObservationCard extends StatelessWidget {
     if (parts.length >= 2) {
       return '${parts.first[0]}${parts[1][0]}'.toUpperCase();
     }
-    return name
-        .substring(0, name.length.clamp(0, 2))
-        .toUpperCase();
+    return name.substring(0, name.length.clamp(0, 2)).toUpperCase();
   }
 
   String _timeAgo(DateTime dt) {
     final now = DateTime.now();
     final diff = now.difference(dt);
-    if (diff.inDays >= 1) return 'hace ${diff.inDays} día${diff.inDays == 1 ? '' : 's'}';
-    if (diff.inHours >= 1) return 'hace ${diff.inHours} hora${diff.inHours == 1 ? '' : 's'}';
+    if (diff.inDays >= 1)
+      return 'hace ${diff.inDays} día${diff.inDays == 1 ? '' : 's'}';
+    if (diff.inHours >= 1)
+      return 'hace ${diff.inHours} hora${diff.inHours == 1 ? '' : 's'}';
     if (diff.inMinutes >= 1) {
       return 'hace ${diff.inMinutes} minuto${diff.inMinutes == 1 ? '' : 's'}';
     }
@@ -810,8 +797,7 @@ class _FileRowsList extends StatelessWidget {
             )),
 
         // Empty file slot if canModify
-        if (canModify)
-          _EmptyFileSlot(onTap: onUploadTap ?? () {}),
+        if (canModify) _EmptyFileSlot(onTap: onUploadTap ?? () {}),
       ],
     );
   }
@@ -834,8 +820,7 @@ class _FileRow extends StatelessWidget {
     // In rejected context, files show "Rechazado" badge (observedBg/observedDark).
     // Note: the handoff uses "observedBg" yellow for rejected file icon bg — we
     // follow the reference exactly.
-    final iconBg =
-        isObservedContext ? AppColors.sentBg : AppColors.observedBg;
+    final iconBg = isObservedContext ? AppColors.sentBg : AppColors.observedBg;
     final iconColor =
         isObservedContext ? AppColors.sentDark : AppColors.observedDark;
     final badgeLabel = isObservedContext ? 'En revisión' : 'Rechazado';
@@ -908,8 +893,7 @@ class _FileRow extends StatelessWidget {
 
           // Badge pill
           Container(
-            padding:
-                const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+            padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
             decoration: BoxDecoration(
               color: badgeBg,
               borderRadius: BorderRadius.circular(999),
@@ -931,8 +915,10 @@ class _FileRow extends StatelessWidget {
   String _timeAgo(DateTime dt) {
     final now = DateTime.now();
     final diff = now.difference(dt);
-    if (diff.inDays >= 1) return 'Hace ${diff.inDays} día${diff.inDays == 1 ? '' : 's'}';
-    if (diff.inHours >= 1) return 'Hace ${diff.inHours} hora${diff.inHours == 1 ? '' : 's'}';
+    if (diff.inDays >= 1)
+      return 'Hace ${diff.inDays} día${diff.inDays == 1 ? '' : 's'}';
+    if (diff.inHours >= 1)
+      return 'Hace ${diff.inHours} hora${diff.inHours == 1 ? '' : 's'}';
     return 'Hace un momento';
   }
 }

--- a/lib/features/post_registration/data/datasources/personal_info_remote_data_source.dart
+++ b/lib/features/post_registration/data/datasources/personal_info_remote_data_source.dart
@@ -17,6 +17,7 @@ abstract class PersonalInfoRemoteDataSource {
     String? birthdate,
     bool? baptized,
     String? baptismDate,
+    String? blood,
   });
 
   Future<List<EmergencyContactModel>> getEmergencyContacts(String userId,
@@ -83,6 +84,7 @@ class PersonalInfoRemoteDataSourceImpl implements PersonalInfoRemoteDataSource {
     String? birthdate,
     bool? baptized,
     String? baptismDate,
+    String? blood,
   }) async {
     try {
       final data = <String, dynamic>{};
@@ -93,6 +95,7 @@ class PersonalInfoRemoteDataSourceImpl implements PersonalInfoRemoteDataSource {
       if (baptized == true && baptismDate != null) {
         data['baptism_date'] = baptismDate;
       }
+      if (blood != null) data['blood'] = blood;
 
       final response = await dio.patch(
         '$_baseUrl${ApiEndpoints.users}/$userId',

--- a/lib/features/post_registration/presentation/providers/personal_info_providers.dart
+++ b/lib/features/post_registration/presentation/providers/personal_info_providers.dart
@@ -9,6 +9,7 @@ import '../../data/models/disease_model.dart';
 import '../../data/models/medicine_model.dart';
 import '../../data/models/relationship_type_model.dart';
 import '../../../auth/presentation/providers/auth_providers.dart';
+import '../../../profile/presentation/widgets/blood_type_selector.dart';
 import '../../../../providers/dio_provider.dart';
 import '../../../../core/utils/app_logger.dart';
 
@@ -29,12 +30,14 @@ class PersonalInfoFormState {
   final DateTime? birthdate;
   final bool baptized;
   final DateTime? baptismDate;
+  final BloodType? bloodType;
 
   const PersonalInfoFormState({
     this.gender,
     this.birthdate,
     this.baptized = false,
     this.baptismDate,
+    this.bloodType,
   });
 
   PersonalInfoFormState copyWith({
@@ -42,12 +45,14 @@ class PersonalInfoFormState {
     DateTime? birthdate,
     bool? baptized,
     DateTime? baptismDate,
+    BloodType? bloodType,
   }) {
     return PersonalInfoFormState(
       gender: gender ?? this.gender,
       birthdate: birthdate ?? this.birthdate,
       baptized: baptized ?? this.baptized,
       baptismDate: baptismDate ?? this.baptismDate,
+      bloodType: bloodType ?? this.bloodType,
     );
   }
 }
@@ -565,7 +570,7 @@ class SavePersonalInfoNotifier extends AutoDisposeAsyncNotifier<void> {
       final dataSource = ref.read(personalInfoDataSourceProvider);
 
       AppLogger.d(
-        'savePersonalInfo userId=$userId gender=${formState.gender} baptized=${formState.baptized}',
+        'savePersonalInfo userId=$userId gender=${formState.gender} baptized=${formState.baptized} blood=${formState.bloodType?.apiKey}',
         tag: tag,
       );
 
@@ -575,6 +580,7 @@ class SavePersonalInfoNotifier extends AutoDisposeAsyncNotifier<void> {
         birthdate: formState.birthdate?.toUtc().toIso8601String(),
         baptized: formState.baptized,
         baptismDate: formState.baptismDate?.toUtc().toIso8601String(),
+        blood: formState.bloodType?.apiKey,
       );
 
       final selectedAllergies = ref.read(selectedAllergiesProvider);

--- a/lib/features/post_registration/presentation/views/personal_info_step_view.dart
+++ b/lib/features/post_registration/presentation/views/personal_info_step_view.dart
@@ -10,6 +10,7 @@ import 'package:sacdia_app/core/utils/responsive.dart';
 import 'package:sacdia_app/core/widgets/sac_card.dart';
 import 'package:sacdia_app/features/auth/domain/utils/authorization_utils.dart';
 import 'package:sacdia_app/features/auth/presentation/providers/auth_providers.dart';
+import 'package:sacdia_app/features/profile/presentation/widgets/blood_type_selector.dart';
 import '../providers/personal_info_providers.dart';
 import 'emergency_contacts_view.dart';
 import 'legal_representative_view.dart';
@@ -216,6 +217,18 @@ class _PersonalInfoStepViewState extends ConsumerState<PersonalInfoStepView> {
                 onTap: () => _selectBaptismDate(context),
               ),
             ],
+            const SizedBox(height: 20),
+            Text(
+              tr('post_registration.personal_info.blood.label'),
+              style: Theme.of(context).textTheme.labelLarge?.copyWith(
+                    color: context.sac.textSecondary,
+                  ),
+            ),
+            const SizedBox(height: 8),
+            _BloodTypeCard(
+              bloodType: formState.bloodType,
+              onTap: () => _selectBloodType(context),
+            ),
             const SizedBox(height: 28),
           ],
 
@@ -603,6 +616,14 @@ class _PersonalInfoStepViewState extends ConsumerState<PersonalInfoStepView> {
     }
   }
 
+  Future<void> _selectBloodType(BuildContext context) async {
+    final current = ref.read(personalInfoFormProvider).bloodType;
+    final picked = await showBloodTypeSelector(context, current: current);
+    if (picked == null) return;
+    ref.read(personalInfoFormProvider.notifier).state =
+        ref.read(personalInfoFormProvider).copyWith(bloodType: picked);
+  }
+
   Future<void> _selectBaptismDate(BuildContext context) async {
     final birthdate = ref.read(personalInfoFormProvider).birthdate;
     final now = DateTime.now();
@@ -847,6 +868,62 @@ class _DatePickerCard extends StatelessWidget {
           HugeIcon(
             icon: HugeIcons.strokeRoundedCalendar01,
             size: 18,
+            color: context.sac.textTertiary,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Card para mostrar y seleccionar tipo de sangre.
+class _BloodTypeCard extends StatelessWidget {
+  final BloodType? bloodType;
+  final VoidCallback onTap;
+
+  const _BloodTypeCard({required this.bloodType, required this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    final selected = bloodType != null;
+    return SacCard(
+      onTap: onTap,
+      child: Row(
+        children: [
+          Container(
+            width: 40,
+            height: 40,
+            decoration: BoxDecoration(
+              color: selected
+                  ? AppColors.errorLight
+                  : context.sac.surfaceVariant,
+              borderRadius: BorderRadius.circular(10),
+            ),
+            child: Center(
+              child: HugeIcon(
+                icon: HugeIcons.strokeRoundedBlood,
+                size: 20,
+                color:
+                    selected ? AppColors.error : context.sac.textTertiary,
+              ),
+            ),
+          ),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Text(
+              selected
+                  ? bloodType!.display
+                  : tr('post_registration.personal_info.blood.empty'),
+              style: TextStyle(
+                fontSize: 15,
+                fontWeight: selected ? FontWeight.w700 : FontWeight.w500,
+                color: selected ? context.sac.text : context.sac.textTertiary,
+                letterSpacing: selected ? 0.4 : 0,
+              ),
+            ),
+          ),
+          HugeIcon(
+            icon: HugeIcons.strokeRoundedArrowRight01,
             color: context.sac.textTertiary,
           ),
         ],

--- a/lib/features/post_registration/presentation/views/personal_info_step_view.dart
+++ b/lib/features/post_registration/presentation/views/personal_info_step_view.dart
@@ -894,17 +894,15 @@ class _BloodTypeCard extends StatelessWidget {
             width: 40,
             height: 40,
             decoration: BoxDecoration(
-              color: selected
-                  ? AppColors.errorLight
-                  : context.sac.surfaceVariant,
+              color:
+                  selected ? AppColors.errorLight : context.sac.surfaceVariant,
               borderRadius: BorderRadius.circular(10),
             ),
             child: Center(
               child: HugeIcon(
                 icon: HugeIcons.strokeRoundedBlood,
                 size: 20,
-                color:
-                    selected ? AppColors.error : context.sac.textTertiary,
+                color: selected ? AppColors.error : context.sac.textTertiary,
               ),
             ),
           ),

--- a/lib/features/virtual_card/data/repositories/virtual_card_repository_impl.dart
+++ b/lib/features/virtual_card/data/repositories/virtual_card_repository_impl.dart
@@ -74,8 +74,7 @@ class VirtualCardRepositoryImpl implements VirtualCardRepository {
     } on AppException {
       rethrow;
     } catch (e) {
-      AppLogger.e('Error inesperado al descargar PDF',
-          tag: _tag, error: e);
+      AppLogger.e('Error inesperado al descargar PDF', tag: _tag, error: e);
       throw ServerException(message: e.toString());
     }
   }

--- a/lib/features/virtual_card/presentation/views/virtual_card_view.dart
+++ b/lib/features/virtual_card/presentation/views/virtual_card_view.dart
@@ -193,9 +193,7 @@ class _VirtualCardViewState extends ConsumerState<VirtualCardView> {
                             const SizedBox(width: 8),
                             Expanded(
                               child: ActionPill(
-                                label: _downloadingPdf
-                                    ? 'Descargando…'
-                                    : 'PDF',
+                                label: _downloadingPdf ? 'Descargando…' : 'PDF',
                                 icon: ActionIcon.pdf,
                                 onTap: _downloadingPdf
                                     ? null

--- a/lib/features/virtual_card/presentation/widgets/credencial/credencial_card.dart
+++ b/lib/features/virtual_card/presentation/widgets/credencial/credencial_card.dart
@@ -231,8 +231,7 @@ class CredencialCard extends StatelessWidget {
                       CredChip(label: 'Etapa ${vm.etapa}')
                     else if (vm.cargo.isNotEmpty &&
                         vm.sectionFull.isNotEmpty &&
-                        vm.cargo.toLowerCase() !=
-                            vm.sectionFull.toLowerCase())
+                        vm.cargo.toLowerCase() != vm.sectionFull.toLowerCase())
                       CredChip(label: vm.sectionFull),
                   ],
                 ),
@@ -304,8 +303,7 @@ class CredencialCard extends StatelessWidget {
                   padding: const EdgeInsets.all(8),
                   decoration: BoxDecoration(
                     color: Colors.white,
-                    borderRadius:
-                        BorderRadius.circular(CredencialTokens.rCard),
+                    borderRadius: BorderRadius.circular(CredencialTokens.rCard),
                     border: Border.all(color: CredencialTokens.borderLight),
                     boxShadow: [
                       BoxShadow(

--- a/lib/features/virtual_card/presentation/widgets/credencial/credencial_qr_fullscreen.dart
+++ b/lib/features/virtual_card/presentation/widgets/credencial/credencial_qr_fullscreen.dart
@@ -31,8 +31,7 @@ class CredencialQrFullscreen extends StatefulWidget {
   });
 
   @override
-  State<CredencialQrFullscreen> createState() =>
-      _CredencialQrFullscreenState();
+  State<CredencialQrFullscreen> createState() => _CredencialQrFullscreenState();
 }
 
 class _CredencialQrFullscreenState extends State<CredencialQrFullscreen> {
@@ -82,8 +81,8 @@ class _CredencialQrFullscreenState extends State<CredencialQrFullscreen> {
     final messenger = ScaffoldMessenger.of(context);
 
     try {
-      final boundary = _qrBoundaryKey.currentContext
-          ?.findRenderObject() as RenderRepaintBoundary?;
+      final boundary = _qrBoundaryKey.currentContext?.findRenderObject()
+          as RenderRepaintBoundary?;
       if (boundary == null) {
         throw StateError('QR boundary no encontrado');
       }

--- a/lib/features/virtual_card/presentation/widgets/credencial/credencial_view_model.dart
+++ b/lib/features/virtual_card/presentation/widgets/credencial/credencial_view_model.dart
@@ -129,11 +129,17 @@ class CredencialViewModel {
     final source =
         '${card.clubName ?? ''} ${card.roleCode ?? ''} ${card.sectionName ?? ''}'
             .toLowerCase();
-    if (source.contains('avent')) { return SeccionCode.AV; }
+    if (source.contains('avent')) {
+      return SeccionCode.AV;
+    }
     if (source.contains('guia') ||
         source.contains('guía') ||
-        source.contains('mayor')) { return SeccionCode.GM; }
-    if (source.contains('conq')) { return SeccionCode.CQ; }
+        source.contains('mayor')) {
+      return SeccionCode.GM;
+    }
+    if (source.contains('conq')) {
+      return SeccionCode.CQ;
+    }
     // Default to CQ — the most common section in SACDIA clubs.
     return SeccionCode.CQ;
   }
@@ -149,8 +155,7 @@ class CredencialViewModel {
           .split(RegExp(r'\s+'))
           .where((w) => w.isNotEmpty)
           .toList();
-      final acronym =
-          words.take(3).map((w) => w[0].toUpperCase()).join();
+      final acronym = words.take(3).map((w) => w[0].toUpperCase()).join();
       if (acronym.isNotEmpty) return acronym;
     }
     if (sectionName != null && sectionName.trim().length >= 3) {

--- a/test/features/virtual_card/credencial_pdf_test.dart
+++ b/test/features/virtual_card/credencial_pdf_test.dart
@@ -96,7 +96,8 @@ void main() {
       expect(withoutEmergencia[0], equals(0x25));
     });
 
-    test('generates PDF when qrData is empty (no QR widget rendered)', () async {
+    test('generates PDF when qrData is empty (no QR widget rendered)',
+        () async {
       final vm = CredencialViewModel(
         nombre: 'Sin QR',
         cargo: 'Miembro',


### PR DESCRIPTION
## Summary
- Add optional `BloodType` field to `PersonalInfoFormState` and surface it in the personal-info step view via the existing profile bottomsheet selector.
- Forward the selected value to PATCH `/users/:id` as `blood` (TS enum key) using the shared `updatePersonalInfo` datasource path used by gender/birthday/baptism.
- Add i18n keys `post_registration.personal_info.blood.{label,empty}` in es/en/fr/pt-BR.

## Why
Edit-blood landed in `medical_info_view` (PR #45) but onboarding never collected it, so all new users defaulted to null and the credencial digital displayed empty until a manual edit.

## Notes
- Field is optional. `canCompleteStep2Provider` is unchanged.
- Reuses `BloodType` enum + `showBloodTypeSelector` from `lib/features/profile/presentation/widgets/blood_type_selector.dart` — no duplication.
- Backend already accepts `blood` on this endpoint (PR #79).

## Test plan
- [ ] Open POST-REG step 2, tap blood card, choose any type, finish step → verify `PATCH /users/:id` body includes `blood: <KEY>`.
- [ ] Skip blood selection → step still completes; PATCH body omits `blood`.
- [ ] After save, open `MedicalInfoView` → blood pill shows the selected display value.
- [ ] Verify selector renders in es/en/fr/pt-BR.
- [ ] `flutter analyze` clean.