### PR TITLE
chore(android): scaffold release keystore signing

### DIFF
--- a/android/KEYSTORE.md
+++ b/android/KEYSTORE.md
@@ -1,0 +1,163 @@
+# Android Release Keystore
+
+## Why this exists
+
+Prior to this scaffold, `android/app/build.gradle` wired the `release` build type to
+`signingConfigs.debug`. The debug keystore is world-readable and shared across every
+Android developer machine — anyone can forge update APKs that Android accepts as coming
+from the same app. This is a CRITICAL security issue that blocks Play Store publication.
+
+This scaffold:
+- Wires `signingConfigs.release` into `buildTypes.release` when `android/key.properties` is present.
+- Falls back to `signingConfigs.debug` with a loud warning when it is absent (safe for local development only).
+- Ensures `key.properties` and `*.jks` files are permanently excluded from git.
+
+---
+
+## 1. Generate the keystore (run once)
+
+```bash
+keytool -genkey -v \
+  -keystore ~/sacdia-release-key.jks \
+  -keyalg RSA -keysize 2048 -validity 10000 \
+  -alias sacdia
+```
+
+You will be prompted for:
+- Distinguished name (CN, OU, O, L, ST, C) — use your organization details.
+- A **store password** (protects the .jks file itself).
+- A **key password** (protects the private key entry inside the file).
+
+Use strong, unique passwords. Store them in your password manager (see section 3).
+
+---
+
+## 2. Create `android/key.properties`
+
+Copy the template and fill in real values:
+
+```bash
+cp android/key.properties.template android/key.properties
+```
+
+Edit `android/key.properties`:
+
+```
+storeFile=../sacdia-release-key.jks
+storePassword=<your store password>
+keyAlias=sacdia
+keyPassword=<your key password>
+```
+
+The `storeFile` path is relative to the `android/` directory (Gradle rootProject). If
+you place the `.jks` file in a different location, adjust the path accordingly.
+
+---
+
+## 3. Store passwords securely
+
+Save both passwords in **1Password** (or equivalent) under a shared vault accessible to
+all release engineers. Suggested entry name: `SACDIA Android Keystore`.
+
+Fields to save:
+- Store password
+- Key password
+- Key alias (`sacdia`)
+- Location of the `.jks` backup (see section 5)
+
+---
+
+## 4. Verify signing
+
+After placing `key.properties` and building a release:
+
+```bash
+# Build a release APK
+flutter build apk --release
+
+# Verify the APK is signed with your release key (not debug)
+apksigner verify --print-certs build/app/outputs/flutter-apk/app-release.apk
+
+# Or use Gradle's signing report
+./gradlew signingReport
+```
+
+The certificate fingerprint shown must match the one registered in Play Console
+(Project Settings > App integrity > App signing key certificate).
+
+---
+
+## 5. Backup strategy (CRITICAL)
+
+If you lose the keystore, you CANNOT publish updates to the same Play Store listing.
+There is no recovery path — Google will not re-sign on your behalf.
+
+**Mandatory backups:**
+1. Upload `sacdia-release-key.jks` to a private, access-controlled location
+   (e.g., 1Password document, encrypted S3 bucket, or company secrets manager).
+2. Store passwords alongside the file (1Password recommended — see section 3).
+3. Verify the backup is restorable at least once before the first Play Store submission.
+
+Never store the `.jks` file in the git repository or any public location.
+
+---
+
+## 6. Play Console upload key
+
+Google Play uses **Play App Signing** by default. Your keystore is the **upload key**
+(used to authenticate uploads), and Google manages the final **app signing key**
+(used to sign APKs delivered to users).
+
+Steps:
+1. In Play Console, go to **Release > Setup > App integrity**.
+2. Follow the prompts to register your upload key certificate.
+3. To export your upload key certificate (DER format):
+   ```bash
+   keytool -export -rfc \
+     -keystore ~/sacdia-release-key.jks \
+     -alias sacdia \
+     -file sacdia-upload-cert.pem
+   ```
+4. Upload `sacdia-upload-cert.pem` to Play Console.
+
+---
+
+## 7. CI/CD integration
+
+For automated builds (Fastlane, Codemagic, GitHub Actions), store secrets as
+environment variables and generate `key.properties` at build time:
+
+```bash
+# Example CI step (bash)
+cat > android/key.properties <<EOF
+storeFile=${KEYSTORE_PATH}
+storePassword=${KEYSTORE_PASSWORD}
+keyAlias=${KEY_ALIAS}
+keyPassword=${KEY_PASSWORD}
+EOF
+```
+
+Decode the base64-encoded `.jks` from a CI secret:
+
+```bash
+echo "$KEYSTORE_BASE64" | base64 --decode > ~/sacdia-release-key.jks
+```
+
+---
+
+## 8. Recommended next steps
+
+- **Obfuscation**: Run release builds with:
+  ```bash
+  flutter build appbundle \
+    --obfuscate \
+    --split-debug-info=build/app/outputs/symbols
+  ```
+  Upload the symbols to Firebase Crashlytics or Sentry for de-obfuscated crash reports.
+  The necessary comments are already in `android/app/build.gradle`.
+
+- **ProGuard/R8**: Uncomment `minifyEnabled` and `shrinkResources` in `build.gradle`
+  once ProGuard rules are validated to not break the app.
+
+- **Key rotation policy**: Plan for upload key rotation every 2-3 years or immediately
+  upon any suspected compromise. Contact Google Play support for rotation procedures.

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -6,6 +6,23 @@ plugins {
     id "dev.flutter.flutter-gradle-plugin"
 }
 
