### PR TITLE
refactor(app): route UI side effects through providers

### DIFF
--- a/lib/features/activities/data/datasources/nominatim_remote_data_source.dart
+++ b/lib/features/activities/data/datasources/nominatim_remote_data_source.dart
@@ -1,0 +1,49 @@
+import 'package:dio/dio.dart';
+
+import '../../domain/entities/location_search_result.dart';
+
+abstract class NominatimRemoteDataSource {
+  Future<List<LocationSearchResult>> search(String query);
+}
+
+class NominatimRemoteDataSourceImpl implements NominatimRemoteDataSource {
+  final Dio _dio;
+
+  NominatimRemoteDataSourceImpl({Dio? dio})
+      : _dio = dio ??
+            Dio(
+              BaseOptions(
+                baseUrl: 'https://nominatim.openstreetmap.org',
+                connectTimeout: const Duration(seconds: 5),
+                receiveTimeout: const Duration(seconds: 5),
+                headers: const {
+                  'User-Agent': 'SACDIA App/1.0 (contact@sacdia.org)',
+                  'Accept-Language': 'es',
+                },
+              ),
+            );
+
+  @override
+  Future<List<LocationSearchResult>> search(String query) async {
+    final response = await _dio.get<List<dynamic>>(
+      '/search',
+      queryParameters: {
+        'q': query.trim(),
+        'format': 'json',
+        'limit': 5,
+        'addressdetails': 1,
+        'accept-language': 'es',
+      },
+    );
+
+    final data = response.data ?? const [];
+    return data.map((item) {
+      final map = item as Map<String, dynamic>;
+      return LocationSearchResult(
+        lat: double.parse(map['lat'] as String),
+        lon: double.parse(map['lon'] as String),
+        displayName: map['display_name'] as String,
+      );
+    }).toList();
+  }
+}

--- a/lib/features/activities/domain/entities/location_search_result.dart
+++ b/lib/features/activities/domain/entities/location_search_result.dart
@@ -1,0 +1,12 @@
+/// Resultado de búsqueda de ubicación devuelto por Nominatim.
+class LocationSearchResult {
+  final double lat;
+  final double lon;
+  final String displayName;
+
+  const LocationSearchResult({
+    required this.lat,
+    required this.lon,
+    required this.displayName,
+  });
+}

--- a/lib/features/activities/domain/usecases/upload_activity_image.dart
+++ b/lib/features/activities/domain/usecases/upload_activity_image.dart
@@ -1,0 +1,34 @@
+import 'dart:io';
+
+import 'package:dartz/dartz.dart';
+import 'package:equatable/equatable.dart';
+
+import '../../../../core/errors/failures.dart';
+import '../../../../core/usecases/usecase.dart';
+import '../repositories/activities_repository.dart';
+
+/// Caso de uso para subir una imagen asociada a una actividad.
+class UploadActivityImage
+    implements UseCase<String, UploadActivityImageParams> {
+  final ActivitiesRepository repository;
+
+  UploadActivityImage(this.repository);
+
+  @override
+  Future<Either<Failure, String>> call(UploadActivityImageParams params) {
+    return repository.uploadActivityImage(params.activityId, params.imageFile);
+  }
+}
+
+class UploadActivityImageParams extends Equatable {
+  final int activityId;
+  final File imageFile;
+
+  const UploadActivityImageParams({
+    required this.activityId,
+    required this.imageFile,
+  });
+
+  @override
+  List<Object> get props => [activityId, imageFile.path];
+}

--- a/lib/features/activities/presentation/providers/activities_providers.dart
+++ b/lib/features/activities/presentation/providers/activities_providers.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:io';
 
 import 'package:dio/dio.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -15,6 +16,7 @@ import '../../domain/usecases/create_activity.dart';
 import '../../domain/usecases/get_club_activities.dart';
 import '../../domain/usecases/get_activity_detail.dart';
 import '../../domain/usecases/register_attendance.dart';
+import '../../domain/usecases/upload_activity_image.dart';
 
 /// Provider para el data source remoto de actividades
 final activitiesRemoteDataSourceProvider =
