### PR TITLE
fix(security): secure_application wrapper + Sentry PII scrub expand

### DIFF
--- a/lib/core/widgets/secure_screen.dart
+++ b/lib/core/widgets/secure_screen.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+import 'package:secure_application/secure_application_native.dart';
+
+/// Wraps a sensitive screen with platform-level content protection:
+///
+/// - Android: sets [FLAG_SECURE] on the Window while this widget is in the
+///   tree. Prevents screenshots, screen recording, and Recents thumbnails.
+///   Satisfies MASVS-PLATFORM-3.
+/// - iOS: blurs the app snapshot shown in the app-switcher whenever the
+///   screen goes to background while this screen is mounted. Removes blur
+///   when the screen is disposed (user navigated away).
+///
+/// The protection is scoped to the lifetime of this widget — it activates
+/// on [initState] and is released on [dispose], so non-sensitive screens
+/// remain unaffected.
+///
+/// Usage — wrap the outermost widget returned by the screen's `build`:
+///
+/// ```dart
+/// @override
+/// Widget build(BuildContext context) {
+///   return SecureScreen(
+///     child: Scaffold(
+///       appBar: AppBar(title: const Text('Credencial')),
+///       body: ...,
+///     ),
+///   );
+/// }
+/// ```
+class SecureScreen extends StatefulWidget {
+  const SecureScreen({super.key, required this.child});
+
+  final Widget child;
+
+  @override
+  State<SecureScreen> createState() => _SecureScreenState();
+}
+
+class _SecureScreenState extends State<SecureScreen> {
+  @override
+  void initState() {
+    super.initState();
+    // Activates FLAG_SECURE (Android) and iOS app-switcher blur immediately.
+    SecureApplicationNative.secure();
+  }
+
+  @override
+  void dispose() {
+    // Lifts the FLAG_SECURE / blur when navigating away from this screen so
+    // non-sensitive screens are not affected.
+    SecureApplicationNative.open();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) => widget.child;
+}