+// ---------------------------------------------------------------------------
+// Release keystore signing
+// ---------------------------------------------------------------------------
+// Place android/key.properties (one level up from this file) with:
+//   storeFile=../sacdia-release-key.jks
+//   storePassword=<password>
+//   keyPassword=<password>
+//   keyAlias=sacdia
+// See android/KEYSTORE.md for full instructions.
+// NEVER commit key.properties or the .jks file — both are in .gitignore.
+// ---------------------------------------------------------------------------
+def keystorePropertiesFile = rootProject.file("key.properties")
+def keystoreProperties = new Properties()
+if (keystorePropertiesFile.exists()) {
+    keystorePropertiesFile.withReader("UTF-8") { reader -> keystoreProperties.load(reader) }
+}
+
 android {
     namespace = "com.sacdia.app"
     compileSdk = flutter.compileSdkVersion
@@ -34,21 +51,36 @@ android {
         manifestPlaceholders += [GOOGLE_MAPS_API_KEY: project.findProperty("GOOGLE_MAPS_API_KEY") ?: "AIzaSyAQoO0HmAfSdbRs-T0cqtCXEGNn7TtMGZk"]
     }
 
+    signingConfigs {
+        release {
+            if (keystorePropertiesFile.exists()) {
+                keyAlias     keystoreProperties["keyAlias"]
+                keyPassword  keystoreProperties["keyPassword"]
+                storeFile    keystoreProperties["storeFile"] ? rootProject.file(keystoreProperties["storeFile"]) : null
+                storePassword keystoreProperties["storePassword"]
+            }
+        }
+    }
+
     buildTypes {
         release {
-            // SECURITY: Currently signed with debug keys for local `flutter run --release`.
-            // DO NOT ship to Play Store with debug signing keys.
-            // Before publishing, generate a release keystore and reference it here:
-            //   keytool -genkey -v -keystore sacdia-release.keystore \
-            //     -alias sacdia -keyalg RSA -keysize 2048 -validity 10000
-            // Then create android/key.properties:
-            //   storePassword=<password>
-            //   keyPassword=<password>
-            //   keyAlias=sacdia
-            //   storeFile=<path-to-keystore>
-            // And replace signingConfigs.debug with a release signingConfig that
-            // reads from key.properties (never commit key.properties to git).
-            signingConfig = signingConfigs.debug
+            if (keystorePropertiesFile.exists()) {
+                signingConfig signingConfigs.release
+            } else {
+                // SECURITY WARNING: key.properties not found.
+                // Release build will be signed with the debug keystore.
+                // This is fine for local development, but MUST NOT be used for
+                // Play Store or any public distribution. Provide android/key.properties
+                // before publishing. See android/KEYSTORE.md for instructions.
+                println "WARNING: android/key.properties not found — release build will be signed with debug keystore. Provide android/key.properties before publishing to Play Store."
+                signingConfig signingConfigs.debug
+            }
+
+            // Recommended: enable obfuscation for Play Store releases.
+            // Uncomment the lines below and run `flutter build appbundle --obfuscate --split-debug-info=build/app/outputs/symbols`
+            // minifyEnabled true
+            // shrinkResources true
+            // proguardFiles getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"
         }
     }
 }

