### PR TITLE
feat(profile): edit gender from profile via bottomsheet selector

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -2602,7 +2602,12 @@
       "date_placeholder": "Select date",
       "date_picker_cancel": "Cancel",
       "date_picker_confirm": "OK",
-      "crop_photo_title": "Crop photo"
+      "crop_photo_title": "Crop photo",
+      "gender_select_title": "Select your gender",
+      "gender_select_subtitle": "This information appears on your profile and digital credential.",
+      "gender_updated": "Gender updated to {value}",
+      "gender_update_failed": "Could not update gender",
+      "gender_unset": "Gender not set"
     },
     "medical_info": {
       "title": "Medical Info",

--- a/assets/translations/es.json
+++ b/assets/translations/es.json
@@ -2602,7 +2602,12 @@
       "date_placeholder": "Seleccionar fecha",
       "date_picker_cancel": "Cancelar",
       "date_picker_confirm": "Aceptar",
-      "crop_photo_title": "Recortar foto"
+      "crop_photo_title": "Recortar foto",
+      "gender_select_title": "Seleccioná tu género",
+      "gender_select_subtitle": "Esta información aparece en tu perfil y credencial digital.",
+      "gender_updated": "Género actualizado a {value}",
+      "gender_update_failed": "No se pudo actualizar el género",
+      "gender_unset": "Sin género registrado"
     },
     "medical_info": {
       "title": "Información Médica",

--- a/assets/translations/fr.json
+++ b/assets/translations/fr.json
@@ -2602,7 +2602,12 @@
       "date_placeholder": "Sélectionner une date",
       "date_picker_cancel": "Annuler",
       "date_picker_confirm": "OK",
-      "crop_photo_title": "Rogner la photo"
+      "crop_photo_title": "Rogner la photo",
+      "gender_select_title": "Sélectionnez votre genre",
+      "gender_select_subtitle": "Ces informations apparaissent sur votre profil et votre carte numérique.",
+      "gender_updated": "Genre mis à jour : {value}",
+      "gender_update_failed": "Impossible de mettre à jour le genre",
+      "gender_unset": "Genre non renseigné"
     },
     "medical_info": {
       "title": "Informations médicales",

--- a/assets/translations/pt-BR.json
+++ b/assets/translations/pt-BR.json
@@ -2602,7 +2602,12 @@
       "date_placeholder": "Selecionar data",
       "date_picker_cancel": "Cancelar",
       "date_picker_confirm": "OK",
-      "crop_photo_title": "Recortar foto"
+      "crop_photo_title": "Recortar foto",
+      "gender_select_title": "Selecione seu gênero",
+      "gender_select_subtitle": "Esta informação aparece no seu perfil e credencial digital.",
+      "gender_updated": "Gênero atualizado para {value}",
+      "gender_update_failed": "Não foi possível atualizar o gênero",
+      "gender_unset": "Gênero não registrado"
     },
     "medical_info": {
       "title": "Informações Médicas",

--- a/lib/features/profile/presentation/views/edit_profile_view.dart
+++ b/lib/features/profile/presentation/views/edit_profile_view.dart
@@ -17,6 +17,7 @@ import '../../../../core/widgets/sac_text_field.dart';
 import '../../../auth/presentation/providers/auth_providers.dart';
 import '../../../post_registration/presentation/providers/post_registration_providers.dart';
 import '../providers/profile_providers.dart';
+import '../widgets/gender_selector.dart';
 
 /// Vista para editar el perfil del usuario.
 ///
@@ -42,7 +43,7 @@ class _EditProfileViewState extends ConsumerState<EditProfileView> {
   final _addressController = TextEditingController();
 
   // State — personal info fields (F3)
-  String? _selectedGender;
+  Gender? _selectedGender;
   DateTime? _birthdate;
   bool _baptized = false;
   DateTime? _baptismDate;
@@ -77,7 +78,7 @@ class _EditProfileViewState extends ConsumerState<EditProfileView> {
 
       // Pre-populate personal info fields (F3)
       setState(() {
-        _selectedGender = profile.gender;
+        _selectedGender = Gender.fromApiKey(profile.gender);
         _birthdate = profile.birthDate;
         _baptized = profile.baptized;
         _baptismDate = profile.baptismDate;
@@ -234,7 +235,7 @@ class _EditProfileViewState extends ConsumerState<EditProfileView> {
     };
 
     // Add personal info fields (F3)
-    if (_selectedGender != null) data['gender'] = _selectedGender;
+    if (_selectedGender != null) data['gender'] = _selectedGender!.apiKey;
     if (_birthdate != null) {
       data['birthday'] = _birthdate!.toUtc().toIso8601String();
     }
@@ -473,30 +474,19 @@ class _EditProfileViewState extends ConsumerState<EditProfileView> {
                     ),
                     const SizedBox(height: 12),
 
-                    // Gender chip selector
-                    Text(
-                      tr('profile.edit.gender_label'),
-                      style: Theme.of(context).textTheme.labelLarge?.copyWith(
-                            color: context.sac.textSecondary,
-                          ),
-                    ),
-                    const SizedBox(height: 8),
-                    Row(
-                      children: [
-                        _GenderChip(
-                          label: tr('profile.edit.gender_male'),
-                          value: 'M',
-                          selectedValue: _selectedGender,
-                          onTap: () => setState(() => _selectedGender = 'M'),
-                        ),
-                        const SizedBox(width: 12),
-                        _GenderChip(
-                          label: tr('profile.edit.gender_female'),
-                          value: 'F',
-                          selectedValue: _selectedGender,
-                          onTap: () => setState(() => _selectedGender = 'F'),
-                        ),
-                      ],
+                    // Gender — bottomsheet selector (matches blood type pattern)
+                    _GenderPickerField(
+                      label: tr('profile.edit.gender_label'),
+                      selected: _selectedGender,
+                      onTap: () async {
+                        final picked = await showGenderSelector(
+                          context,
+                          current: _selectedGender,
+                        );
+                        if (picked != null) {
+                          setState(() => _selectedGender = picked);
+                        }
+                      },
                     ),
 
                     const SizedBox(height: 16),
@@ -766,61 +756,77 @@ class _SectionHeader extends StatelessWidget {
   }
 }
 
-/// Chip selector de género (F3).
-class _GenderChip extends StatelessWidget {
+/// Campo tappable que muestra el género seleccionado y abre el bottomsheet
+/// selector al ser presionado (F3 — patrón bottomsheet de grupo sanguíneo).
+class _GenderPickerField extends StatelessWidget {
   final String label;
-  final String value;
-  final String? selectedValue;
+  final Gender? selected;
   final VoidCallback onTap;
 
-  const _GenderChip({
+  const _GenderPickerField({
     required this.label,
-    required this.value,
-    required this.selectedValue,
+    required this.selected,
     required this.onTap,
   });
 
   @override
   Widget build(BuildContext context) {
-    final isSelected = selectedValue == value;
+    final hasValue = selected != null;
 
-    return Expanded(
-      child: GestureDetector(
-        onTap: onTap,
-        child: AnimatedContainer(
-          duration: const Duration(milliseconds: 200),
-          padding: const EdgeInsets.symmetric(vertical: 12),
-          decoration: BoxDecoration(
-            color: isSelected ? AppColors.primaryLight : context.sac.surface,
-            borderRadius: BorderRadius.circular(12),
-            border: Border.all(
-              color: isSelected ? AppColors.primary : context.sac.border,
-              width: isSelected ? 2 : 1,
+    return SacCard(
+      onTap: onTap,
+      child: Row(
+        children: [
+          Container(
+            width: 40,
+            height: 40,
+            decoration: BoxDecoration(
+              color: hasValue
+                  ? AppColors.primaryLight
+                  : context.sac.surfaceVariant,
+              borderRadius: BorderRadius.circular(10),
+            ),
+            child: Center(
+              child: HugeIcon(
+                icon: hasValue ? selected!.icon : HugeIcons.strokeRoundedUser,
+                size: 20,
+                color: hasValue ? AppColors.primary : context.sac.textTertiary,
+              ),
             ),
           ),
-          child: Row(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: [
-              HugeIcon(
-                icon: HugeIcons.strokeRoundedUser,
-                size: 20,
-                color:
-                    isSelected ? AppColors.primary : context.sac.textSecondary,
-              ),
-              const SizedBox(width: 8),
-              Text(
-                label,
-                style: TextStyle(
-                  fontSize: 14,
-                  fontWeight: isSelected ? FontWeight.w600 : FontWeight.w400,
-                  color: isSelected
-                      ? AppColors.primary
-                      : context.sac.textSecondary,
+          const SizedBox(width: 12),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  label,
+                  style: TextStyle(
+                    fontSize: 12,
+                    color: context.sac.textTertiary,
+                  ),
                 ),
-              ),
-            ],
+                const SizedBox(height: 2),
+                Text(
+                  hasValue
+                      ? selected!.display(context)
+                      : 'profile.edit.gender_unset'.tr(),
+                  style: TextStyle(
+                    fontSize: 15,
+                    fontWeight: FontWeight.w500,
+                    color:
+                        hasValue ? context.sac.text : context.sac.textTertiary,
+                  ),
+                ),
+              ],
+            ),
           ),
-        ),
+          HugeIcon(
+            icon: HugeIcons.strokeRoundedArrowRight01,
+            size: 18,
+            color: context.sac.textTertiary,
+          ),
+        ],
       ),
     );
   }

--- a/lib/features/profile/presentation/widgets/gender_selector.dart
+++ b/lib/features/profile/presentation/widgets/gender_selector.dart
@@ -1,0 +1,166 @@
+import 'package:easy_localization/easy_localization.dart';
+import 'package:flutter/material.dart';
+import 'package:hugeicons/hugeicons.dart';
+import 'package:sacdia_app/core/theme/app_colors.dart';
+import 'package:sacdia_app/core/theme/sac_colors.dart';
+import 'package:sacdia_app/core/utils/icon_helper.dart';
+
+/// Género soportado por el backend (`gender` en `UpdateUserDto`).
+///
+/// - [display] es el label visible al usuario.
+/// - [apiKey] es el valor que el backend espera en `PATCH /users/:id`
+///   con campo `gender` (validado por `@IsIn(['M', 'F'])`).
+enum Gender {
+  male('M'),
+  female('F');
+
+  const Gender(this.apiKey);
+
+  final String apiKey;
+
+  String display(BuildContext context) {
+    switch (this) {
+      case Gender.male:
+        return 'profile.edit.gender_male'.tr();
+      case Gender.female:
+        return 'profile.edit.gender_female'.tr();
+    }
+  }
+
+  HugeIconData get icon {
+    switch (this) {
+      case Gender.male:
+        return HugeIcons.strokeRoundedMale02;
+      case Gender.female:
+        return HugeIcons.strokeRoundedFemale02;
+    }
+  }
+
+  static Gender? fromApiKey(String? value) {
+    if (value == null || value.isEmpty) return null;
+    for (final g in Gender.values) {
+      if (g.apiKey == value) return g;
+    }
+    return null;
+  }
+}
+
+/// Bottomsheet para seleccionar género.
+///
+/// Devuelve el [Gender] seleccionado, o `null` si el usuario cancela.
+Future<Gender?> showGenderSelector(
+  BuildContext context, {
+  Gender? current,
+}) {
+  return showModalBottomSheet<Gender>(
+    context: context,
+    isScrollControlled: false,
+    showDragHandle: true,
+    builder: (ctx) => _GenderSheet(current: current),
+  );
+}
+
+class _GenderSheet extends StatelessWidget {
+  const _GenderSheet({this.current});
+
+  final Gender? current;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return SafeArea(
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(16, 4, 16, 24),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              'profile.edit.gender_select_title'.tr(),
+              style: theme.textTheme.titleMedium?.copyWith(
+                fontWeight: FontWeight.w700,
+              ),
+            ),
+            const SizedBox(height: 4),
+            Text(
+              'profile.edit.gender_select_subtitle'.tr(),
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+            const SizedBox(height: 16),
+            Row(
+              children: Gender.values
+                  .map(
+                    (g) => _GenderChip(
+                      gender: g,
+                      selected: current == g,
+                      onTap: () => Navigator.of(context).pop(g),
+                    ),
+                  )
+                  .toList(),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _GenderChip extends StatelessWidget {
+  const _GenderChip({
+    required this.gender,
+    required this.selected,
+    required this.onTap,
+  });
+
+  final Gender gender;
+  final bool selected;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Expanded(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 6),
+        child: GestureDetector(
+          onTap: onTap,
+          child: AnimatedContainer(
+            duration: const Duration(milliseconds: 200),
+            padding: const EdgeInsets.symmetric(vertical: 16),
+            decoration: BoxDecoration(
+              color: selected ? AppColors.primaryLight : context.sac.surface,
+              borderRadius: BorderRadius.circular(12),
+              border: Border.all(
+                color: selected ? AppColors.primary : context.sac.border,
+                width: selected ? 2 : 1,
+              ),
+            ),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                HugeIcon(
+                  icon: gender.icon,
+                  size: 28,
+                  color:
+                      selected ? AppColors.primary : context.sac.textSecondary,
+                ),
+                const SizedBox(height: 8),
+                Text(
+                  gender.display(context),
+                  style: TextStyle(
+                    fontSize: 14,
+                    fontWeight: selected ? FontWeight.w600 : FontWeight.w400,
+                    color: selected
+                        ? AppColors.primary
+                        : context.sac.textSecondary,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `GenderSelector` bottomsheet widget (`gender_selector.dart`) with `Gender` enum matching `blood_type_selector.dart` pattern from PR #45
- Replaces inline gender chips in `EditProfileView` with a tappable `SacCard` row that opens the new bottomsheet
- Adds 5 translation keys per locale (select_title, select_subtitle, updated, update_failed, unset) across es/en/fr/pt-BR
- Gender field maps to backend `PATCH /users/:userId` body field `gender` (`'M' | 'F'`)

## current_class gap

`PATCH /users/:userId` (`UpdateUserDto`) does **not** accept any class-related field. `current_class` is derived from the `enrollments` table and is read-only on this endpoint. No backend endpoint exists to update it directly for a self-service user flow. Implementation of `current_class` editing requires a new backend contract (e.g. a dedicated enrollment endpoint or an extension to `UpdateUserDto` with `class_id`). **Not implemented — gap reported.**

## Test plan

- [ ] Open Edit Profile screen — gender field shows current value or unset placeholder
- [ ] Tap gender field — bottomsheet opens with Male/Female animated chips
- [ ] Select gender — bottomsheet closes, field updates immediately
- [ ] Save — `PATCH /users/:id` is called with `gender: 'M'` or `gender: 'F'`
- [ ] Cancel (drag down or back) — no change
- [ ] Verify translations render correctly in es, en, fr, pt-BR
- [ ] `flutter analyze` — no new errors (5 pre-existing infos in unrelated files)