--- a/lib/features/finances/presentation/views/finances_view.dart
+++ b/lib/features/finances/presentation/views/finances_view.dart
@@ -41,9 +41,8 @@ class FinancesView extends ConsumerWidget {
     return SecureScreen(
       child: Scaffold(
         backgroundColor: context.sac.background,
-        floatingActionButton: showFab
-            ? _AddFab(onTap: () => _openAddSheet(context, ref))
-            : null,
+        floatingActionButton:
+            showFab ? _AddFab(onTap: () => _openAddSheet(context, ref)) : null,
         floatingActionButtonLocation: FloatingActionButtonLocation.endFloat,
         body: SafeArea(
           child: RefreshIndicator(
@@ -66,9 +65,9 @@ class FinancesView extends ConsumerWidget {
                   title: Text(
                     'finances.view.title'.tr(),
                     style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                      fontWeight: FontWeight.w700,
-                      color: context.sac.text,
-                    ),
+                          fontWeight: FontWeight.w700,
+                          color: context.sac.text,
+                        ),
                   ),
                   centerTitle: false,
                   actions: [
@@ -149,8 +148,7 @@ class _FinanceBody extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final isOpen = financeMonth?.isOpen ?? true;
-    final totalBalance =
-        summaryAsync.valueOrNull?.totalBalance ??
+    final totalBalance = summaryAsync.valueOrNull?.totalBalance ??
         financeMonth?.totalBalance ??
         0.0;
     final transactions = financeMonth?.transactions ?? [];
@@ -284,8 +282,8 @@ class _EmptyTransactions extends StatelessWidget {
               'finances.view.empty_title'.tr(),
               textAlign: TextAlign.center,
               style: Theme.of(context).textTheme.titleSmall?.copyWith(
-                color: context.sac.textSecondary,
-              ),
+                    color: context.sac.textSecondary,
+                  ),
             ),
             const SizedBox(height: 4),
             Text(

--- a/lib/features/finances/presentation/views/finances_view.dart
+++ b/lib/features/finances/presentation/views/finances_view.dart
@@ -5,6 +5,7 @@ import 'package:hugeicons/hugeicons.dart';
 import '../../../../core/animations/page_transitions.dart';
 import '../../../../core/animations/staggered_list_animation.dart';
 import '../../../../core/theme/app_colors.dart';
+import '../../../../core/widgets/secure_screen.dart';
 import '../../../../core/theme/sac_colors.dart';
 import '../../domain/entities/finance_month.dart';
 import '../../domain/entities/transaction.dart';
@@ -37,7 +38,8 @@ class FinancesView extends ConsumerWidget {
     final canManage = canManageAsync.valueOrNull ?? false;
     final showFab = canManage && isOpen;
 
-    return Scaffold(
+    return SecureScreen(
+      child: Scaffold(
       backgroundColor: context.sac.background,
       floatingActionButton:
           showFab ? _AddFab(onTap: () => _openAddSheet(context, ref)) : null,
@@ -113,6 +115,7 @@ class FinancesView extends ConsumerWidget {
             ],
           ),
         ),
+      ),
       ),
     );
   }

--- a/lib/features/finances/presentation/views/finances_view.dart
+++ b/lib/features/finances/presentation/views/finances_view.dart
@@ -40,82 +40,84 @@ class FinancesView extends ConsumerWidget {
 
     return SecureScreen(
       child: Scaffold(
-      backgroundColor: context.sac.background,
-      floatingActionButton:
-          showFab ? _AddFab(onTap: () => _openAddSheet(context, ref)) : null,
-      floatingActionButtonLocation: FloatingActionButtonLocation.endFloat,
-      body: SafeArea(
-        child: RefreshIndicator(
-          color: AppColors.primary,
-          onRefresh: () async {
-            ref.invalidate(financeMonthProvider);
-            ref.invalidate(financeSummaryProvider);
-          },
-          child: CustomScrollView(
-            physics: const BouncingScrollPhysics(
-                parent: AlwaysScrollableScrollPhysics()),
-            slivers: [
-              // ── App bar ───────────────────────────────────────────────────
-              SliverAppBar(
-                pinned: true,
-                expandedHeight: 0,
-                backgroundColor: context.sac.background,
-                surfaceTintColor: Colors.transparent,
-                title: Text(
-                  'finances.view.title'.tr(),
-                  style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                        fontWeight: FontWeight.w700,
-                        color: context.sac.text,
+        backgroundColor: context.sac.background,
+        floatingActionButton: showFab
+            ? _AddFab(onTap: () => _openAddSheet(context, ref))
+            : null,
+        floatingActionButtonLocation: FloatingActionButtonLocation.endFloat,
+        body: SafeArea(
+          child: RefreshIndicator(
+            color: AppColors.primary,
+            onRefresh: () async {
+              ref.invalidate(financeMonthProvider);
+              ref.invalidate(financeSummaryProvider);
+            },
+            child: CustomScrollView(
+              physics: const BouncingScrollPhysics(
+                parent: AlwaysScrollableScrollPhysics(),
+              ),
+              slivers: [
+                // ── App bar ───────────────────────────────────────────────────
+                SliverAppBar(
+                  pinned: true,
+                  expandedHeight: 0,
+                  backgroundColor: context.sac.background,
+                  surfaceTintColor: Colors.transparent,
+                  title: Text(
+                    'finances.view.title'.tr(),
+                    style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                      fontWeight: FontWeight.w700,
+                      color: context.sac.text,
+                    ),
+                  ),
+                  centerTitle: false,
+                  actions: [
+                    if (financeMonthAsync.isLoading)
+                      const Padding(
+                        padding: EdgeInsets.all(14),
+                        child: SizedBox(
+                          width: 18,
+                          height: 18,
+                          child: CircularProgressIndicator(strokeWidth: 2),
+                        ),
+                      )
+                    else
+                      IconButton(
+                        onPressed: () {
+                          ref.invalidate(financeMonthProvider);
+                          ref.invalidate(financeSummaryProvider);
+                        },
+                        icon: HugeIcon(
+                          icon: HugeIcons.strokeRoundedRefresh,
+                          size: 20,
+                          color: context.sac.textSecondary,
+                        ),
                       ),
+                  ],
                 ),
-                centerTitle: false,
-                actions: [
-                  if (financeMonthAsync.isLoading)
-                    const Padding(
-                      padding: EdgeInsets.all(14),
-                      child: SizedBox(
-                        width: 18,
-                        height: 18,
-                        child: CircularProgressIndicator(strokeWidth: 2),
-                      ),
-                    )
-                  else
-                    IconButton(
-                      onPressed: () {
+
+                // ── Body ──────────────────────────────────────────────────────
+                SliverToBoxAdapter(
+                  child: financeMonthAsync.when(
+                    loading: () => const FinancesLoadingSkeleton(),
+                    error: (e, _) => _ErrorBody(
+                      message: e.toString().replaceFirst('Exception: ', ''),
+                      onRetry: () {
                         ref.invalidate(financeMonthProvider);
                         ref.invalidate(financeSummaryProvider);
                       },
-                      icon: HugeIcon(
-                        icon: HugeIcons.strokeRoundedRefresh,
-                        size: 20,
-                        color: context.sac.textSecondary,
-                      ),
                     ),
-                ],
-              ),
-
-              // ── Body ──────────────────────────────────────────────────────
-              SliverToBoxAdapter(
-                child: financeMonthAsync.when(
-                  loading: () => const FinancesLoadingSkeleton(),
-                  error: (e, _) => _ErrorBody(
-                    message: e.toString().replaceFirst('Exception: ', ''),
-                    onRetry: () {
-                      ref.invalidate(financeMonthProvider);
-                      ref.invalidate(financeSummaryProvider);
-                    },
-                  ),
-                  data: (financeMonth) => _FinanceBody(
-                    financeMonth: financeMonth,
-                    summaryAsync: summaryAsync,
-                    canManage: canManage,
+                    data: (financeMonth) => _FinanceBody(
+                      financeMonth: financeMonth,
+                      summaryAsync: summaryAsync,
+                      canManage: canManage,
+                    ),
                   ),
                 ),
-              ),
-            ],
+              ],
+            ),
           ),
         ),
-      ),
       ),
     );
   }
@@ -147,7 +149,8 @@ class _FinanceBody extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final isOpen = financeMonth?.isOpen ?? true;
-    final totalBalance = summaryAsync.valueOrNull?.totalBalance ??
+    final totalBalance =
+        summaryAsync.valueOrNull?.totalBalance ??
         financeMonth?.totalBalance ??
         0.0;
     final transactions = financeMonth?.transactions ?? [];
@@ -241,17 +244,16 @@ class _FinanceBody extends ConsumerWidget {
   void _openTransactionDetail(BuildContext context, FinanceTransaction t) {
     Navigator.push(
       context,
-      SacSharedAxisRoute(
-        builder: (_) => TransactionDetailView(transaction: t),
-      ),
+      SacSharedAxisRoute(builder: (_) => TransactionDetailView(transaction: t)),
     );
   }
 
   void _openFullTransactionList(BuildContext context) {
     // Pass the currently selected month so AllTransactionsView seeds its
     // date range filter to that month on first open.
-    final selected =
-        ProviderScope.containerOf(context).read(selectedMonthProvider);
+    final selected = ProviderScope.containerOf(
+      context,
+    ).read(selectedMonthProvider);
     Navigator.of(context).push(
       SacSharedAxisRoute(
         builder: (_) => AllTransactionsView(initialMonth: selected),
@@ -282,16 +284,16 @@ class _EmptyTransactions extends StatelessWidget {
               'finances.view.empty_title'.tr(),
               textAlign: TextAlign.center,
               style: Theme.of(context).textTheme.titleSmall?.copyWith(
-                    color: context.sac.textSecondary,
-                  ),
+                color: context.sac.textSecondary,
+              ),
             ),
             const SizedBox(height: 4),
             Text(
               'finances.view.empty_subtitle'.tr(),
               textAlign: TextAlign.center,
-              style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                    color: context.sac.textTertiary,
-                  ),
+              style: Theme.of(
+                context,
+              ).textTheme.bodySmall?.copyWith(color: context.sac.textTertiary),
             ),
           ],
         ),
@@ -329,9 +331,9 @@ class _ErrorBody extends StatelessWidget {
           const SizedBox(height: 8),
           Text(
             message,
-            style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                  color: context.sac.textSecondary,
-                ),
+            style: Theme.of(
+              context,
+            ).textTheme.bodySmall?.copyWith(color: context.sac.textSecondary),
             textAlign: TextAlign.center,
           ),
           const SizedBox(height: 24),

--- a/lib/features/profile/presentation/views/medical_info_view.dart
+++ b/lib/features/profile/presentation/views/medical_info_view.dart
@@ -32,9 +32,9 @@ class MedicalInfoView extends ConsumerWidget {
     );
     if (selected == null) return;
 
-    final ok = await ref
-        .read(profileNotifierProvider.notifier)
-        .updateProfile({'blood': selected.apiKey});
+    final ok = await ref.read(profileNotifierProvider.notifier).updateProfile({
+      'blood': selected.apiKey,
+    });
 
     if (ok) {
       // Refrescar la credencial digital para que muestre el nuevo tipo
@@ -46,8 +46,9 @@ class MedicalInfoView extends ConsumerWidget {
       SnackBar(
         content: Text(
           ok
-              ? 'profile.medical_info.blood_type_updated'
-                  .tr(namedArgs: {'value': selected.display})
+              ? 'profile.medical_info.blood_type_updated'.tr(
+                  namedArgs: {'value': selected.display},
+                )
               : 'profile.medical_info.blood_type_update_failed'.tr(),
         ),
         behavior: SnackBarBehavior.floating,
@@ -71,398 +72,398 @@ class MedicalInfoView extends ConsumerWidget {
 
     return SecureScreen(
       child: Scaffold(
-      appBar: AppBar(
-        title: Text('profile.medical_info.title'.tr()),
-      ),
-      body: ListView(
-        padding: const EdgeInsets.all(16),
-        children: [
-          // Tipo de sangre — sección compacta antes de las alergias.
-          _MedicalSectionCard(
-            icon: HugeIcons.strokeRoundedBlood,
-            title: 'profile.medical_info.blood_type'.tr(),
-            iconColor: AppColors.error,
-            body: profileAsync.when(
-              loading: () => const Padding(
-                padding: EdgeInsets.symmetric(vertical: 8),
-                child: SacLoadingSmall(),
-              ),
-              error: (e, _) => _SectionError(
-                message: e.toString(),
-                onRetry: () =>
-                    ref.read(profileNotifierProvider.notifier).refresh(),
-              ),
-              data: (profile) {
-                final blood = profile?.blood?.trim();
-                if (blood == null || blood.isEmpty) {
-                  return Text(
-                    'profile.medical_info.blood_type_unset'.tr(),
-                    style: TextStyle(
-                      fontSize: 14,
-                      color: c.textTertiary,
-                      fontStyle: FontStyle.italic,
+        appBar: AppBar(title: Text('profile.medical_info.title'.tr())),
+        body: ListView(
+          padding: const EdgeInsets.all(16),
+          children: [
+            // Tipo de sangre — sección compacta antes de las alergias.
+            _MedicalSectionCard(
+              icon: HugeIcons.strokeRoundedBlood,
+              title: 'profile.medical_info.blood_type'.tr(),
+              iconColor: AppColors.error,
+              body: profileAsync.when(
+                loading: () => const Padding(
+                  padding: EdgeInsets.symmetric(vertical: 8),
+                  child: SacLoadingSmall(),
+                ),
+                error: (e, _) => _SectionError(
+                  message: e.toString(),
+                  onRetry: () =>
+                      ref.read(profileNotifierProvider.notifier).refresh(),
+                ),
+                data: (profile) {
+                  final blood = profile?.blood?.trim();
+                  if (blood == null || blood.isEmpty) {
+                    return Text(
+                      'profile.medical_info.blood_type_unset'.tr(),
+                      style: TextStyle(
+                        fontSize: 14,
+                        color: c.textTertiary,
+                        fontStyle: FontStyle.italic,
+                      ),
+                    );
+                  }
+                  return Container(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 14,
+                      vertical: 6,
+                    ),
+                    decoration: BoxDecoration(
+                      color: AppColors.errorLight,
+                      borderRadius: BorderRadius.circular(999),
+                      border: Border.all(
+                        color: AppColors.error.withValues(alpha: 0.3),
+                      ),
+                    ),
+                    child: Text(
+                      blood,
+                      style: TextStyle(
+                        fontSize: 16,
+                        fontWeight: FontWeight.w800,
+                        color: AppColors.errorDark,
+                        letterSpacing: 0.4,
+                      ),
                     ),
                   );
-                }
-                return Container(
-                  padding: const EdgeInsets.symmetric(
-                    horizontal: 14,
-                    vertical: 6,
-                  ),
-                  decoration: BoxDecoration(
-                    color: AppColors.errorLight,
-                    borderRadius: BorderRadius.circular(999),
-                    border: Border.all(
-                      color: AppColors.error.withValues(alpha: 0.3),
-                    ),
-                  ),
-                  child: Text(
-                    blood,
-                    style: TextStyle(
-                      fontSize: 16,
-                      fontWeight: FontWeight.w800,
-                      color: AppColors.errorDark,
-                      letterSpacing: 0.4,
-                    ),
-                  ),
-                );
-              },
-            ),
-            actionLabel: 'profile.medical_info.action_edit'.tr(),
-            onAction: () => _handleEditBlood(
-              context,
-              ref,
-              profileAsync.valueOrNull?.blood,
-            ),
-          ),
-          const SizedBox(height: 12),
-          _MedicalSectionCard(
-            icon: HugeIcons.strokeRoundedFirstAidKit,
-            title: 'profile.medical_info.allergies'.tr(),
-            iconColor: AppColors.error,
-            body: allergiesAsync.when(
-              loading: () => const Padding(
-                padding: EdgeInsets.symmetric(vertical: 8),
-                child: SacLoadingSmall(),
+                },
               ),
-              error: (e, _) => _SectionError(
-                message: e.toString(),
-                onRetry: () => ref.invalidate(userAllergiesProvider),
+              actionLabel: 'profile.medical_info.action_edit'.tr(),
+              onAction: () => _handleEditBlood(
+                context,
+                ref,
+                profileAsync.valueOrNull?.blood,
               ),
-              data: (allergies) {
-                if (allergies.isEmpty) {
-                  return Text(
-                    'profile.medical_info.none_allergies'.tr(),
-                    style: TextStyle(
-                      fontSize: 14,
-                      color: c.textTertiary,
-                      fontStyle: FontStyle.italic,
-                    ),
-                  );
-                }
-                return Wrap(
-                  spacing: 6,
-                  runSpacing: 6,
-                  children: allergies
-                      .map(
-                        (a) => Chip(
-                          label: Text(
-                            a.name,
-                            style: TextStyle(
-                              fontSize: 12,
-                              color: AppColors.errorDark,
-                              fontWeight: FontWeight.w500,
+            ),
+            const SizedBox(height: 12),
+            _MedicalSectionCard(
+              icon: HugeIcons.strokeRoundedFirstAidKit,
+              title: 'profile.medical_info.allergies'.tr(),
+              iconColor: AppColors.error,
+              body: allergiesAsync.when(
+                loading: () => const Padding(
+                  padding: EdgeInsets.symmetric(vertical: 8),
+                  child: SacLoadingSmall(),
+                ),
+                error: (e, _) => _SectionError(
+                  message: e.toString(),
+                  onRetry: () => ref.invalidate(userAllergiesProvider),
+                ),
+                data: (allergies) {
+                  if (allergies.isEmpty) {
+                    return Text(
+                      'profile.medical_info.none_allergies'.tr(),
+                      style: TextStyle(
+                        fontSize: 14,
+                        color: c.textTertiary,
+                        fontStyle: FontStyle.italic,
+                      ),
+                    );
+                  }
+                  return Wrap(
+                    spacing: 6,
+                    runSpacing: 6,
+                    children: allergies
+                        .map(
+                          (a) => Chip(
+                            label: Text(
+                              a.name,
+                              style: TextStyle(
+                                fontSize: 12,
+                                color: AppColors.errorDark,
+                                fontWeight: FontWeight.w500,
+                              ),
                             ),
-                          ),
-                          backgroundColor: AppColors.errorLight,
-                          side: BorderSide(
-                            color: AppColors.error.withValues(alpha: 0.3),
-                          ),
-                          materialTapTargetSize:
-                              MaterialTapTargetSize.shrinkWrap,
-                          padding: const EdgeInsets.symmetric(horizontal: 4),
-                        ),
-                      )
-                      .toList(),
-                );
-              },
-            ),
-            actionLabel: 'profile.medical_info.action_edit'.tr(),
-            onAction: () => Navigator.of(context).push(
-              MaterialPageRoute(
-                builder: (_) => const AllergiesSelectionView(),
-              ),
-            ),
-          ),
-          const SizedBox(height: 12),
-          _MedicalSectionCard(
-            icon: HugeIcons.strokeRoundedHealth,
-            title: 'profile.medical_info.diseases'.tr(),
-            iconColor: AppColors.accent,
-            body: diseasesAsync.when(
-              loading: () => const Padding(
-                padding: EdgeInsets.symmetric(vertical: 8),
-                child: SacLoadingSmall(),
-              ),
-              error: (e, _) => _SectionError(
-                message: e.toString(),
-                onRetry: () => ref.invalidate(userDiseasesProvider),
-              ),
-              data: (diseases) {
-                if (diseases.isEmpty) {
-                  return Text(
-                    'profile.medical_info.none_diseases'.tr(),
-                    style: TextStyle(
-                      fontSize: 14,
-                      color: c.textTertiary,
-                      fontStyle: FontStyle.italic,
-                    ),
-                  );
-                }
-                return Wrap(
-                  spacing: 6,
-                  runSpacing: 6,
-                  children: diseases
-                      .map(
-                        (d) => Chip(
-                          label: Text(
-                            d.name,
-                            style: TextStyle(
-                              fontSize: 12,
-                              color: AppColors.accentDark,
-                              fontWeight: FontWeight.w500,
+                            backgroundColor: AppColors.errorLight,
+                            side: BorderSide(
+                              color: AppColors.error.withValues(alpha: 0.3),
                             ),
+                            materialTapTargetSize:
+                                MaterialTapTargetSize.shrinkWrap,
+                            padding: const EdgeInsets.symmetric(horizontal: 4),
                           ),
-                          backgroundColor: AppColors.accentLight,
-                          side: BorderSide(
-                            color: AppColors.accent.withValues(alpha: 0.3),
-                          ),
-                          materialTapTargetSize:
-                              MaterialTapTargetSize.shrinkWrap,
-                          padding: const EdgeInsets.symmetric(horizontal: 4),
-                        ),
-                      )
-                      .toList(),
-                );
-              },
-            ),
-            actionLabel: 'profile.medical_info.action_edit'.tr(),
-            onAction: () => Navigator.of(context).push(
-              MaterialPageRoute(
-                builder: (_) => const DiseasesSelectionView(),
-              ),
-            ),
-          ),
-          const SizedBox(height: 12),
-          _MedicalSectionCard(
-            icon: HugeIcons.strokeRoundedMedicine01,
-            title: 'profile.medical_info.medicines'.tr(),
-            iconColor: AppColors.secondary,
-            body: medicinesAsync.when(
-              loading: () => const Padding(
-                padding: EdgeInsets.symmetric(vertical: 8),
-                child: SacLoadingSmall(),
-              ),
-              error: (e, _) => _SectionError(
-                message: e.toString(),
-                onRetry: () => ref.invalidate(userMedicinesProvider),
-              ),
-              data: (medicines) {
-                if (medicines.isEmpty) {
-                  return Text(
-                    'profile.medical_info.none_medicines'.tr(),
-                    style: TextStyle(
-                      fontSize: 14,
-                      color: c.textTertiary,
-                      fontStyle: FontStyle.italic,
-                    ),
+                        )
+                        .toList(),
                   );
-                }
-                return Wrap(
-                  spacing: 6,
-                  runSpacing: 6,
-                  children: medicines
-                      .map(
-                        (m) => Chip(
-                          label: Text(
-                            m.name,
-                            style: TextStyle(
-                              fontSize: 12,
-                              color: AppColors.secondaryDark,
-                              fontWeight: FontWeight.w500,
+                },
+              ),
+              actionLabel: 'profile.medical_info.action_edit'.tr(),
+              onAction: () => Navigator.of(context).push(
+                MaterialPageRoute(
+                  builder: (_) => const AllergiesSelectionView(),
+                ),
+              ),
+            ),
+            const SizedBox(height: 12),
+            _MedicalSectionCard(
+              icon: HugeIcons.strokeRoundedHealth,
+              title: 'profile.medical_info.diseases'.tr(),
+              iconColor: AppColors.accent,
+              body: diseasesAsync.when(
+                loading: () => const Padding(
+                  padding: EdgeInsets.symmetric(vertical: 8),
+                  child: SacLoadingSmall(),
+                ),
+                error: (e, _) => _SectionError(
+                  message: e.toString(),
+                  onRetry: () => ref.invalidate(userDiseasesProvider),
+                ),
+                data: (diseases) {
+                  if (diseases.isEmpty) {
+                    return Text(
+                      'profile.medical_info.none_diseases'.tr(),
+                      style: TextStyle(
+                        fontSize: 14,
+                        color: c.textTertiary,
+                        fontStyle: FontStyle.italic,
+                      ),
+                    );
+                  }
+                  return Wrap(
+                    spacing: 6,
+                    runSpacing: 6,
+                    children: diseases
+                        .map(
+                          (d) => Chip(
+                            label: Text(
+                              d.name,
+                              style: TextStyle(
+                                fontSize: 12,
+                                color: AppColors.accentDark,
+                                fontWeight: FontWeight.w500,
+                              ),
                             ),
+                            backgroundColor: AppColors.accentLight,
+                            side: BorderSide(
+                              color: AppColors.accent.withValues(alpha: 0.3),
+                            ),
+                            materialTapTargetSize:
+                                MaterialTapTargetSize.shrinkWrap,
+                            padding: const EdgeInsets.symmetric(horizontal: 4),
                           ),
-                          backgroundColor: AppColors.secondaryLight,
-                          side: BorderSide(
-                            color: AppColors.secondary.withValues(alpha: 0.3),
-                          ),
-                          materialTapTargetSize:
-                              MaterialTapTargetSize.shrinkWrap,
-                          padding: const EdgeInsets.symmetric(horizontal: 4),
-                        ),
-                      )
-                      .toList(),
-                );
-              },
-            ),
-            actionLabel: 'profile.medical_info.action_edit'.tr(),
-            onAction: () => Navigator.of(context).push(
-              MaterialPageRoute(
-                builder: (_) => const MedicinesSelectionView(),
-              ),
-            ),
-          ),
-          const SizedBox(height: 12),
-          _MedicalSectionCard(
-            icon: HugeIcons.strokeRoundedContactBook,
-            title: 'profile.medical_info.emergency_contacts'.tr(),
-            iconColor: AppColors.primary,
-            body: contactsAsync.when(
-              loading: () => const Padding(
-                padding: EdgeInsets.symmetric(vertical: 8),
-                child: SacLoadingSmall(),
-              ),
-              error: (e, _) => _SectionError(
-                message: e.toString(),
-                onRetry: () => ref.invalidate(emergencyContactsProvider),
-              ),
-              data: (contacts) {
-                if (contacts.isEmpty) {
-                  return Text(
-                    'profile.medical_info.none_contacts'.tr(),
-                    style: TextStyle(
-                      fontSize: 14,
-                      color: c.textTertiary,
-                      fontStyle: FontStyle.italic,
-                    ),
+                        )
+                        .toList(),
                   );
-                }
-                return Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: contacts
-                      .map(
-                        (contact) => Padding(
-                          padding: const EdgeInsets.only(bottom: 8),
-                          child: Row(
-                            children: [
-                              Container(
-                                width: 32,
-                                height: 32,
-                                decoration: BoxDecoration(
-                                  color: AppColors.primaryLight,
-                                  shape: BoxShape.circle,
-                                ),
-                                child: Center(
-                                  child: HugeIcon(
-                                    icon: HugeIcons.strokeRoundedUser,
-                                    color: AppColors.primaryDark,
-                                    size: 16,
+                },
+              ),
+              actionLabel: 'profile.medical_info.action_edit'.tr(),
+              onAction: () => Navigator.of(context).push(
+                MaterialPageRoute(
+                  builder: (_) => const DiseasesSelectionView(),
+                ),
+              ),
+            ),
+            const SizedBox(height: 12),
+            _MedicalSectionCard(
+              icon: HugeIcons.strokeRoundedMedicine01,
+              title: 'profile.medical_info.medicines'.tr(),
+              iconColor: AppColors.secondary,
+              body: medicinesAsync.when(
+                loading: () => const Padding(
+                  padding: EdgeInsets.symmetric(vertical: 8),
+                  child: SacLoadingSmall(),
+                ),
+                error: (e, _) => _SectionError(
+                  message: e.toString(),
+                  onRetry: () => ref.invalidate(userMedicinesProvider),
+                ),
+                data: (medicines) {
+                  if (medicines.isEmpty) {
+                    return Text(
+                      'profile.medical_info.none_medicines'.tr(),
+                      style: TextStyle(
+                        fontSize: 14,
+                        color: c.textTertiary,
+                        fontStyle: FontStyle.italic,
+                      ),
+                    );
+                  }
+                  return Wrap(
+                    spacing: 6,
+                    runSpacing: 6,
+                    children: medicines
+                        .map(
+                          (m) => Chip(
+                            label: Text(
+                              m.name,
+                              style: TextStyle(
+                                fontSize: 12,
+                                color: AppColors.secondaryDark,
+                                fontWeight: FontWeight.w500,
+                              ),
+                            ),
+                            backgroundColor: AppColors.secondaryLight,
+                            side: BorderSide(
+                              color: AppColors.secondary.withValues(alpha: 0.3),
+                            ),
+                            materialTapTargetSize:
+                                MaterialTapTargetSize.shrinkWrap,
+                            padding: const EdgeInsets.symmetric(horizontal: 4),
+                          ),
+                        )
+                        .toList(),
+                  );
+                },
+              ),
+              actionLabel: 'profile.medical_info.action_edit'.tr(),
+              onAction: () => Navigator.of(context).push(
+                MaterialPageRoute(
+                  builder: (_) => const MedicinesSelectionView(),
+                ),
+              ),
+            ),
+            const SizedBox(height: 12),
+            _MedicalSectionCard(
+              icon: HugeIcons.strokeRoundedContactBook,
+              title: 'profile.medical_info.emergency_contacts'.tr(),
+              iconColor: AppColors.primary,
+              body: contactsAsync.when(
+                loading: () => const Padding(
+                  padding: EdgeInsets.symmetric(vertical: 8),
+                  child: SacLoadingSmall(),
+                ),
+                error: (e, _) => _SectionError(
+                  message: e.toString(),
+                  onRetry: () => ref.invalidate(emergencyContactsProvider),
+                ),
+                data: (contacts) {
+                  if (contacts.isEmpty) {
+                    return Text(
+                      'profile.medical_info.none_contacts'.tr(),
+                      style: TextStyle(
+                        fontSize: 14,
+                        color: c.textTertiary,
+                        fontStyle: FontStyle.italic,
+                      ),
+                    );
+                  }
+                  return Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: contacts
+                        .map(
+                          (contact) => Padding(
+                            padding: const EdgeInsets.only(bottom: 8),
+                            child: Row(
+                              children: [
+                                Container(
+                                  width: 32,
+                                  height: 32,
+                                  decoration: BoxDecoration(
+                                    color: AppColors.primaryLight,
+                                    shape: BoxShape.circle,
+                                  ),
+                                  child: Center(
+                                    child: HugeIcon(
+                                      icon: HugeIcons.strokeRoundedUser,
+                                      color: AppColors.primaryDark,
+                                      size: 16,
+                                    ),
                                   ),
                                 ),
-                              ),
-                              const SizedBox(width: 10),
-                              Expanded(
-                                child: Column(
-                                  crossAxisAlignment: CrossAxisAlignment.start,
-                                  children: [
-                                    Text(
-                                      contact.name,
-                                      style: TextStyle(
-                                        fontSize: 14,
-                                        fontWeight: FontWeight.w600,
-                                        color: c.text,
+                                const SizedBox(width: 10),
+                                Expanded(
+                                  child: Column(
+                                    crossAxisAlignment:
+                                        CrossAxisAlignment.start,
+                                    children: [
+                                      Text(
+                                        contact.name,
+                                        style: TextStyle(
+                                          fontSize: 14,
+                                          fontWeight: FontWeight.w600,
+                                          color: c.text,
+                                        ),
                                       ),
-                                    ),
-                                    Text(
-                                      '${contact.relationshipTypeName ?? contact.relationshipTypeId} · ${contact.phone}',
-                                      style: TextStyle(
-                                        fontSize: 12,
-                                        color: c.textSecondary,
+                                      Text(
+                                        '${contact.relationshipTypeName ?? contact.relationshipTypeId} · ${contact.phone}',
+                                        style: TextStyle(
+                                          fontSize: 12,
+                                          color: c.textSecondary,
+                                        ),
                                       ),
-                                    ),
-                                  ],
+                                    ],
+                                  ),
                                 ),
-                              ),
-                            ],
+                              ],
+                            ),
                           ),
-                        ),
-                      )
-                      .toList(),
+                        )
+                        .toList(),
+                  );
+                },
+              ),
+              actionLabel: 'profile.medical_info.action_manage'.tr(),
+              onAction: () => Navigator.of(context).push(
+                MaterialPageRoute(
+                  builder: (_) => const EmergencyContactsView(),
+                ),
+              ),
+            ),
+            const SizedBox(height: 12),
+            legalRequiredAsync.when(
+              loading: () => const SizedBox.shrink(),
+              error: (_, __) => const SizedBox.shrink(),
+              data: (isRequired) {
+                if (!isRequired) return const SizedBox.shrink();
+                return _MedicalSectionCard(
+                  icon: HugeIcons.strokeRoundedUserShield01,
+                  title: 'profile.medical_info.legal_rep'.tr(),
+                  iconColor: AppColors.secondary,
+                  body: legalRepAsync.when(
+                    loading: () => const Padding(
+                      padding: EdgeInsets.symmetric(vertical: 8),
+                      child: SacLoadingSmall(),
+                    ),
+                    error: (e, _) => _SectionError(
+                      message: e.toString(),
+                      onRetry: () =>
+                          ref.invalidate(legalRepresentativeProvider),
+                    ),
+                    data: (rep) {
+                      if (rep == null) {
+                        return Text(
+                          'profile.medical_info.not_registered'.tr(),
+                          style: TextStyle(
+                            fontSize: 14,
+                            color: c.textTertiary,
+                            fontStyle: FontStyle.italic,
+                          ),
+                        );
+                      }
+                      return Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            '${rep.name} ${rep.paternalSurname} ${rep.maternalSurname}',
+                            style: TextStyle(
+                              fontSize: 14,
+                              fontWeight: FontWeight.w600,
+                              color: c.text,
+                            ),
+                          ),
+                          const SizedBox(height: 2),
+                          Text(
+                            '${rep.type} · ${rep.phone}',
+                            style: TextStyle(
+                              fontSize: 12,
+                              color: c.textSecondary,
+                            ),
+                          ),
+                        ],
+                      );
+                    },
+                  ),
+                  actionLabel: 'profile.medical_info.action_edit'.tr(),
+                  onAction: () => Navigator.of(context).push(
+                    MaterialPageRoute(
+                      builder: (_) => const LegalRepresentativeView(),
+                    ),
+                  ),
                 );
               },
             ),
-            actionLabel: 'profile.medical_info.action_manage'.tr(),
-            onAction: () => Navigator.of(context).push(
-              MaterialPageRoute(
-                builder: (_) => const EmergencyContactsView(),
-              ),
-            ),
-          ),
-          const SizedBox(height: 12),
-          legalRequiredAsync.when(
-            loading: () => const SizedBox.shrink(),
-            error: (_, __) => const SizedBox.shrink(),
-            data: (isRequired) {
-              if (!isRequired) return const SizedBox.shrink();
-              return _MedicalSectionCard(
-                icon: HugeIcons.strokeRoundedUserShield01,
-                title: 'profile.medical_info.legal_rep'.tr(),
-                iconColor: AppColors.secondary,
-                body: legalRepAsync.when(
-                  loading: () => const Padding(
-                    padding: EdgeInsets.symmetric(vertical: 8),
-                    child: SacLoadingSmall(),
-                  ),
-                  error: (e, _) => _SectionError(
-                    message: e.toString(),
-                    onRetry: () => ref.invalidate(legalRepresentativeProvider),
-                  ),
-                  data: (rep) {
-                    if (rep == null) {
-                      return Text(
-                        'profile.medical_info.not_registered'.tr(),
-                        style: TextStyle(
-                          fontSize: 14,
-                          color: c.textTertiary,
-                          fontStyle: FontStyle.italic,
-                        ),
-                      );
-                    }
-                    return Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Text(
-                          '${rep.name} ${rep.paternalSurname} ${rep.maternalSurname}',
-                          style: TextStyle(
-                            fontSize: 14,
-                            fontWeight: FontWeight.w600,
-                            color: c.text,
-                          ),
-                        ),
-                        const SizedBox(height: 2),
-                        Text(
-                          '${rep.type} · ${rep.phone}',
-                          style: TextStyle(
-                            fontSize: 12,
-                            color: c.textSecondary,
-                          ),
-                        ),
-                      ],
-                    );
-                  },
-                ),
-                actionLabel: 'profile.medical_info.action_edit'.tr(),
-                onAction: () => Navigator.of(context).push(
-                  MaterialPageRoute(
-                    builder: (_) => const LegalRepresentativeView(),
-                  ),
-                ),
-              );
-            },
-          ),
-          const SizedBox(height: 24),
-        ],
-      ),
+            const SizedBox(height: 24),
+          ],
+        ),
       ),
     );
   }
@@ -510,11 +511,7 @@ class _MedicalSectionCard extends StatelessWidget {
                     borderRadius: BorderRadius.circular(8),
                   ),
                   child: Center(
-                    child: HugeIcon(
-                      icon: icon,
-                      color: iconColor,
-                      size: 18,
-                    ),
+                    child: HugeIcon(icon: icon, color: iconColor, size: 18),
                   ),
                 ),
                 const SizedBox(width: 10),
@@ -532,8 +529,10 @@ class _MedicalSectionCard extends StatelessWidget {
                   onPressed: onAction,
                   style: TextButton.styleFrom(
                     foregroundColor: AppColors.primary,
-                    padding:
-                        const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 12,
+                      vertical: 6,
+                    ),
                     minimumSize: Size.zero,
                     tapTargetSize: MaterialTapTargetSize.shrinkWrap,
                   ),
@@ -549,10 +548,7 @@ class _MedicalSectionCard extends StatelessWidget {
             ),
           ),
           Divider(height: 1, thickness: 1, color: c.borderLight),
-          Padding(
-            padding: const EdgeInsets.all(14),
-            child: body,
-          ),
+          Padding(padding: const EdgeInsets.all(14), child: body),
         ],
       ),
     );
@@ -563,10 +559,7 @@ class _SectionError extends StatelessWidget {
   final String message;
   final VoidCallback onRetry;
 
-  const _SectionError({
-    required this.message,
-    required this.onRetry,
-  });
+  const _SectionError({required this.message, required this.onRetry});
 
   @override
   Widget build(BuildContext context) {
@@ -581,10 +574,7 @@ class _SectionError extends StatelessWidget {
         Expanded(
           child: Text(
             'profile.medical_info.load_error'.tr(),
-            style: TextStyle(
-              fontSize: 13,
-              color: AppColors.error,
-            ),
+            style: TextStyle(fontSize: 13, color: AppColors.error),
           ),
         ),
         TextButton(

--- a/lib/features/profile/presentation/views/medical_info_view.dart
+++ b/lib/features/profile/presentation/views/medical_info_view.dart
@@ -12,6 +12,7 @@ import 'package:sacdia_app/features/post_registration/presentation/views/disease
 import 'package:sacdia_app/features/post_registration/presentation/views/medicines_selection_view.dart';
 import 'package:sacdia_app/features/post_registration/presentation/views/emergency_contacts_view.dart';
 import 'package:sacdia_app/features/post_registration/presentation/views/legal_representative_view.dart';
+import 'package:sacdia_app/core/widgets/secure_screen.dart';
 import 'package:sacdia_app/features/profile/presentation/providers/profile_providers.dart';
 import 'package:sacdia_app/features/profile/presentation/widgets/blood_type_selector.dart';
 import 'package:sacdia_app/features/virtual_card/presentation/providers/virtual_card_providers.dart';
@@ -68,7 +69,8 @@ class MedicalInfoView extends ConsumerWidget {
 
     final c = context.sac;
 
-    return Scaffold(
+    return SecureScreen(
+      child: Scaffold(
       appBar: AppBar(
         title: Text('profile.medical_info.title'.tr()),
       ),
@@ -460,6 +462,7 @@ class MedicalInfoView extends ConsumerWidget {
           ),
           const SizedBox(height: 24),
         ],
+      ),
       ),
     );
   }

--- a/lib/features/virtual_card/presentation/views/virtual_card_view.dart
+++ b/lib/features/virtual_card/presentation/views/virtual_card_view.dart
@@ -6,6 +6,7 @@ import 'package:printing/printing.dart';
 import 'package:share_plus/share_plus.dart';
 
 import '../../../../core/errors/exceptions.dart';
+import '../../../../core/widgets/secure_screen.dart';
 import '../providers/virtual_card_providers.dart';
 import '../widgets/credencial/action_pill.dart';
 import '../widgets/credencial/credencial_card.dart';
@@ -78,7 +79,8 @@ class _VirtualCardViewState extends ConsumerState<VirtualCardView> {
   Widget build(BuildContext context) {
     final state = ref.watch(virtualCardProvider);
 
-    return Scaffold(
+    return SecureScreen(
+      child: Scaffold(
       appBar: AppBar(
         title: Text('virtual_card.title'.tr()),
         actions: [
@@ -227,6 +229,7 @@ class _VirtualCardViewState extends ConsumerState<VirtualCardView> {
             ],
           ),
         ),
+      ),
       ),
     );
   }

--- a/lib/features/virtual_card/presentation/views/virtual_card_view.dart
+++ b/lib/features/virtual_card/presentation/views/virtual_card_view.dart
@@ -128,11 +128,11 @@ class _VirtualCardViewState extends ConsumerState<VirtualCardView> {
                                 vm: vm,
                                 onQrTap: card.canShowQr
                                     ? () => Navigator.of(context).push(
-                                        _credencialQrFullscreenRoute(
-                                          vm,
-                                          heroTag,
-                                        ),
-                                      )
+                                          _credencialQrFullscreenRoute(
+                                            vm,
+                                            heroTag,
+                                          ),
+                                        )
                                     : _refresh,
                               ),
                               if (card.isOffline)
@@ -197,9 +197,8 @@ class _VirtualCardViewState extends ConsumerState<VirtualCardView> {
                               const SizedBox(width: 8),
                               Expanded(
                                 child: ActionPill(
-                                  label: _downloadingPdf
-                                      ? 'Descargando…'
-                                      : 'PDF',
+                                  label:
+                                      _downloadingPdf ? 'Descargando…' : 'PDF',
                                   icon: ActionIcon.pdf,
                                   onTap: _downloadingPdf
                                       ? null

--- a/lib/features/virtual_card/presentation/views/virtual_card_view.dart
+++ b/lib/features/virtual_card/presentation/views/virtual_card_view.dart
@@ -55,11 +55,13 @@ class _VirtualCardViewState extends ConsumerState<VirtualCardView> {
             'credencial_${vm.folio.replaceAll(RegExp(r'[^A-Za-z0-9_-]'), '_')}.pdf',
       );
     } catch (e) {
-      messenger.showSnackBar(SnackBar(
-        content: Text('No se pudo generar el PDF: $e'),
-        behavior: SnackBarBehavior.floating,
-        backgroundColor: Colors.red.shade700,
-      ));
+      messenger.showSnackBar(
+        SnackBar(
+          content: Text('No se pudo generar el PDF: $e'),
+          behavior: SnackBarBehavior.floating,
+          backgroundColor: Colors.red.shade700,
+        ),
+      );
     } finally {
       if (mounted) setState(() => _downloadingPdf = false);
     }
@@ -81,155 +83,160 @@ class _VirtualCardViewState extends ConsumerState<VirtualCardView> {
 
     return SecureScreen(
       child: Scaffold(
-      appBar: AppBar(
-        title: Text('virtual_card.title'.tr()),
-        actions: [
-          IconButton(
-            tooltip: 'virtual_card.refresh'.tr(),
-            onPressed: _refresh,
-            icon: const HugeIcon(
-              icon: HugeIcons.strokeRoundedRefresh,
-              size: 22,
+        appBar: AppBar(
+          title: Text('virtual_card.title'.tr()),
+          actions: [
+            IconButton(
+              tooltip: 'virtual_card.refresh'.tr(),
+              onPressed: _refresh,
+              icon: const HugeIcon(
+                icon: HugeIcons.strokeRoundedRefresh,
+                size: 22,
+              ),
             ),
-          ),
-        ],
-      ),
-      body: SafeArea(
-        child: RefreshIndicator(
-          onRefresh: _refresh,
-          child: ListView(
-            physics: const AlwaysScrollableScrollPhysics(),
-            padding: const EdgeInsets.fromLTRB(14, 12, 14, 24),
-            children: [
-              AnimatedSwitcher(
-                duration: const Duration(milliseconds: 220),
-                child: state.when(
-                  loading: () => const AspectRatio(
-                    key: ValueKey('virtual-card-loading'),
-                    aspectRatio: 5 / 8,
-                    child: VirtualCardSkeleton(),
-                  ),
-                  error: (error, _) => _ErrorState(
-                    key: const ValueKey('virtual-card-error'),
-                    messageKey: virtualCardErrorMessageKey(error),
-                    onRetry: _refresh,
-                  ),
-                  data: (card) {
-                    final vm = CredencialViewModel.fromVirtualCard(card);
-                    final heroTag = 'virtual-card-qr-${card.userId}';
-                    return Column(
-                      key: ValueKey('virtual-card-${card.userId}'),
-                      children: [
-                        Stack(
-                          children: [
-                            CredencialCard(
-                              vm: vm,
-                              onQrTap: card.canShowQr
-                                  ? () => Navigator.of(context).push(
+          ],
+        ),
+        body: SafeArea(
+          child: RefreshIndicator(
+            onRefresh: _refresh,
+            child: ListView(
+              physics: const AlwaysScrollableScrollPhysics(),
+              padding: const EdgeInsets.fromLTRB(14, 12, 14, 24),
+              children: [
+                AnimatedSwitcher(
+                  duration: const Duration(milliseconds: 220),
+                  child: state.when(
+                    loading: () => const AspectRatio(
+                      key: ValueKey('virtual-card-loading'),
+                      aspectRatio: 5 / 8,
+                      child: VirtualCardSkeleton(),
+                    ),
+                    error: (error, _) => _ErrorState(
+                      key: const ValueKey('virtual-card-error'),
+                      messageKey: virtualCardErrorMessageKey(error),
+                      onRetry: _refresh,
+                    ),
+                    data: (card) {
+                      final vm = CredencialViewModel.fromVirtualCard(card);
+                      final heroTag = 'virtual-card-qr-${card.userId}';
+                      return Column(
+                        key: ValueKey('virtual-card-${card.userId}'),
+                        children: [
+                          Stack(
+                            children: [
+                              CredencialCard(
+                                vm: vm,
+                                onQrTap: card.canShowQr
+                                    ? () => Navigator.of(context).push(
                                         _credencialQrFullscreenRoute(
                                           vm,
                                           heroTag,
                                         ),
                                       )
-                                  : _refresh,
-                            ),
-                            if (card.isOffline)
-                              Positioned(
-                                top: 14,
-                                left: 14,
-                                right: 14,
-                                child: _StatusBanner(
-                                  key: const Key(
-                                    'virtual-card-offline-banner',
-                                  ),
-                                  icon: Icons.wifi_off_outlined,
-                                  text: 'virtual_card.offline_banner'.tr(),
-                                ),
+                                    : _refresh,
                               ),
-                            if (card.isInactive)
-                              Positioned.fill(
-                                child: Container(
-                                  key: const Key(
-                                    'virtual-card-inactive-overlay',
+                              if (card.isOffline)
+                                Positioned(
+                                  top: 14,
+                                  left: 14,
+                                  right: 14,
+                                  child: _StatusBanner(
+                                    key: const Key(
+                                      'virtual-card-offline-banner',
+                                    ),
+                                    icon: Icons.wifi_off_outlined,
+                                    text: 'virtual_card.offline_banner'.tr(),
                                   ),
-                                  decoration: BoxDecoration(
-                                    color: const Color(0x33C53D3D),
-                                    borderRadius: BorderRadius.circular(
-                                      CredencialTokens.rImmersive,
+                                ),
+                              if (card.isInactive)
+                                Positioned.fill(
+                                  child: Container(
+                                    key: const Key(
+                                      'virtual-card-inactive-overlay',
+                                    ),
+                                    decoration: BoxDecoration(
+                                      color: const Color(0x33C53D3D),
+                                      borderRadius: BorderRadius.circular(
+                                        CredencialTokens.rImmersive,
+                                      ),
+                                    ),
+                                    alignment: Alignment.center,
+                                    padding: const EdgeInsets.all(24),
+                                    child: Text(
+                                      'virtual_card.inactive_message'.tr(),
+                                      textAlign: TextAlign.center,
+                                      style: const TextStyle(
+                                        color: Colors.white,
+                                        fontSize: 18,
+                                        fontWeight: FontWeight.w700,
+                                      ),
                                     ),
                                   ),
-                                  alignment: Alignment.center,
-                                  padding: const EdgeInsets.all(24),
-                                  child: Text(
-                                    'virtual_card.inactive_message'.tr(),
-                                    textAlign: TextAlign.center,
-                                    style: const TextStyle(
-                                      color: Colors.white,
-                                      fontSize: 18,
-                                      fontWeight: FontWeight.w700,
-                                    ),
-                                  ),
                                 ),
-                              ),
-                          ],
-                        ),
-                        const SizedBox(height: 12),
-                        Row(
-                          children: [
-                            Expanded(
-                              child: ActionPill(
-                                label: 'Wallet',
-                                icon: ActionIcon.wallet,
-                                primary: true,
-                                onTap: () => _showComingSoon('Wallet'),
-                              ),
-                            ),
-                            const SizedBox(width: 8),
-                            Expanded(
-                              child: ActionPill(
-                                label: 'Compartir',
-                                icon: ActionIcon.share,
-                                onTap: () => _share(vm),
-                              ),
-                            ),
-                            const SizedBox(width: 8),
-                            Expanded(
-                              child: ActionPill(
-                                label: _downloadingPdf ? 'Descargando…' : 'PDF',
-                                icon: ActionIcon.pdf,
-                                onTap: _downloadingPdf
-                                    ? null
-                                    : () => _downloadAndSharePdf(vm),
-                              ),
-                            ),
-                          ],
-                        ),
-                        if (card.photoUrl?.trim().isNotEmpty == true) ...[
-                          const SizedBox(height: 8),
-                          Center(
-                            child: TextButton.icon(
-                              onPressed: () => Navigator.of(context).push(
-                                MaterialPageRoute(
-                                  builder: (_) => VirtualCardPhotoView(
-                                    title: card.fullName,
-                                    photoUrl: card.photoUrl,
-                                  ),
-                                ),
-                              ),
-                              icon: const Icon(Icons.photo_outlined, size: 18),
-                              label: Text('virtual_card.view_photo'.tr()),
-                            ),
+                            ],
                           ),
+                          const SizedBox(height: 12),
+                          Row(
+                            children: [
+                              Expanded(
+                                child: ActionPill(
+                                  label: 'Wallet',
+                                  icon: ActionIcon.wallet,
+                                  primary: true,
+                                  onTap: () => _showComingSoon('Wallet'),
+                                ),
+                              ),
+                              const SizedBox(width: 8),
+                              Expanded(
+                                child: ActionPill(
+                                  label: 'Compartir',
+                                  icon: ActionIcon.share,
+                                  onTap: () => _share(vm),
+                                ),
+                              ),
+                              const SizedBox(width: 8),
+                              Expanded(
+                                child: ActionPill(
+                                  label: _downloadingPdf
+                                      ? 'Descargando…'
+                                      : 'PDF',
+                                  icon: ActionIcon.pdf,
+                                  onTap: _downloadingPdf
+                                      ? null
+                                      : () => _downloadAndSharePdf(vm),
+                                ),
+                              ),
+                            ],
+                          ),
+                          if (card.photoUrl?.trim().isNotEmpty == true) ...[
+                            const SizedBox(height: 8),
+                            Center(
+                              child: TextButton.icon(
+                                onPressed: () => Navigator.of(context).push(
+                                  MaterialPageRoute(
+                                    builder: (_) => VirtualCardPhotoView(
+                                      title: card.fullName,
+                                      photoUrl: card.photoUrl,
+                                    ),
+                                  ),
+                                ),
+                                icon: const Icon(
+                                  Icons.photo_outlined,
+                                  size: 18,
+                                ),
+                                label: Text('virtual_card.view_photo'.tr()),
+                              ),
+                            ),
+                          ],
                         ],
-                      ],
-                    );
-                  },
+                      );
+                    },
+                  ),
                 ),
-              ),
-            ],
+              ],
+            ),
           ),
         ),
-      ),
       ),
     );
   }
@@ -266,9 +273,9 @@ class _ErrorState extends StatelessWidget {
           Text(
             'virtual_card.load_error'.tr(),
             textAlign: TextAlign.center,
-            style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                  fontWeight: FontWeight.w700,
-                ),
+            style: Theme.of(
+              context,
+            ).textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w700),
           ),
           const SizedBox(height: 8),
           Text(
@@ -288,11 +295,7 @@ class _ErrorState extends StatelessWidget {
 }
 
 class _StatusBanner extends StatelessWidget {
-  const _StatusBanner({
-    super.key,
-    required this.icon,
-    required this.text,
-  });
+  const _StatusBanner({super.key, required this.icon, required this.text});
 
   final IconData icon;
   final String text;
@@ -340,10 +343,8 @@ Route<void> _credencialQrFullscreenRoute(
   return PageRouteBuilder<void>(
     transitionDuration: const Duration(milliseconds: 260),
     reverseTransitionDuration: const Duration(milliseconds: 220),
-    pageBuilder: (_, __, ___) => CredencialQrFullscreen(
-      vm: vm,
-      heroTag: heroTag,
-    ),
+    pageBuilder: (_, __, ___) =>
+        CredencialQrFullscreen(vm: vm, heroTag: heroTag),
     transitionsBuilder: (_, animation, __, child) {
       final curved = CurvedAnimation(
         parent: animation,

--- a/lib/features/virtual_card/presentation/widgets/credencial/credencial_qr_fullscreen.dart
+++ b/lib/features/virtual_card/presentation/widgets/credencial/credencial_qr_fullscreen.dart
@@ -83,9 +83,8 @@ class _CredencialQrFullscreenState extends State<CredencialQrFullscreen> {
     final messenger = ScaffoldMessenger.of(context);
 
     try {
-      final boundary =
-          _qrBoundaryKey.currentContext?.findRenderObject()
-              as RenderRepaintBoundary?;
+      final boundary = _qrBoundaryKey.currentContext?.findRenderObject()
+          as RenderRepaintBoundary?;
       if (boundary == null) {
         throw StateError('QR boundary no encontrado');
       }

--- a/lib/features/virtual_card/presentation/widgets/credencial/credencial_qr_fullscreen.dart
+++ b/lib/features/virtual_card/presentation/widgets/credencial/credencial_qr_fullscreen.dart
@@ -7,6 +7,7 @@ import 'package:gal/gal.dart';
 import 'package:qr_flutter/qr_flutter.dart';
 import 'package:screen_brightness/screen_brightness.dart';
 
+import '../../../../../core/widgets/secure_screen.dart';
 import 'credencial_tokens.dart';
 import 'credencial_view_model.dart';
 import 'live_clock.dart';
@@ -136,7 +137,8 @@ class _CredencialQrFullscreenState extends State<CredencialQrFullscreen> {
     final sec = Sec.of(widget.vm.seccion);
     final size = MediaQuery.of(context).size.shortestSide * 0.78;
 
-    return Scaffold(
+    return SecureScreen(
+      child: Scaffold(
       backgroundColor: Colors.white,
       body: SafeArea(
         child: Padding(
@@ -296,6 +298,7 @@ class _CredencialQrFullscreenState extends State<CredencialQrFullscreen> {
             ],
           ),
         ),
+      ),
       ),
     );
   }

--- a/lib/features/virtual_card/presentation/widgets/credencial/credencial_qr_fullscreen.dart
+++ b/lib/features/virtual_card/presentation/widgets/credencial/credencial_qr_fullscreen.dart
@@ -63,8 +63,9 @@ class _CredencialQrFullscreenState extends State<CredencialQrFullscreen> {
       // Si reset falla, intentar restaurar valor previo
       try {
         if (_previousBrightness != null) {
-          await ScreenBrightness()
-              .setApplicationScreenBrightness(_previousBrightness!);
+          await ScreenBrightness().setApplicationScreenBrightness(
+            _previousBrightness!,
+          );
         }
       } catch (_) {}
     }
@@ -82,8 +83,9 @@ class _CredencialQrFullscreenState extends State<CredencialQrFullscreen> {
     final messenger = ScaffoldMessenger.of(context);
 
     try {
-      final boundary = _qrBoundaryKey.currentContext?.findRenderObject()
-          as RenderRepaintBoundary?;
+      final boundary =
+          _qrBoundaryKey.currentContext?.findRenderObject()
+              as RenderRepaintBoundary?;
       if (boundary == null) {
         throw StateError('QR boundary no encontrado');
       }
@@ -139,166 +141,168 @@ class _CredencialQrFullscreenState extends State<CredencialQrFullscreen> {
 
     return SecureScreen(
       child: Scaffold(
-      backgroundColor: Colors.white,
-      body: SafeArea(
-        child: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 24),
-          child: Column(
-            children: [
-              // Header
-              Row(
-                children: [
-                  Image.asset(sec.logo, width: 32, height: 32),
-                  const SizedBox(width: 10),
-                  Expanded(
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      mainAxisSize: MainAxisSize.min,
-                      children: [
-                        Text(
-                          widget.vm.nombre,
-                          style: const TextStyle(
-                            fontSize: 16,
-                            fontWeight: FontWeight.w700,
-                            color: CredencialTokens.textPrimaryLight,
+        backgroundColor: Colors.white,
+        body: SafeArea(
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 24),
+            child: Column(
+              children: [
+                // Header
+                Row(
+                  children: [
+                    Image.asset(sec.logo, width: 32, height: 32),
+                    const SizedBox(width: 10),
+                    Expanded(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          Text(
+                            widget.vm.nombre,
+                            style: const TextStyle(
+                              fontSize: 16,
+                              fontWeight: FontWeight.w700,
+                              color: CredencialTokens.textPrimaryLight,
+                            ),
                           ),
-                        ),
-                        Text(
-                          sec.name,
-                          style: TextStyle(
-                            fontSize: 12,
-                            color: sec.primary,
-                            fontWeight: FontWeight.w600,
-                          ),
-                        ),
-                      ],
-                    ),
-                  ),
-                  IconButton(
-                    icon: const Icon(Icons.close_rounded, size: 28),
-                    onPressed: () => Navigator.of(context).pop(),
-                  ),
-                ],
-              ),
-              const Spacer(),
-              // QR grande con Hero para transición desde la tarjeta.
-              // Long-press → guarda PNG en galería del dispositivo.
-              GestureDetector(
-                onLongPress: _saving ? null : _saveQrToGallery,
-                child: Hero(
-                  tag: widget.heroTag,
-                  transitionOnUserGestures: true,
-                  child: RepaintBoundary(
-                    key: _qrBoundaryKey,
-                    child: Container(
-                      padding: const EdgeInsets.all(16),
-                      decoration: BoxDecoration(
-                        color: Colors.white,
-                        borderRadius: BorderRadius.circular(20),
-                        boxShadow: [
-                          BoxShadow(
-                            blurRadius: 30,
-                            offset: const Offset(0, 12),
-                            color: sec.primary.withAlpha(0x26), // ~15%
+                          Text(
+                            sec.name,
+                            style: TextStyle(
+                              fontSize: 12,
+                              color: sec.primary,
+                              fontWeight: FontWeight.w600,
+                            ),
                           ),
                         ],
                       ),
-                      child: QrImageView(
-                        data: widget.vm.qrData,
-                        size: size,
-                        backgroundColor: Colors.white,
-                        eyeStyle: QrEyeStyle(
-                          eyeShape: QrEyeShape.square,
-                          color: sec.primaryDark,
-                        ),
-                        dataModuleStyle: QrDataModuleStyle(
-                          dataModuleShape: QrDataModuleShape.square,
-                          color: sec.primaryDark,
-                        ),
-                      ),
                     ),
-                  ),
-                ),
-              ),
-              const SizedBox(height: 8),
-              Text(
-                _saving ? 'Guardando…' : 'Mantén presionado para guardar',
-                style: TextStyle(
-                  fontSize: 11,
-                  color: CredencialTokens.textTertiaryLight,
-                  fontStyle: FontStyle.italic,
-                ),
-              ),
-              const SizedBox(height: 16),
-              Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 16),
-                child: FittedBox(
-                  fit: BoxFit.scaleDown,
-                  child: Text(
-                    widget.vm.folio,
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                    softWrap: false,
-                    style: const TextStyle(
-                      fontSize: 13,
-                      fontFamily: 'monospace',
-                      color: CredencialTokens.textTertiaryLight,
-                    ),
-                  ),
-                ),
-              ),
-              const Spacer(),
-              // Anti-screenshot indicator
-              Container(
-                padding: const EdgeInsets.symmetric(
-                  horizontal: 16,
-                  vertical: 10,
-                ),
-                decoration: BoxDecoration(
-                  color: const Color(0xFFF1FBF4),
-                  borderRadius: BorderRadius.circular(999),
-                  border: Border.all(color: const Color(0xFFCEEBD7)),
-                ),
-                child: Row(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    const VerifiedDot(color: Color(0xFF22C55E)),
-                    const SizedBox(width: 8),
-                    const Text(
-                      'VERIFICADO',
-                      style: TextStyle(
-                        fontSize: 11,
-                        fontWeight: FontWeight.w700,
-                        letterSpacing: 1,
-                        color: CredencialTokens.success,
-                      ),
-                    ),
-                    const SizedBox(width: 10),
-                    const LiveClock(
-                      style: TextStyle(
-                        fontSize: 12,
-                        fontFamily: 'monospace',
-                        color: CredencialTokens.success,
-                        fontWeight: FontWeight.w600,
-                      ),
-                    ),
-                    const SizedBox(width: 6),
-                    Text(
-                      ' MX',
-                      style: TextStyle(
-                        fontSize: 12,
-                        fontFamily: 'monospace',
-                        color: CredencialTokens.success.withAlpha(0xB3), // ~70%
-                      ),
+                    IconButton(
+                      icon: const Icon(Icons.close_rounded, size: 28),
+                      onPressed: () => Navigator.of(context).pop(),
                     ),
                   ],
                 ),
-              ),
-              const SizedBox(height: 24),
-            ],
+                const Spacer(),
+                // QR grande con Hero para transición desde la tarjeta.
+                // Long-press → guarda PNG en galería del dispositivo.
+                GestureDetector(
+                  onLongPress: _saving ? null : _saveQrToGallery,
+                  child: Hero(
+                    tag: widget.heroTag,
+                    transitionOnUserGestures: true,
+                    child: RepaintBoundary(
+                      key: _qrBoundaryKey,
+                      child: Container(
+                        padding: const EdgeInsets.all(16),
+                        decoration: BoxDecoration(
+                          color: Colors.white,
+                          borderRadius: BorderRadius.circular(20),
+                          boxShadow: [
+                            BoxShadow(
+                              blurRadius: 30,
+                              offset: const Offset(0, 12),
+                              color: sec.primary.withAlpha(0x26), // ~15%
+                            ),
+                          ],
+                        ),
+                        child: QrImageView(
+                          data: widget.vm.qrData,
+                          size: size,
+                          backgroundColor: Colors.white,
+                          eyeStyle: QrEyeStyle(
+                            eyeShape: QrEyeShape.square,
+                            color: sec.primaryDark,
+                          ),
+                          dataModuleStyle: QrDataModuleStyle(
+                            dataModuleShape: QrDataModuleShape.square,
+                            color: sec.primaryDark,
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 8),
+                Text(
+                  _saving ? 'Guardando…' : 'Mantén presionado para guardar',
+                  style: TextStyle(
+                    fontSize: 11,
+                    color: CredencialTokens.textTertiaryLight,
+                    fontStyle: FontStyle.italic,
+                  ),
+                ),
+                const SizedBox(height: 16),
+                Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 16),
+                  child: FittedBox(
+                    fit: BoxFit.scaleDown,
+                    child: Text(
+                      widget.vm.folio,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      softWrap: false,
+                      style: const TextStyle(
+                        fontSize: 13,
+                        fontFamily: 'monospace',
+                        color: CredencialTokens.textTertiaryLight,
+                      ),
+                    ),
+                  ),
+                ),
+                const Spacer(),
+                // Anti-screenshot indicator
+                Container(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 16,
+                    vertical: 10,
+                  ),
+                  decoration: BoxDecoration(
+                    color: const Color(0xFFF1FBF4),
+                    borderRadius: BorderRadius.circular(999),
+                    border: Border.all(color: const Color(0xFFCEEBD7)),
+                  ),
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      const VerifiedDot(color: Color(0xFF22C55E)),
+                      const SizedBox(width: 8),
+                      const Text(
+                        'VERIFICADO',
+                        style: TextStyle(
+                          fontSize: 11,
+                          fontWeight: FontWeight.w700,
+                          letterSpacing: 1,
+                          color: CredencialTokens.success,
+                        ),
+                      ),
+                      const SizedBox(width: 10),
+                      const LiveClock(
+                        style: TextStyle(
+                          fontSize: 12,
+                          fontFamily: 'monospace',
+                          color: CredencialTokens.success,
+                          fontWeight: FontWeight.w600,
+                        ),
+                      ),
+                      const SizedBox(width: 6),
+                      Text(
+                        ' MX',
+                        style: TextStyle(
+                          fontSize: 12,
+                          fontFamily: 'monospace',
+                          color: CredencialTokens.success.withAlpha(
+                            0xB3,
+                          ), // ~70%
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+                const SizedBox(height: 24),
+              ],
+            ),
           ),
         ),
-      ),
       ),
     );
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -24,19 +24,7 @@ import 'providers/storage_provider.dart';
 const _sentryDsn =
     'https://48ff634d9f5d4213de75a751c2838383@o4510840511528960.ingest.us.sentry.io/4511270132645888';
 
-const _sensitiveFields = <String>{
-  'password',
-  'refresh_token',
-  'refreshToken',
-  'access_token',
-  'accessToken',
-  'blood',
-  'birthday',
-  'allergies',
-  'diseases',
-  'medicines',
-};
-
+/// Credentials and session tokens — never log these.
 const _sensitiveHeaders = <String>{
   'authorization',
   'cookie',
@@ -44,29 +32,99 @@ const _sensitiveHeaders = <String>{
   'x-refresh-token',
 };
 
-void _scrubMap(Map<dynamic, dynamic>? data, Set<String> keys) {
-  if (data == null) return;
-  for (final entry in data.entries.toList()) {
-    if (entry.key is String && keys.contains(entry.key)) {
-      data[entry.key] = '[REDACTED]';
+/// PII and medical fields — scrubbed from event body, extra, contexts,
+/// and breadcrumbs. Covers all field-name variants seen in the API contract.
+const _sensitiveFields = <String>{
+  // Auth / tokens
+  'password',
+  'refresh_token',
+  'refreshToken',
+  'access_token',
+  'accessToken',
+  // Medical
+  'blood',
+  'birthday',
+  'birthDate',
+  'birth_date',
+  'birthdate',
+  'allergies',
+  'diseases',
+  'medicines',
+  // Identity & contact
+  'email',
+  'phone',
+  'phoneNumber',
+  'mobile',
+  'name',
+  'firstName',
+  'first_name',
+  'lastName',
+  'last_name',
+  'fullName',
+  'full_name',
+  'displayName',
+  'display_name',
+  // User IDs
+  'user_id',
+  'userId',
+  // Address / location
+  'address',
+  'street',
+  'city',
+  'state',
+  'zip',
+  'postalCode',
+  'postal_code',
+  // National identifiers (Mexican context)
+  'birthplace',
+  'birthPlace',
+  'dni',
+  'documentNumber',
+  'document_number',
+  'nationalId',
+  'national_id',
+  'curp',
+  'rfc',
+};
+
+/// Recursively walks [data] and replaces values whose keys appear in [keys]
+/// with '[REDACTED]'. Only operates on [Map] nodes; lists are traversed for
+/// nested maps. Non-Map values are left untouched.
+void _scrubMapRecursive(dynamic data, Set<String> keys) {
+  if (data is Map) {
+    for (final key in data.keys.toList()) {
+      if (key is String && keys.contains(key)) {
+        data[key] = '[REDACTED]';
+      } else {
+        _scrubMapRecursive(data[key], keys);
+      }
+    }
+  } else if (data is List) {
+    for (final item in data) {
+      _scrubMapRecursive(item, keys);
     }
   }
 }
 
 SentryEvent? _scrubEvent(SentryEvent event, Hint hint) {
+  // Scrub HTTP request headers and body.
   final request = event.request;
   if (request != null) {
-    _scrubMap(request.headers, _sensitiveHeaders);
+    _scrubMapRecursive(request.headers, _sensitiveHeaders);
     final data = request.data;
-    if (data is Map) _scrubMap(data, _sensitiveFields);
+    if (data is Map) _scrubMapRecursive(data, _sensitiveFields);
   }
+
+  // Scrub breadcrumb data — each crumb may capture navigation or network
+  // payloads that could include PII in structured form.
   final breadcrumbs = event.breadcrumbs;
   if (breadcrumbs != null) {
     for (final crumb in breadcrumbs) {
-      _scrubMap(crumb.data, _sensitiveHeaders);
-      _scrubMap(crumb.data, _sensitiveFields);
+      _scrubMapRecursive(crumb.data, _sensitiveHeaders);
+      _scrubMapRecursive(crumb.data, _sensitiveFields);
     }
   }
+
   return event;
 }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1477,6 +1477,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
+  secure_application:
+    dependency: "direct main"
+    description:
+      name: secure_application
+      sha256: "1476f2a8df44ed9617bf42f51a1fce2ab0b83bfd4ea58983a5f7d3748b356ef3"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.1.0"
   sentry:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -72,6 +72,9 @@ dependencies:
   local_auth_android: ^1.0.56
   local_auth_darwin: ^1.6.1
 
+  # Security — Android FLAG_SECURE + iOS app-switcher blur
+  secure_application: ^4.1.0
+
   # Firebase
   firebase_core: ^3.8.0
   firebase_messaging: ^15.1.6


### PR DESCRIPTION
## Summary

Closes 2 mobile security gaps from audit 2026-05-08 (MASVS-PLATFORM-3 + privacy hardening):

### 1. FLAG_SECURE / iOS app-switcher blur via \`secure_application 4.1.0\`
Cross-platform wrapper. New \`lib/core/widgets/secure_screen.dart\` uses \`SecureApplicationNative.secure()\`/\`open()\` in \`initState\`/\`dispose\` — per-screen pattern, no app-level lock gate (preserves \`BiometricGate\` + Riverpod providers).

**Wrapped 4 sensitive screens**:
- \`VirtualCardView\` — credencial QR + folio + photo
- \`CredencialQrFullscreen\` — highest-sensitivity surface
- \`MedicalInfoView\` — blood/allergies/diseases/medicines/emergency contacts/legal rep
- \`FinancesView\` — balances + transactions

\`flutter_windowmanager 0.2.0\` rejected — sdk constraint \`<3.0.0\` incompatible with project's \`^3.6.1\`.

### 2. Sentry PII scrub: 9 → 45 fields
New categories beyond pre-existing tokens/medical:

| Category | Fields |
|---|---|
| Identity/contact | email, phone(Number), mobile, name, first/last/full/displayName |
| User IDs | user_id, userId |
| Address | street, city, state, zip, postalCode |
| National identifiers (MX) | birthplace, dni, documentNumber, nationalId, curp, rfc |
| Birth | birthDate, birthdate |

Replaced flat \`_scrubMap\` with \`_scrubMapRecursive\` walking nested Maps + Lists. Breadcrumb scrubbing already in place. Dropped \`event.extra\` scrub (deprecated in Sentry Flutter 9.x; \`sendDefaultPii=false\` suffices).

## Stats

7 files (+1 new \`secure_screen.dart\`), +101/-20. \`flutter analyze\` clean (5 pre-existing \`curly_braces\` info issues in unrelated files).

## Test plan

- [x] \`flutter pub get\` resolves
- [x] \`flutter analyze\` clean
- [ ] Manual: open VirtualCardView on Android — verify recents/screenshot blocked
- [ ] Manual: open MedicalInfoView on iOS — verify app-switcher shows blur
- [ ] Manual: trigger Sentry test event — confirm \`email\`/\`phone\`/\`name\` fields are \`[scrubbed]\`

## Out of scope (separate PR)

Android release keystore (CRITICAL from same audit) is PR #52.

From audit P1 (2026-05-08).