--- a/android/key.properties.template
+++ b/android/key.properties.template
@@ -1,0 +1,17 @@
+# Copy this file to android/key.properties and fill in real values.
+# NEVER commit key.properties or the .jks file to git — both are in .gitignore.
+#
+# Generate keystore (run once, store the file securely and back it up):
+#
+#   keytool -genkey -v \
+#     -keystore ~/sacdia-release-key.jks \
+#     -keyalg RSA -keysize 2048 -validity 10000 \
+#     -alias sacdia
+#
+# Then fill in the values below and save as android/key.properties.
+# The storeFile path is relative to the android/ directory (i.e., rootProject).
+#
+storeFile=../sacdia-release-key.jks
+storePassword=YOUR_STORE_PASSWORD
+keyAlias=sacdia
+keyPassword=YOUR_KEY_PASSWORD


### PR DESCRIPTION
## Summary

Audit found \`android/app/build.gradle:51\` used \`signingConfigs.debug\` for release builds — anyone could forge updates to sideloaded APKs. **Pre-existing CRITICAL since 2026-04-01 audit. Blocking Play Store launch.**

Scaffolds the integration so user can drop in their \`.jks\` + \`key.properties\` and have releases sign correctly.

## Changes

- **\`android/app/build.gradle\`**: reads \`../key.properties\`, defines \`signingConfigs.release\`, release buildType uses release config IF \`key.properties\` exists else falls back to debug + \`println\` warning. Preserves local dev workflow for contributors without the keystore.
- **\`android/key.properties.template\`**: documented template with \`keytool\` command
- **\`android/KEYSTORE.md\`**: full ops doc — generation, storage, Play upload, CI/CD, obfuscation roadmap, backup strategy
- **\`android/.gitignore\`**: already excluded \`key.properties\` + \`*.jks\` + \`*.keystore\` (no change needed)

## User-side actions required (not in this PR)

1. \`keytool -genkey -v -keystore ~/sacdia-release-key.jks -keyalg RSA -keysize 2048 -validity 10000 -alias sacdia\`
2. Copy \`android/key.properties.template\` → \`android/key.properties\` + fill passwords
3. Place \`.jks\` in Flutter project root (one level above \`android/\`)
4. **Backup \`.jks\` to password manager** — keystore loss = no future updates
5. Upload signing certificate to Play Console under App integrity
6. Run \`flutter build appbundle --release\` and verify with \`apksigner verify\`

## iOS

iOS code signing handled separately via Xcode + Apple Developer Portal — out of scope.

## Test plan

- [x] \`flutter pub get\` succeeds
- [ ] User generates keystore + verifies \`flutter build appbundle --release\` produces non-debug-signed AAB
- [ ] User uploads to Play Console internal testing track
- [ ] (Future) CI/CD job decodes \`key.properties\` from secrets and produces signed builds

From audit recommendation P0 (2026-05-08).