@@ -57,6 +59,11 @@ final createActivityUseCaseProvider = Provider<CreateActivity>((ref) {
 /// Provider para el caso de uso de registrar asistencia
 final registerAttendanceProvider = Provider<RegisterAttendance>((ref) {
   return RegisterAttendance(ref.read(activitiesRepositoryProvider));
+});
+
+/// Provider para el caso de uso de subir imagen de actividad
+final uploadActivityImageProvider = Provider<UploadActivityImage>((ref) {
+  return UploadActivityImage(ref.read(activitiesRepositoryProvider));
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -384,6 +391,44 @@ class UpdateActivityNotifier extends AutoDisposeNotifier<UpdateActivityState> {
 final updateActivityNotifierProvider =
     NotifierProvider.autoDispose<UpdateActivityNotifier, UpdateActivityState>(
   UpdateActivityNotifier.new,
+);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ACTIVITY IMAGE UPLOAD
+// ─────────────────────────────────────────────────────────────────────────────
+
+class ActivityImageUploadNotifier extends AutoDisposeAsyncNotifier<String?> {
+  @override
+  Future<String?> build() async => null;
+
+  Future<bool> upload({
+    required int activityId,
+    required File imageFile,
+  }) async {
+    state = const AsyncValue.loading();
+
+    final result = await ref.read(uploadActivityImageProvider)(
+      UploadActivityImageParams(activityId: activityId, imageFile: imageFile),
+    );
+
+    return result.fold(
+      (failure) {
+        state = AsyncValue.error(failure.message, StackTrace.current);
+        return false;
+      },
+      (url) {
+        state = AsyncValue.data(url);
+        ref.invalidate(clubActivitiesProvider);
+        ref.invalidate(activityDetailProvider(activityId));
+        return true;
+      },
+    );
+  }
+}
+
+final activityImageUploadNotifierProvider =
+    AsyncNotifierProvider.autoDispose<ActivityImageUploadNotifier, String?>(
+  ActivityImageUploadNotifier.new,
 );
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/lib/features/activities/presentation/providers/location_search_providers.dart
+++ b/lib/features/activities/presentation/providers/location_search_providers.dart
@@ -1,0 +1,7 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../data/datasources/nominatim_remote_data_source.dart';
+
+final nominatimRemoteDataSourceProvider = Provider<NominatimRemoteDataSource>(
+  (ref) => NominatimRemoteDataSourceImpl(),
+);

--- a/lib/features/activities/presentation/views/create_activity_view.dart
+++ b/lib/features/activities/presentation/views/create_activity_view.dart
@@ -241,35 +241,34 @@ class _CreateActivityViewState extends ConsumerState<CreateActivityView> {
     if (_pickedImageFile != null && createdActivity != null) {
       setState(() => _isUploadingImage = true);
 
-      final repository = ref.read(activitiesRepositoryProvider);
-      final uploadResult = await repository.uploadActivityImage(
-        createdActivity.id,
-        File(_pickedImageFile!.path),
-      );
+      final uploadSuccess =
+          await ref.read(activityImageUploadNotifierProvider.notifier).upload(
+                activityId: createdActivity.id,
+                imageFile: File(_pickedImageFile!.path),
+              );
 
       if (mounted) setState(() => _isUploadingImage = false);
 
       if (!mounted) return;
 
-      uploadResult.fold(
-        (failure) {
-          // Activity was created — just warn about the image
-          ScaffoldMessenger.of(context).showSnackBar(
-            SnackBar(
-              content: Text(
-                'activities.create.success_image_error'
-                    .tr(namedArgs: {'error': failure.message}),
-              ),
-              backgroundColor: AppColors.error,
-              behavior: SnackBarBehavior.floating,
-              shape: RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(10),
+      if (!uploadSuccess) {
+        final error = ref.read(activityImageUploadNotifierProvider).error;
+        // Activity was created — just warn about the image
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(
+              'activities.create.success_image_error'.tr(
+                namedArgs: {'error': error?.toString() ?? tr('common.error')},
               ),
             ),
-          );
-        },
-        (_) {}, // success — no extra feedback needed
-      );
+            backgroundColor: AppColors.error,
+            behavior: SnackBarBehavior.floating,
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(10),
+            ),
+          ),
+        );
+      }
     }
 
     if (!mounted) return;

--- a/lib/features/activities/presentation/views/edit_activity_view.dart
+++ b/lib/features/activities/presentation/views/edit_activity_view.dart
@@ -294,33 +294,32 @@ class _EditActivityViewState extends ConsumerState<EditActivityView> {
     if (_pickedImageFile != null) {
       setState(() => _isUploadingImage = true);
 
-      final repository = ref.read(activitiesRepositoryProvider);
-      final uploadResult = await repository.uploadActivityImage(
-        a.id,
-        File(_pickedImageFile!.path),
-      );
+      final uploadSuccess =
+          await ref.read(activityImageUploadNotifierProvider.notifier).upload(
+                activityId: a.id,
+                imageFile: File(_pickedImageFile!.path),
+              );
 
       if (mounted) setState(() => _isUploadingImage = false);
       if (!mounted) return;
 
-      uploadResult.fold(
-        (failure) {
-          ScaffoldMessenger.of(context).showSnackBar(
-            SnackBar(
-              content: Text(
-                'activities.edit.success_image_error'
-                    .tr(namedArgs: {'error': failure.message}),
-              ),
-              backgroundColor: AppColors.error,
-              behavior: SnackBarBehavior.floating,
-              shape: RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(10),
+      if (!uploadSuccess) {
+        final error = ref.read(activityImageUploadNotifierProvider).error;
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(
+              'activities.edit.success_image_error'.tr(
+                namedArgs: {'error': error?.toString() ?? tr('common.error')},
               ),
             ),
-          );
-        },
-        (_) {},
-      );
+            backgroundColor: AppColors.error,
+            behavior: SnackBarBehavior.floating,
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(10),
+            ),
+          ),
+        );
+      }
     }
 
     if (!mounted) return;

--- a/lib/features/activities/presentation/views/location_picker_view.dart
+++ b/lib/features/activities/presentation/views/location_picker_view.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 
-import 'package:dio/dio.dart';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -8,12 +7,16 @@ import 'package:geocoding/geocoding.dart';
 import 'package:geolocator/geolocator.dart';
 import 'package:google_maps_flutter/google_maps_flutter.dart';
 import 'package:hugeicons/hugeicons.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:loading_animation_widget/loading_animation_widget.dart';
 import 'package:sacdia_app/core/constants/maps_constants.dart';
 import 'package:sacdia_app/core/theme/app_colors.dart';
 import 'package:sacdia_app/core/utils/icon_helper.dart';
 import 'package:sacdia_app/core/theme/app_theme.dart';
 import 'package:sacdia_app/core/theme/sac_colors.dart';
+import 'package:sacdia_app/features/activities/data/datasources/nominatim_remote_data_source.dart';
+import 'package:sacdia_app/features/activities/domain/entities/location_search_result.dart';
+import 'package:sacdia_app/features/activities/presentation/providers/location_search_providers.dart';
 
 /// Resultado devuelto por [LocationPickerView] al confirmar una ubicación.
 class LocationPickerResult {
@@ -30,23 +33,6 @@ class LocationPickerResult {
     required this.name,
     required this.lat,
     required this.long,
-  });
-}
-
-// ─────────────────────────────────────────────────────────────────────────────
-// Modelo privado para resultados de Nominatim
-// ─────────────────────────────────────────────────────────────────────────────
-
-/// Resultado de la API de Nominatim con coordenadas y nombre del lugar.
-class _NominatimPlace {
-  final double lat;
-  final double lon;
-  final String displayName;
-
-  const _NominatimPlace({
-    required this.lat,
-    required this.lon,
-    required this.displayName,
   });
 }
 
@@ -70,7 +56,7 @@ class _NominatimPlace {
 /// ```
 ///
 /// Usa Google Maps SDK (requiere API Key configurada en Android y iOS).
-class LocationPickerView extends StatefulWidget {
+class LocationPickerView extends ConsumerStatefulWidget {
   /// Ubicación inicial del mapa. Si es null, usa la ubicación del usuario
   /// o la ubicación por defecto definida en [MapsConstants] (Ciudad de México).
   final LatLng? initialLocation;
@@ -78,10 +64,10 @@ class LocationPickerView extends StatefulWidget {
   const LocationPickerView({super.key, this.initialLocation});
 
   @override
-  State<LocationPickerView> createState() => _LocationPickerViewState();
+  ConsumerState<LocationPickerView> createState() => _LocationPickerViewState();
 }
 
-class _LocationPickerViewState extends State<LocationPickerView> {
+class _LocationPickerViewState extends ConsumerState<LocationPickerView> {
   // ── Controladores ─────────────────────────────────────────────────────────
   final Completer<GoogleMapController> _mapCompleter = Completer();
 
@@ -244,9 +230,11 @@ class _LocationPickerViewState extends State<LocationPickerView> {
   // ── Búsqueda ──────────────────────────────────────────────────────────────
 
   Future<void> _openSearch() async {
-    final place = await showSearch<_NominatimPlace?>(
+    final place = await showSearch<LocationSearchResult?>(
       context: context,
-      delegate: _LocationSearchDelegate(),
+      delegate: _LocationSearchDelegate(
+        dataSource: ref.read(nominatimRemoteDataSourceProvider),
+      ),
     );
 
     if (place == null || !mounted) return;
@@ -699,30 +687,18 @@ class _ShimmerLineState extends State<_ShimmerLine>
 ///
 /// Devuelve un [_NominatimPlace] con coordenadas y nombre del lugar
 /// seleccionado, evitando una segunda llamada de geocodificación.
-class _LocationSearchDelegate extends SearchDelegate<_NominatimPlace?> {
-  _LocationSearchDelegate()
+class _LocationSearchDelegate extends SearchDelegate<LocationSearchResult?> {
+  _LocationSearchDelegate({required this.dataSource})
       : super(
           searchFieldLabel: 'activities.location_picker.search_hint'.tr(),
           keyboardType: TextInputType.streetAddress,
           textInputAction: TextInputAction.search,
         );
 
-  // ── Nominatim ─────────────────────────────────────────────────────────────
-
-  static final Dio _dio = Dio(
-    BaseOptions(
-      baseUrl: 'https://nominatim.openstreetmap.org',
-      connectTimeout: const Duration(seconds: 5),
-      receiveTimeout: const Duration(seconds: 5),
-      headers: {
-        'User-Agent': 'SACDIA App/1.0 (contact@sacdia.org)',
-        'Accept-Language': 'es',
-      },
-    ),
-  );
+  final NominatimRemoteDataSource dataSource;
 
   // Estado interno del delegado
-  List<_NominatimPlace> _results = [];
+  List<LocationSearchResult> _results = [];
   bool _isLoading = false;
   bool _hasError = false;
   Timer? _debounce;
@@ -749,26 +725,7 @@ class _LocationSearchDelegate extends SearchDelegate<_NominatimPlace?> {
       if (q != _lastQuery) {
         _lastQuery = q;
         try {
-          final response = await _dio.get<List<dynamic>>(
-            '/search',
-            queryParameters: {
-              'q': q.trim(),
-              'format': 'json',
-              'limit': 5,
-              'addressdetails': 1,
-              'accept-language': 'es',
-            },
-          );
-
-          final data = response.data ?? [];
-          final places = data.map((item) {
-            final map = item as Map<String, dynamic>;
-            return _NominatimPlace(
-              lat: double.parse(map['lat'] as String),
-              lon: double.parse(map['lon'] as String),
-              displayName: map['display_name'] as String,
-            );
-          }).toList();
+          final places = await dataSource.search(q);
 
           refresh(() {
             _results = places;
@@ -804,7 +761,7 @@ class _LocationSearchDelegate extends SearchDelegate<_NominatimPlace?> {
   // ── SearchDelegate overrides ───────────────────────────────────────────────
 
   @override
-  void close(BuildContext context, _NominatimPlace? result) {
+  void close(BuildContext context, LocationSearchResult? result) {
     // Cancel any pending debounce timer on any dismissal path (back gesture,
     // system back, or programmatic close) to prevent dangling async callbacks.
     _debounce?.cancel();

--- a/lib/features/auth/presentation/providers/auth_providers.dart
+++ b/lib/features/auth/presentation/providers/auth_providers.dart
@@ -11,6 +11,7 @@ import '../../domain/entities/authorization_snapshot.dart';
 import '../../domain/entities/user_entity.dart';
 import '../../domain/repositories/auth_repository.dart';
 import '../../domain/usecases/get_current_user.dart';
+import '../../domain/usecases/reset_password_request.dart';
 import '../../domain/usecases/sign_in.dart';
 import '../../domain/usecases/sign_in_with_apple.dart';
 import '../../domain/usecases/sign_in_with_google.dart';
@@ -78,6 +79,11 @@ final updatePasswordProvider = Provider<UpdatePassword>((ref) {
   return UpdatePassword(ref.read(authRepositoryProvider));
 });
 
+/// Provider para el caso de uso de recuperación de contraseña
+final resetPasswordRequestProvider = Provider<ResetPasswordRequest>((ref) {
+  return ResetPasswordRequest(ref.read(authRepositoryProvider));
+});
+
 /// Provider para el caso de uso de OAuth con Google
 final signInWithGoogleProvider = Provider<SignInWithGoogle>((ref) {
   return SignInWithGoogle(ref.read(authRepositoryProvider));
@@ -87,6 +93,37 @@ final signInWithGoogleProvider = Provider<SignInWithGoogle>((ref) {
 final signInWithAppleProvider = Provider<SignInWithApple>((ref) {
   return SignInWithApple(ref.read(authRepositoryProvider));
 });
+
+/// Notifier para solicitar recuperación de contraseña sin acoplar la vista al repositorio.
+class ForgotPasswordNotifier extends AutoDisposeAsyncNotifier<void> {
+  @override
+  Future<void> build() async {}
+
+  Future<bool> submit(String email) async {
+    state = const AsyncValue.loading();
+
+    final result = await ref.read(resetPasswordRequestProvider)(
+      ResetPasswordRequestParams(email: email),
+    );
+
+    return result.fold(
+      (failure) {
+        state = AsyncValue.error(failure.message, StackTrace.current);
+        return false;
+      },
+      (_) {
+        state = const AsyncValue.data(null);
+        return true;
+      },
+    );
+  }
+}
+
+/// Provider para recuperación de contraseña.
+final forgotPasswordNotifierProvider =
+    AsyncNotifierProvider.autoDispose<ForgotPasswordNotifier, void>(
+  ForgotPasswordNotifier.new,
+);
 
 /// Notifier para manejar la autenticación y sus estados
 class AuthNotifier extends AsyncNotifier<UserEntity?> {

--- a/lib/features/auth/presentation/views/forgot_password_view.dart
+++ b/lib/features/auth/presentation/views/forgot_password_view.dart
@@ -25,7 +25,6 @@ class ForgotPasswordView extends ConsumerStatefulWidget {
 class _ForgotPasswordViewState extends ConsumerState<ForgotPasswordView> {
   final _formKey = GlobalKey<FormState>();
   final _emailController = TextEditingController();
-  bool _isLoading = false;
   String? _errorMessage;
   bool _emailSent = false;
 
@@ -40,40 +39,35 @@ class _ForgotPasswordViewState extends ConsumerState<ForgotPasswordView> {
     final formState = _formKey.currentState;
     if (formState == null || !formState.validate()) return;
 
-    setState(() => _isLoading = true);
-
     try {
-      final result = await ref
-          .read(authRepositoryProvider)
-          .resetPassword(_emailController.text.trim());
+      final success = await ref
+          .read(forgotPasswordNotifierProvider.notifier)
+          .submit(_emailController.text.trim());
 
       if (!mounted) return;
 
-      result.fold(
-        (failure) {
-          setState(() {
-            _errorMessage = failure.message;
-            _isLoading = false;
-          });
-        },
-        (_) {
-          setState(() {
-            _isLoading = false;
-            _emailSent = true;
-          });
-        },
-      );
+      if (success) {
+        setState(() => _emailSent = true);
+      } else {
+        final error = ref.read(forgotPasswordNotifierProvider).error;
+        setState(() {
+          _errorMessage =
+              error?.toString() ?? 'auth.forgot_password_error'.tr();
+        });
+      }
     } catch (e) {
       if (!mounted) return;
       setState(() {
         _errorMessage = 'auth.forgot_password_error'.tr();
-        _isLoading = false;
       });
     }
   }
 
   @override
   Widget build(BuildContext context) {
+    final forgotPasswordState = ref.watch(forgotPasswordNotifierProvider);
+    final isLoading = forgotPasswordState.isLoading;
+
     return Scaffold(
       backgroundColor: context.sac.surface,
       body: SafeArea(
@@ -191,7 +185,9 @@ class _ForgotPasswordViewState extends ConsumerState<ForgotPasswordView> {
                     prefixIcon: HugeIcons.strokeRoundedMail01,
                     validator: Validators.validateEmail,
                     textInputAction: TextInputAction.done,
-                    onSubmitted: (_) => _handleSubmit(),
+                    onSubmitted: (_) {
+                      if (!isLoading) _handleSubmit();
+                    },
                   ),
                   const SizedBox(height: 24),
 
@@ -227,7 +223,7 @@ class _ForgotPasswordViewState extends ConsumerState<ForgotPasswordView> {
                   // Submit button
                   SacButton.primary(
                     text: 'auth.forgot_password_button'.tr(),
-                    isLoading: _isLoading,
+                    isLoading: isLoading,
                     onPressed: _handleSubmit,
                   ),
                   const SizedBox(height: 40),

--- a/lib/features/honors/data/repositories/honors_repository_impl.dart
+++ b/lib/features/honors/data/repositories/honors_repository_impl.dart
@@ -283,6 +283,30 @@ class HonorsRepositoryImpl implements HonorsRepository {
   }
 
   @override
+  Future<Either<Failure, void>> uploadHonorFile({
+    required String userId,
+    required int honorId,
+    required File file,
+    required String fileName,
+  }) async {
+    try {
+      await remoteDataSource.uploadHonorFile(
+        userId: userId,
+        honorId: honorId,
+        file: file,
+        fileName: fileName,
+      );
+      return const Right(null);
+    } on ServerException catch (e) {
+      return Left(ServerFailure(message: e.message, code: e.code));
+    } on AuthException catch (e) {
+      return Left(AuthFailure(message: e.message, code: e.code));
+    } catch (e) {
+      return Left(UnexpectedFailure(message: e.toString()));
+    }
+  }
+
+  @override
   Future<Either<Failure, RequirementEvidence>> uploadRequirementEvidence(
     String userId,
     int honorId,

--- a/lib/features/honors/domain/repositories/honors_repository.dart
+++ b/lib/features/honors/domain/repositories/honors_repository.dart
@@ -86,6 +86,14 @@ abstract class HonorsRepository {
       bulkUpdateRequirementProgress(
           String userId, int honorId, List<Map<String, dynamic>> updates);
 
+  /// Sube un archivo de evidencia general al honor del usuario.
+  Future<Either<Failure, void>> uploadHonorFile({
+    required String userId,
+    required int honorId,
+    required File file,
+    required String fileName,
+  });
+
   /// Sube un archivo de evidencia para un requisito específico de una especialidad.
   /// [mimeType] debe ser validado por el llamador antes de invocar este método.
   Future<Either<Failure, RequirementEvidence>> uploadRequirementEvidence(

--- a/lib/features/honors/domain/usecases/upload_honor_file.dart
+++ b/lib/features/honors/domain/usecases/upload_honor_file.dart
@@ -1,0 +1,42 @@
+import 'dart:io';
+
+import 'package:dartz/dartz.dart';
+import 'package:equatable/equatable.dart';
+
+import '../../../../core/errors/failures.dart';
+import '../../../../core/usecases/usecase.dart';
+import '../repositories/honors_repository.dart';
+
+/// Caso de uso para subir un archivo de evidencia general de una especialidad.
+class UploadHonorFile implements UseCase<void, UploadHonorFileParams> {
+  final HonorsRepository repository;
+
+  UploadHonorFile(this.repository);
+
+  @override
+  Future<Either<Failure, void>> call(UploadHonorFileParams params) {
+    return repository.uploadHonorFile(
+      userId: params.userId,
+      honorId: params.honorId,
+      file: params.file,
+      fileName: params.fileName,
+    );
+  }
+}
+
+class UploadHonorFileParams extends Equatable {
+  final String userId;
+  final int honorId;
+  final File file;
+  final String fileName;
+
+  const UploadHonorFileParams({
+    required this.userId,
+    required this.honorId,
+    required this.file,
+    required this.fileName,
+  });
+
+  @override
+  List<Object> get props => [userId, honorId, file.path, fileName];
+}

--- a/lib/features/honors/presentation/providers/honors_providers.dart
+++ b/lib/features/honors/presentation/providers/honors_providers.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:dio/dio.dart';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -21,6 +23,7 @@ import '../../domain/usecases/get_user_honors.dart';
 import '../../domain/usecases/register_user_honor.dart';
 import '../../domain/usecases/start_honor.dart';
 import '../../domain/usecases/update_requirement_progress.dart';
+import '../../domain/usecases/upload_honor_file.dart';
 
 /// Provider para el data source remoto de especialidades
 final honorsRemoteDataSourceProvider = Provider<HonorsRemoteDataSource>((ref) {
@@ -67,6 +70,11 @@ final startHonorProvider = Provider<StartHonor>((ref) {
 /// Provider para el caso de uso de registrar especialidad completa
 final registerUserHonorProvider = Provider<RegisterUserHonor>((ref) {
   return RegisterUserHonor(ref.read(honorsRepositoryProvider));
+});
+
+/// Provider para el caso de uso de subir archivo de evidencia general
+final uploadHonorFileProvider = Provider<UploadHonorFile>((ref) {
+  return UploadHonorFile(ref.read(honorsRepositoryProvider));
 });
 
 /// Provider para las categorías de especialidades
@@ -199,6 +207,79 @@ final honorEnrollmentNotifierProvider =
     AsyncNotifierProvider.autoDispose<HonorEnrollmentNotifier, UserHonor?>(() {
   return HonorEnrollmentNotifier();
 });
+
+// ── Honor evidence actions ──────────────────────────────────────────────────
+
+class HonorEvidenceActionsNotifier extends AutoDisposeAsyncNotifier<void> {
+  @override
+  Future<void> build() async {}
+
+  Future<bool> uploadFile({
+    required String userId,
+    required int honorId,
+    required File file,
+    required String fileName,
+  }) async {
+    state = const AsyncValue.loading();
+
+    final result = await ref.read(uploadHonorFileProvider)(
+      UploadHonorFileParams(
+        userId: userId,
+        honorId: honorId,
+        file: file,
+        fileName: fileName,
+      ),
+    );
+
+    return result.fold(
+      (failure) {
+        state = AsyncValue.error(failure.message, StackTrace.current);
+        return false;
+      },
+      (_) {
+        state = const AsyncValue.data(null);
+        ref.invalidate(userHonorsProvider);
+        ref.invalidate(userHonorForHonorProvider(honorId));
+        return true;
+      },
+    );
+  }
+
+  Future<bool> deleteEvidenceFile({
+    required String userId,
+    required UserHonor userHonor,
+    required String imageUrl,
+  }) async {
+    state = const AsyncValue.loading();
+
+    final updatedImages =
+        userHonor.images.where((url) => url != imageUrl).toList();
+
+    final result = await ref.read(honorsRepositoryProvider).updateUserHonor(
+      userId,
+      userHonor.honorId,
+      {'images': updatedImages},
+    );
+
+    return result.fold(
+      (failure) {
+        state = AsyncValue.error(failure.message, StackTrace.current);
+        return false;
+      },
+      (_) {
+        state = const AsyncValue.data(null);
+        ref.invalidate(userHonorsProvider);
+        ref.invalidate(userHonorForHonorProvider(userHonor.honorId));
+        return true;
+      },
+    );
+  }
+}
+
+final honorEvidenceActionsNotifierProvider =
+    AsyncNotifierProvider.autoDispose<HonorEvidenceActionsNotifier, void>(
+  HonorEvidenceActionsNotifier.new,
+);
 
 // ── Registration Notifier ────────────────────────────────────────────────────
 

--- a/lib/features/honors/presentation/views/honor_evidence_view.dart
+++ b/lib/features/honors/presentation/views/honor_evidence_view.dart
@@ -285,25 +285,28 @@ class _HonorEvidenceViewState extends ConsumerState<HonorEvidenceView> {
     setState(() => _isUploading = true);
 
     try {
-      final dataSource = ref.read(honorsRemoteDataSourceProvider);
-      await dataSource.uploadHonorFile(
-        userId: userId,
-        honorId: widget.honorId,
-        file: file,
-        fileName: fileName,
-      );
+      final success = await ref
+          .read(honorEvidenceActionsNotifierProvider.notifier)
+          .uploadFile(
+            userId: userId,
+            honorId: widget.honorId,
+            file: file,
+            fileName: fileName,
+          );
 
-      ref.invalidate(userHonorsProvider);
-      ref.invalidate(userHonorForHonorProvider(widget.honorId));
+      if (!mounted) return;
 
-      if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: Text('honors.evidence.upload_success'.tr()),
-            backgroundColor: AppColors.sacGreen,
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(
+            success
+                ? 'honors.evidence.upload_success'.tr()
+                : 'honors.evidence.upload_error'
+                    .tr(namedArgs: {'name': fileName}),
           ),
-        );
-      }
+          backgroundColor: success ? AppColors.sacGreen : AppColors.sacRed,
+        ),
+      );
     } catch (e) {
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
@@ -326,24 +329,21 @@ class _HonorEvidenceViewState extends ConsumerState<HonorEvidenceView> {
     setState(() => _isUploading = true);
 
     try {
-      final updatedImages =
-          userHonor.images.where((url) => url != imageUrl).toList();
-
-      final dataSource = ref.read(honorsRemoteDataSourceProvider);
-      await dataSource.updateUserHonor(
-        userId,
-        userHonor.honorId,
-        {'images': updatedImages},
-      );
-
-      ref.invalidate(userHonorsProvider);
-      ref.invalidate(userHonorForHonorProvider(widget.honorId));
+      final success = await ref
+          .read(honorEvidenceActionsNotifierProvider.notifier)
+          .deleteEvidenceFile(
+            userId: userId,
+            userHonor: userHonor,
+            imageUrl: imageUrl,
+          );
 
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
-            content: Text('honors.evidence.delete_success'.tr()),
-            backgroundColor: AppColors.sacGreen,
+            content: Text(success
+                ? 'honors.evidence.delete_success'.tr()
+                : 'honors.evidence.delete_error'.tr()),
+            backgroundColor: success ? AppColors.sacGreen : AppColors.sacRed,
           ),
         );
       }

--- a/lib/features/notifications/presentation/providers/notifications_providers.dart
+++ b/lib/features/notifications/presentation/providers/notifications_providers.dart
@@ -6,6 +6,7 @@ import '../../data/datasources/notifications_remote_data_source.dart';
 import '../../data/repositories/notifications_repository_impl.dart';
 import '../../domain/entities/notification_item.dart';
 import '../../domain/repositories/notifications_repository.dart';
+import 'unread_notifications_count_provider.dart';
 
 // ── Infrastructure providers ──────────────────────────────────────────────────
 
@@ -110,6 +111,49 @@ class NotificationsInboxNotifier extends Notifier<NotificationsInboxState> {
       return item;
     }).toList();
     state = state.copyWith(items: updated);
+  }
+
+  /// Marca una notificación como leída con optimistic update + rollback.
+  Future<void> markAsRead(String deliveryId) async {
+    final currentItem =
+        state.items.where((item) => item.deliveryId == deliveryId).firstOrNull;
+    if (currentItem == null || currentItem.isRead) return;
+
+    updateItemReadState(deliveryId, isRead: true);
+    ref.read(unreadNotificationsCountProvider.notifier).decrement();
+
+    final result =
+        await ref.read(notificationsRepositoryProvider).markAsRead(deliveryId);
+    result.fold(
+      (_) {
+        updateItemReadState(deliveryId, isRead: false);
+        ref.read(unreadNotificationsCountProvider.notifier).increment();
+      },
+      (_) {},
+    );
+  }
+
+  /// Marca todas las notificaciones como leídas desde el notifier.
+  Future<void> markAllAsRead() async {
+    final previousItems = state.items;
+    final updatedItems = previousItems
+        .map((item) => item.isRead
+            ? item
+            : item.copyWith(isRead: true, readAt: DateTime.now()))
+        .toList();
+
+    state = state.copyWith(items: updatedItems);
+    ref.read(unreadNotificationsCountProvider.notifier).setZero();
+
+    final result =
+        await ref.read(notificationsRepositoryProvider).markAllAsRead();
+    result.fold(
+      (_) {
+        state = state.copyWith(items: previousItems);
+        ref.read(unreadNotificationsCountProvider.notifier).refresh();
+      },
+      (_) {},
+    );
   }
 
   /// Carga la siguiente página si hay más datos disponibles.

--- a/lib/features/notifications/presentation/views/notifications_inbox_view.dart
+++ b/lib/features/notifications/presentation/views/notifications_inbox_view.dart
@@ -71,20 +71,6 @@ class _NotificationsInboxViewState extends ConsumerState<NotificationsInboxView>
     }
   }
 
-  Future<void> _markAllAsRead() async {
-    final repository = ref.read(notificationsRepositoryProvider);
-    final result = await repository.markAllAsRead();
-    result.fold(
-      (_) {
-        // On failure, nothing to roll back — just let the state remain.
-      },
-      (_) {
-        ref.read(unreadNotificationsCountProvider.notifier).setZero();
-        ref.invalidate(notificationsInboxProvider);
-      },
-    );
-  }
-
   @override
   Widget build(BuildContext context) {
     final inboxState = ref.watch(notificationsInboxProvider);
@@ -148,7 +134,11 @@ class _NotificationsInboxViewState extends ConsumerState<NotificationsInboxView>
           // Mark all as read
           if (unreadCount > 0)
             IconButton(
-              onPressed: inboxState.isLoading ? null : _markAllAsRead,
+              onPressed: inboxState.isLoading
+                  ? null
+                  : () => ref
+                      .read(notificationsInboxProvider.notifier)
+                      .markAllAsRead(),
               icon: HugeIcon(
                 icon: HugeIcons.strokeRoundedCheckmarkSquare01,
                 size: 22,

--- a/lib/features/notifications/presentation/widgets/notification_card.dart
+++ b/lib/features/notifications/presentation/widgets/notification_card.dart
@@ -4,7 +4,6 @@ import '../../../../core/theme/app_colors.dart';
 import '../../../../core/theme/sac_colors.dart';
 import '../../domain/entities/notification_item.dart';
 import '../providers/notifications_providers.dart';
-import '../providers/unread_notifications_count_provider.dart';
 import 'notification_type_badge.dart';
 
 /// Card que muestra una notificación del historial.
@@ -21,27 +20,9 @@ class NotificationCard extends ConsumerWidget {
     final deliveryId = notification.deliveryId;
 
     if (!notification.isRead && deliveryId != null) {
-      // 1. Optimistic update: mark read locally + decrement counter.
-      ref
+      await ref
           .read(notificationsInboxProvider.notifier)
-          .updateItemReadState(deliveryId, isRead: true);
-      ref.read(unreadNotificationsCountProvider.notifier).decrement();
-
-      // 2. Persist via API (fire-and-forget with rollback on failure).
-      final repository = ref.read(notificationsRepositoryProvider);
-      final result = await repository.markAsRead(deliveryId);
-      result.fold(
-        (failure) {
-          // Rollback optimistic update on failure.
-          ref
-              .read(notificationsInboxProvider.notifier)
-              .updateItemReadState(deliveryId, isRead: false);
-          ref.read(unreadNotificationsCountProvider.notifier).increment();
-        },
-        (_) {
-          // Success — nothing extra needed.
-        },
-      );
+          .markAsRead(deliveryId);
     }
   }
 

--- a/lib/features/post_registration/presentation/providers/post_registration_flow_providers.dart
+++ b/lib/features/post_registration/presentation/providers/post_registration_flow_providers.dart
@@ -1,0 +1,134 @@
+import 'package:easy_localization/easy_localization.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../auth/presentation/providers/auth_providers.dart';
+import 'club_selection_providers.dart';
+import 'personal_info_providers.dart';
+import 'post_registration_providers.dart';
+
+/// Resultado de una acción de post-registro ejecutada por el notifier.
+class PostRegistrationFlowResult {
+  final bool success;
+  final String? errorMessage;
+
+  const PostRegistrationFlowResult._({
+    required this.success,
+    this.errorMessage,
+  });
+
+  const PostRegistrationFlowResult.success() : this._(success: true);
+
+  const PostRegistrationFlowResult.failure(String message)
+      : this._(success: false, errorMessage: message);
+}
+
+/// Notifier para completar pasos del post-registro sin acoplar el shell a
+/// repositories/data sources.
+class PostRegistrationFlowNotifier extends AutoDisposeAsyncNotifier<void> {
+  @override
+  Future<void> build() async {}
+
+  String? get _currentUserId => ref.read(authNotifierProvider).valueOrNull?.id;
+
+  Future<PostRegistrationFlowResult> completeStep1() async {
+    final userId = _currentUserId;
+    if (userId == null) {
+      return PostRegistrationFlowResult.failure(
+        tr('errors.user_not_authenticated'),
+      );
+    }
+
+    state = const AsyncValue.loading();
+    final result = await ref
+        .read(postRegistrationRepositoryProvider)
+        .completeStep1(userId);
+
+    return result.fold(
+      (failure) {
+        state = AsyncValue.error(failure.message, StackTrace.current);
+        return PostRegistrationFlowResult.failure(failure.message);
+      },
+      (_) {
+        state = const AsyncValue.data(null);
+        return const PostRegistrationFlowResult.success();
+      },
+    );
+  }
+
+  Future<PostRegistrationFlowResult> completeStep2({
+    required bool canReadSensitiveData,
+  }) async {
+    final userId = _currentUserId;
+    if (userId == null) {
+      return PostRegistrationFlowResult.failure(
+        tr('errors.user_not_authenticated'),
+      );
+    }
+
+    state = const AsyncValue.loading();
+
+    try {
+      if (canReadSensitiveData) {
+        await ref.read(savePersonalInfoProvider.notifier).save();
+        final saveState = ref.read(savePersonalInfoProvider);
+        if (saveState.hasError) {
+          final message = saveState.error?.toString() ??
+              tr('post_registration.shell.error_step_failed');
+          state = AsyncValue.error(message, StackTrace.current);
+          return PostRegistrationFlowResult.failure(message);
+        }
+      } else {
+        await ref.read(personalInfoDataSourceProvider).completeStep2(userId);
+      }
+
+      state = const AsyncValue.data(null);
+      return const PostRegistrationFlowResult.success();
+    } catch (e, stack) {
+      final message = e.toString().replaceFirst('Exception: ', '');
+      state = AsyncValue.error(message, stack);
+      return PostRegistrationFlowResult.failure(message);
+    }
+  }
+
+  Future<PostRegistrationFlowResult> completeStep3() async {
+    final userId = _currentUserId;
+    if (userId == null) {
+      return PostRegistrationFlowResult.failure(
+        tr('errors.user_not_authenticated'),
+      );
+    }
+
+    state = const AsyncValue.loading();
+    ref.read(isSavingStep3Provider.notifier).state = true;
+
+    try {
+      await ref.read(clubSelectionDataSourceProvider).completeStep3(
+            userId: userId,
+            countryId: ref.read(selectedCountryProvider)!,
+            unionId: ref.read(selectedUnionProvider)!,
+            localFieldId: ref.read(selectedLocalFieldProvider)!,
+            clubSectionId: ref.read(selectedClubSectionProvider)!,
+            classId: ref.read(selectedClassProvider)!,
+          );
+
+      state = const AsyncValue.data(null);
+      return const PostRegistrationFlowResult.success();
+    } on Exception catch (e, stack) {
+      final message = e.toString().replaceFirst('Exception: ', '');
+      if (message.contains('409')) {
+        state = const AsyncValue.data(null);
+        return const PostRegistrationFlowResult.success();
+      }
+
+      state = AsyncValue.error(message, stack);
+      return PostRegistrationFlowResult.failure(message);
+    } finally {
+      ref.read(isSavingStep3Provider.notifier).state = false;
+    }
+  }
+}
+
+final postRegistrationFlowNotifierProvider =
+    AsyncNotifierProvider.autoDispose<PostRegistrationFlowNotifier, void>(
+  PostRegistrationFlowNotifier.new,
+);

--- a/lib/features/post_registration/presentation/providers/post_registration_providers.dart
+++ b/lib/features/post_registration/presentation/providers/post_registration_providers.dart
@@ -8,6 +8,7 @@ import '../../data/datasources/post_registration_remote_data_source.dart';
 import '../../data/repositories/post_registration_repository_impl.dart';
 import '../../domain/entities/completion_status.dart';
 import '../../domain/repositories/post_registration_repository.dart';
+import '../../domain/usecases/upload_profile_picture.dart';
 
 /// Provider para el repositorio de post-registro
 final postRegistrationRepositoryProvider =
@@ -23,6 +24,49 @@ final postRegistrationRepositoryProvider =
     networkInfo: networkInfo,
   );
 });
+
+/// Provider para el caso de uso de subir foto de perfil.
+final uploadProfilePictureProvider =
+    Provider.autoDispose<UploadProfilePicture>((ref) {
+  return UploadProfilePicture(ref.read(postRegistrationRepositoryProvider));
+});
+
+/// Notifier para subir foto de perfil sin acoplar vistas al repositorio.
+class ProfilePhotoUploadNotifier extends AutoDisposeAsyncNotifier<String?> {
+  @override
+  Future<String?> build() async => null;
+
+  Future<bool> upload({
+    required String userId,
+    required String filePath,
+  }) async {
+    ref.read(isUploadingPhotoProvider.notifier).state = true;
+    state = const AsyncValue.loading();
+
+    final result = await ref.read(uploadProfilePictureProvider)(
+      UploadProfilePictureParams(userId: userId, filePath: filePath),
+    );
+
+    ref.read(isUploadingPhotoProvider.notifier).state = false;
+
+    return result.fold(
+      (failure) {
+        state = AsyncValue.error(failure.message, StackTrace.current);
+        return false;
+      },
+      (url) {
+        state = AsyncValue.data(url);
+        return true;
+      },
+    );
+  }
+}
+
+/// Provider para upload de foto de perfil.
+final profilePhotoUploadNotifierProvider =
+    AsyncNotifierProvider.autoDispose<ProfilePhotoUploadNotifier, String?>(
+  ProfilePhotoUploadNotifier.new,
+);
 
 /// Provider para el estado de completitud del post-registro
 final completionStatusProvider = AsyncNotifierProvider.autoDispose<

--- a/lib/features/post_registration/presentation/views/photo_step_view.dart
+++ b/lib/features/post_registration/presentation/views/photo_step_view.dart
@@ -129,38 +129,31 @@ class _PhotoStepViewState extends ConsumerState<PhotoStepView> {
     final user = authState.valueOrNull;
     if (user == null) return;
 
-    ref.read(isUploadingPhotoProvider.notifier).state = true;
-
-    try {
-      final result = await ref
-          .read(postRegistrationRepositoryProvider)
-          .uploadProfilePicture(userId: user.id, filePath: filePath);
-
-      result.fold(
-        (failure) {
-          if (mounted) {
-            ScaffoldMessenger.of(context).showSnackBar(
-              SnackBar(
-                content: Text('post_registration.photo.errors.upload'
-                    .tr(namedArgs: {'message': failure.message})),
-                backgroundColor: AppColors.error,
-                behavior: SnackBarBehavior.floating,
-                shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(8)),
-              ),
+    final success =
+        await ref.read(profilePhotoUploadNotifierProvider.notifier).upload(
+              userId: user.id,
+              filePath: filePath,
             );
-            ref.read(selectedPhotoPathProvider.notifier).state = null;
-          }
-        },
-        (url) {
-          AppLogger.i('Foto subida exitosamente', tag: _tag);
-        },
+
+    if (!mounted) return;
+
+    if (!success) {
+      final error = ref.read(profilePhotoUploadNotifierProvider).error;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text('post_registration.photo.errors.upload'.tr(
+            namedArgs: {'message': error?.toString() ?? tr('common.error')},
+          )),
+          backgroundColor: AppColors.error,
+          behavior: SnackBarBehavior.floating,
+          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+        ),
       );
-    } finally {
-      if (mounted) {
-        ref.read(isUploadingPhotoProvider.notifier).state = false;
-      }
+      ref.read(selectedPhotoPathProvider.notifier).state = null;
+      return;
     }
+
+    AppLogger.i('Foto subida exitosamente', tag: _tag);
   }
 
   void _removePhoto() {

--- a/lib/features/post_registration/presentation/views/post_registration_shell.dart
+++ b/lib/features/post_registration/presentation/views/post_registration_shell.dart
@@ -11,14 +11,15 @@ import 'package:sacdia_app/features/auth/domain/entities/user_entity.dart';
 import 'package:sacdia_app/features/auth/domain/utils/authorization_utils.dart';
 import '../../../auth/presentation/providers/auth_providers.dart';
 import '../../../auth/presentation/providers/logout_cleanup.dart';
+import '../providers/post_registration_flow_providers.dart';
 import '../providers/post_registration_providers.dart';
+import '../providers/personal_info_providers.dart';
 import '../widgets/bottom_navigation_buttons.dart';
 import '../widgets/step_indicator.dart';
 import 'club_selection_step_view.dart';
 import 'personal_info_step_view.dart';
 import 'photo_step_view.dart';
 import '../providers/club_selection_providers.dart';
-import '../providers/personal_info_providers.dart';
 
 bool canReadSensitiveStep2Data(String targetUserId, UserEntity? user) {
   return canAccessSensitiveUserDataForUser(user, targetUserId: targetUserId) ||
@@ -121,26 +122,22 @@ class _PostRegistrationShellState extends ConsumerState<PostRegistrationShell> {
   }
 
   Future<void> _completeStep1() async {
-    final authState = ref.read(authNotifierProvider);
-    final userId = authState.valueOrNull?.id;
-    if (userId == null) return;
-
     setState(() => _isCompletingStep = true);
     try {
-      final repository = ref.read(postRegistrationRepositoryProvider);
-      final result = await repository.completeStep1(userId);
+      final result = await ref
+          .read(postRegistrationFlowNotifierProvider.notifier)
+          .completeStep1();
 
-      result.fold(
-        (failure) {
-          if (!mounted) return;
-          ScaffoldMessenger.of(context).showSnackBar(
-            SnackBar(content: Text(failure.message)),
-          );
-        },
-        (_) {
-          if (mounted) _goToStep(2);
-        },
-      );
+      if (!mounted) return;
+      if (result.success) {
+        _goToStep(2);
+      } else {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+              content: Text(result.errorMessage ??
+                  tr('post_registration.shell.error_step_failed'))),
+        );
+      }
     } finally {
       if (mounted) setState(() => _isCompletingStep = false);
     }
@@ -156,64 +153,46 @@ class _PostRegistrationShellState extends ConsumerState<PostRegistrationShell> {
 
     setState(() => _isCompletingStep = true);
     try {
-      if (canReadSensitiveData) {
-        await ref.read(savePersonalInfoProvider.notifier).save();
-      } else {
-        final dataSource = ref.read(personalInfoDataSourceProvider);
-        await dataSource.completeStep2(userId);
-      }
-      if (mounted) _goToStep(3);
-    } catch (e) {
+      final result = await ref
+          .read(postRegistrationFlowNotifierProvider.notifier)
+          .completeStep2(canReadSensitiveData: canReadSensitiveData);
+
       if (!mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          content: Text(tr('post_registration.shell.error_step_failed')),
-        ),
-      );
+      if (result.success) {
+        _goToStep(3);
+      } else {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(result.errorMessage ??
+                tr('post_registration.shell.error_step_failed')),
+          ),
+        );
+      }
     } finally {
       if (mounted) setState(() => _isCompletingStep = false);
     }
   }
 
   Future<void> _completeStep3() async {
-    final authState = ref.read(authNotifierProvider);
-    final userId = authState.valueOrNull?.id;
-    if (userId == null) return;
-
-    ref.read(isSavingStep3Provider.notifier).state = true;
-
-    try {
-      final dataSource = ref.read(clubSelectionDataSourceProvider);
-      await dataSource.completeStep3(
-        userId: userId,
-        countryId: ref.read(selectedCountryProvider)!,
-        unionId: ref.read(selectedUnionProvider)!,
-        localFieldId: ref.read(selectedLocalFieldProvider)!,
-        clubSectionId: ref.read(selectedClubSectionProvider)!,
-        classId: ref.read(selectedClassProvider)!,
-      );
-    } on Exception catch (e) {
-      final msg = e.toString();
-      // 409 Conflict = already completed → treat as success (idempotency)
-      if (!msg.contains('409') && mounted) {
-        ref.read(isSavingStep3Provider.notifier).state = false;
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text(msg.replaceFirst('Exception: ', ''))),
-        );
-        return;
-      }
-    } finally {
-      if (mounted) {
-        ref.read(isSavingStep3Provider.notifier).state = false;
-      }
-    }
+    final result = await ref
+        .read(postRegistrationFlowNotifierProvider.notifier)
+        .completeStep3();
 
     if (!mounted) return;
+
+    if (!result.success) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+            content: Text(result.errorMessage ??
+                tr('post_registration.shell.error_step_failed'))),
+      );
+      return;
+    }
 
     // Update auth state so router redirects correctly
     ref.read(authNotifierProvider.notifier).markPostRegisterComplete();
 
-    if (mounted) context.go(RouteNames.homeDashboard);
+    context.go(RouteNames.homeDashboard);
   }
 
   void _onSkipPhoto() {

--- a/lib/features/profile/presentation/views/edit_profile_view.dart
+++ b/lib/features/profile/presentation/views/edit_profile_view.dart
@@ -137,35 +137,29 @@ class _EditProfileViewState extends ConsumerState<EditProfileView> {
       setState(() => _isUploadingPhoto = true);
 
       try {
-        final result = await ref
-            .read(postRegistrationRepositoryProvider)
-            .uploadProfilePicture(
-              userId: user.id,
-              filePath: croppedFile.path,
-            );
+        final success =
+            await ref.read(profilePhotoUploadNotifierProvider.notifier).upload(
+                  userId: user.id,
+                  filePath: croppedFile.path,
+                );
 
-        result.fold(
-          (failure) {
-            if (mounted) {
-              _showSnackbar(
-                tr('profile.edit.photo_upload_error'),
-                AppColors.error,
-                HugeIcons.strokeRoundedAlert02,
-              );
-            }
-          },
-          (_) {
-            if (mounted) {
-              ref.invalidate(profileNotifierProvider);
-              ref.invalidate(authNotifierProvider);
-              _showSnackbar(
-                tr('profile.edit.photo_upload_success'),
-                AppColors.secondary,
-                HugeIcons.strokeRoundedCheckmarkCircle02,
-              );
-            }
-          },
-        );
+        if (!mounted) return;
+
+        if (!success) {
+          _showSnackbar(
+            tr('profile.edit.photo_upload_error'),
+            AppColors.error,
+            HugeIcons.strokeRoundedAlert02,
+          );
+        } else {
+          ref.invalidate(profileNotifierProvider);
+          ref.invalidate(authNotifierProvider);
+          _showSnackbar(
+            tr('profile.edit.photo_upload_success'),
+            AppColors.secondary,
+            HugeIcons.strokeRoundedCheckmarkCircle02,
+          );
+        }
       } finally {
         if (mounted) {
           setState(() => _isUploadingPhoto = false);

--- a/lib/features/profile/presentation/views/profile_view.dart
+++ b/lib/features/profile/presentation/views/profile_view.dart
@@ -87,45 +87,39 @@ class _ProfileViewState extends ConsumerState<ProfileView> {
       setState(() => _isUploadingPhoto = true);
 
       try {
-        final result = await ref
-            .read(postRegistrationRepositoryProvider)
-            .uploadProfilePicture(
-              userId: user.id,
-              filePath: croppedFile.path,
-            );
+        final success =
+            await ref.read(profilePhotoUploadNotifierProvider.notifier).upload(
+                  userId: user.id,
+                  filePath: croppedFile.path,
+                );
 
-        result.fold(
-          (failure) {
-            if (mounted) {
-              ScaffoldMessenger.of(context).showSnackBar(
-                SnackBar(
-                  content: Text('profile.view.photo_upload_error'.tr()),
-                  backgroundColor: AppColors.error,
-                  behavior: SnackBarBehavior.floating,
-                  shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(10),
-                  ),
-                ),
-              );
-            }
-          },
-          (_) {
-            if (mounted) {
-              ref.invalidate(profileNotifierProvider);
-              ref.invalidate(authNotifierProvider);
-              ScaffoldMessenger.of(context).showSnackBar(
-                SnackBar(
-                  content: Text('profile.view.photo_upload_success'.tr()),
-                  backgroundColor: AppColors.secondary,
-                  behavior: SnackBarBehavior.floating,
-                  shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(10),
-                  ),
-                ),
-              );
-            }
-          },
-        );
+        if (!mounted) return;
+
+        if (!success) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: Text('profile.view.photo_upload_error'.tr()),
+              backgroundColor: AppColors.error,
+              behavior: SnackBarBehavior.floating,
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(10),
+              ),
+            ),
+          );
+        } else {
+          ref.invalidate(profileNotifierProvider);
+          ref.invalidate(authNotifierProvider);
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: Text('profile.view.photo_upload_success'.tr()),
+              backgroundColor: AppColors.secondary,
+              behavior: SnackBarBehavior.floating,
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(10),
+              ),
+            ),
+          );
+        }
       } finally {
         if (mounted) {
           setState(() => _isUploadingPhoto = false);

--- a/test/features/activities/data/datasources/nominatim_remote_data_source_test.dart
+++ b/test/features/activities/data/datasources/nominatim_remote_data_source_test.dart
@@ -1,0 +1,56 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sacdia_app/features/activities/data/datasources/nominatim_remote_data_source.dart';
+
+class _FakeAdapter implements HttpClientAdapter {
+  RequestOptions? capturedOptions;
+
+  @override
+  void close({bool force = false}) {}
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    capturedOptions = options;
+    return ResponseBody.fromString(
+      jsonEncode([
+        {
+          'lat': '19.4326',
+          'lon': '-99.1332',
+          'display_name': 'Centro Histórico, Ciudad de México, México',
+        }
+      ]),
+      200,
+      headers: {
+        Headers.contentTypeHeader: [Headers.jsonContentType],
+      },
+    );
+  }
+}
+
+void main() {
+  test('search maps Nominatim response and preserves query parameters',
+      () async {
+    final adapter = _FakeAdapter();
+    final dio = Dio(BaseOptions(baseUrl: 'https://nominatim.openstreetmap.org'))
+      ..httpClientAdapter = adapter;
+    final dataSource = NominatimRemoteDataSourceImpl(dio: dio);
+
+    final results = await dataSource.search('CDMX');
+
+    expect(results, hasLength(1));
+    expect(results.first.lat, 19.4326);
+    expect(results.first.lon, -99.1332);
+    expect(results.first.displayName, contains('Ciudad de México'));
+    expect(adapter.capturedOptions?.path, '/search');
+    expect(adapter.capturedOptions?.queryParameters['q'], 'CDMX');
+    expect(adapter.capturedOptions?.queryParameters['limit'], 5);
+  });
+}

--- a/test/features/activities/domain/usecases/upload_activity_image_test.dart
+++ b/test/features/activities/domain/usecases/upload_activity_image_test.dart
@@ -1,0 +1,86 @@
+import 'dart:io';
+
+import 'package:dartz/dartz.dart';
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sacdia_app/core/errors/failures.dart';
+import 'package:sacdia_app/features/activities/domain/entities/activity.dart';
+import 'package:sacdia_app/features/activities/domain/entities/attendance.dart';
+import 'package:sacdia_app/features/activities/domain/repositories/activities_repository.dart';
+import 'package:sacdia_app/features/activities/domain/usecases/upload_activity_image.dart';
+import 'package:sacdia_app/features/activities/data/models/create_activity_request.dart';
+
+class _FakeActivitiesRepository implements ActivitiesRepository {
+  int? capturedActivityId;
+  String? capturedPath;
+  Either<Failure, String> result = const Right('https://cdn.example/img.jpg');
+
+  @override
+  Future<Either<Failure, String>> uploadActivityImage(
+    int activityId,
+    File imageFile,
+  ) async {
+    capturedActivityId = activityId;
+    capturedPath = imageFile.path;
+    return result;
+  }
+
+  @override
+  Future<Either<Failure, Activity>> createActivity(
+          {required int clubId, required CreateActivityRequest request}) =>
+      throw UnimplementedError();
+  @override
+  Future<Either<Failure, void>> deleteActivity(int activityId) =>
+      throw UnimplementedError();
+  @override
+  Future<Either<Failure, List<Attendance>>> getActivityAttendance(
+          int activityId,
+          {CancelToken? cancelToken}) =>
+      throw UnimplementedError();
+  @override
+  Future<Either<Failure, Activity>> getActivityById(int activityId,
+          {CancelToken? cancelToken}) =>
+      throw UnimplementedError();
+  @override
+  Future<Either<Failure, List<Activity>>> getClubActivities(int clubId,
+          {int? clubTypeId, CancelToken? cancelToken}) =>
+      throw UnimplementedError();
+  @override
+  Future<Either<Failure, int>> registerAttendance(
+          int activityId, List<String> userIds) =>
+      throw UnimplementedError();
+  @override
+  Future<Either<Failure, Activity>> updateActivity(
+          {required int activityId,
+          String? name,
+          String? description,
+          double? lat,
+          double? long,
+          String? activityTime,
+          String? activityDate,
+          String? activityEndDate,
+          String? activityPlace,
+          int? platform,
+          int? activityTypeId,
+          String? linkMeet,
+          bool? active,
+          Set<String> clearFields = const {},
+          List<int>? clubSectionIds}) =>
+      throw UnimplementedError();
+}
+
+void main() {
+  test('delegates activity image upload to repository', () async {
+    final repo = _FakeActivitiesRepository();
+    final useCase = UploadActivityImage(repo);
+    final file = File('${Directory.systemTemp.path}/activity.jpg');
+
+    final result = await useCase(
+      UploadActivityImageParams(activityId: 42, imageFile: file),
+    );
+
+    expect(result, const Right('https://cdn.example/img.jpg'));
+    expect(repo.capturedActivityId, 42);
+    expect(repo.capturedPath, file.path);
+  });
+}

--- a/test/features/honors/domain/usecases/upload_honor_file_test.dart
+++ b/test/features/honors/domain/usecases/upload_honor_file_test.dart
@@ -1,0 +1,144 @@
+import 'dart:io';
+
+import 'package:dartz/dartz.dart';
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sacdia_app/core/errors/failures.dart';
+import 'package:sacdia_app/features/honors/domain/entities/honor.dart';
+import 'package:sacdia_app/features/honors/domain/entities/honor_category.dart';
+import 'package:sacdia_app/features/honors/domain/entities/honor_group.dart';
+import 'package:sacdia_app/features/honors/domain/entities/honor_requirement.dart';
+import 'package:sacdia_app/features/honors/domain/entities/requirement_evidence.dart';
+import 'package:sacdia_app/features/honors/domain/entities/user_honor.dart';
+import 'package:sacdia_app/features/honors/domain/entities/user_honor_requirement_progress.dart';
+import 'package:sacdia_app/features/honors/domain/repositories/honors_repository.dart';
+import 'package:sacdia_app/features/honors/domain/usecases/register_user_honor.dart';
+import 'package:sacdia_app/features/honors/domain/usecases/upload_honor_file.dart';
+
+class _FakeHonorsRepository implements HonorsRepository {
+  String? capturedUserId;
+  int? capturedHonorId;
+  String? capturedPath;
+  String? capturedFileName;
+  Either<Failure, void> result = const Right(null);
+
+  @override
+  Future<Either<Failure, void>> uploadHonorFile(
+      {required String userId,
+      required int honorId,
+      required File file,
+      required String fileName}) async {
+    capturedUserId = userId;
+    capturedHonorId = honorId;
+    capturedPath = file.path;
+    capturedFileName = fileName;
+    return result;
+  }
+
+  @override
+  Future<Either<Failure, RequirementEvidence>> addRequirementEvidenceLink(
+          String userId, int honorId, int requirementId, String url) =>
+      throw UnimplementedError();
+  @override
+  Future<Either<Failure, List<UserHonorRequirementProgress>>>
+      bulkUpdateRequirementProgress(
+              String userId, int honorId, List<Map<String, dynamic>> updates) =>
+          throw UnimplementedError();
+  @override
+  Future<Either<Failure, void>> deleteRequirementEvidence(
+          String userId, int honorId, int requirementId, int evidenceId) =>
+      throw UnimplementedError();
+  @override
+  Future<Either<Failure, void>> deleteUserHonor(String userId, int honorId) =>
+      throw UnimplementedError();
+  @override
+  Future<Either<Failure, UserHonor>> enrollUserInHonor(
+          String userId, int honorId) =>
+      throw UnimplementedError();
+  @override
+  Future<Either<Failure, Honor>> getHonorById(int honorId,
+          {CancelToken? cancelToken}) =>
+      throw UnimplementedError();
+  @override
+  Future<Either<Failure, List<HonorCategory>>> getHonorCategories(
+          {CancelToken? cancelToken}) =>
+      throw UnimplementedError();
+  @override
+  Future<Either<Failure, List<HonorRequirement>>> getHonorRequirements(
+          int honorId,
+          {CancelToken? cancelToken}) =>
+      throw UnimplementedError();
+  @override
+  Future<Either<Failure, List<Honor>>> getHonors(
+          {int? categoryId,
+          int? clubTypeId,
+          int? skillLevel,
+          CancelToken? cancelToken}) =>
+      throw UnimplementedError();
+  @override
+  Future<Either<Failure, List<HonorGroup>>> getHonorsGroupedByCategory(
+          {CancelToken? cancelToken}) =>
+      throw UnimplementedError();
+  @override
+  Future<Either<Failure, List<RequirementEvidence>>> getRequirementEvidences(
+          String userId, int honorId, int requirementId,
+          {CancelToken? cancelToken}) =>
+      throw UnimplementedError();
+  @override
+  Future<Either<Failure, List<UserHonorRequirementProgress>>>
+      getUserHonorProgress(String userId, int honorId,
+              {CancelToken? cancelToken}) =>
+          throw UnimplementedError();
+  @override
+  Future<Either<Failure, Map<String, dynamic>>> getUserHonorStats(String userId,
+          {CancelToken? cancelToken}) =>
+      throw UnimplementedError();
+  @override
+  Future<Either<Failure, List<UserHonor>>> getUserHonors(String userId,
+          {CancelToken? cancelToken}) =>
+      throw UnimplementedError();
+  @override
+  Future<Either<Failure, UserHonor>> registerUserHonor(
+          RegisterUserHonorParams params) =>
+      throw UnimplementedError();
+  @override
+  Future<Either<Failure, UserHonorRequirementProgress>>
+      updateRequirementProgress(
+              {required int honorId,
+              required int requirementId,
+              required bool completed,
+              String? notes}) =>
+          throw UnimplementedError();
+  @override
+  Future<Either<Failure, UserHonor>> updateUserHonor(
+          String userId, int honorId, Map<String, dynamic> data) =>
+      throw UnimplementedError();
+  @override
+  Future<Either<Failure, RequirementEvidence>> uploadRequirementEvidence(
+          String userId, int honorId, int requirementId, File file,
+          {required String mimeType}) =>
+      throw UnimplementedError();
+}
+
+void main() {
+  test('delegates honor file upload to repository', () async {
+    final repo = _FakeHonorsRepository();
+    final useCase = UploadHonorFile(repo);
+    final file = File('${Directory.systemTemp.path}/honor.pdf');
+
+    final result = await useCase(
+      UploadHonorFileParams(
+        userId: 'user-1',
+        honorId: 7,
+        file: file,
+        fileName: 'honor.pdf',
+      ),
+    );
+
+    expect(result, const Right(null));
+    expect(repo.capturedUserId, 'user-1');
+    expect(repo.capturedHonorId, 7);
+    expect(repo.capturedPath, file.path);
+    expect(repo.capturedFileName, 'honor.pdf');
+  });
+}

--- a/test/features/honors/upload_requirement_evidence_test.dart
+++ b/test/features/honors/upload_requirement_evidence_test.dart
@@ -28,6 +28,15 @@ class _StubHonorsRepository implements HonorsRepository {
   );
 
   @override
+  Future<Either<Failure, void>> uploadHonorFile({
+    required String userId,
+    required int honorId,
+    required File file,
+    required String fileName,
+  }) =>
+      throw UnimplementedError();
+
+  @override
   Future<Either<Failure, RequirementEvidence>> uploadRequirementEvidence(
     String userId,
     int honorId,


### PR DESCRIPTION
## Summary
- Route targeted Flutter UI side effects through Riverpod providers/notifiers instead of direct repository/data-source/API calls.
- Add use cases/providers for password reset, profile photo upload, activity image upload, Nominatim search, and honor evidence upload.
- Move notification mark-read actions into `NotificationsInboxNotifier` with optimistic update/rollback.

## Test Plan
- [x] `flutter test`
- [x] `flutter test test/features/activities/domain/usecases/upload_activity_image_test.dart test/features/activities/data/datasources/nominatim_remote_data_source_test.dart test/features/honors/domain/usecases/upload_honor_file_test.dart test/features/honors/upload_requirement_evidence_test.dart`
- [x] `flutter analyze` (reports only 5 pre-existing info-level curly-brace lints in classes files outside this scope)
- [x] Direct coupling check: targeted views no longer reference direct repositories/data sources/Dio/http.
