### PR TITLE
feat(evidence-review): align mobile coordinator review

### DIFF
--- a/lib/core/config/router.dart
+++ b/lib/core/config/router.dart
@@ -37,7 +37,6 @@ import 'package:sacdia_app/features/units/presentation/views/member_of_month_his
 import 'package:sacdia_app/features/units/presentation/views/units_list_view.dart';
 import 'package:sacdia_app/features/camporees/presentation/views/camporee_payments_view.dart';
 import 'package:sacdia_app/features/camporees/presentation/views/camporee_enroll_club_view.dart';
-import 'package:sacdia_app/features/annual_folders/presentation/views/annual_folder_view.dart';
 import 'package:sacdia_app/features/monthly_reports/presentation/views/monthly_reports_list_view.dart';
 import 'package:sacdia_app/features/monthly_reports/presentation/views/monthly_report_detail_view.dart';
 import 'package:sacdia_app/features/role_assignments/presentation/views/role_assignments_view.dart';
@@ -807,18 +806,13 @@ final routerProvider = Provider<GoRouter>((ref) {
         },
       ),
 
-      // Carpeta anual de un enrollment
+      // Compat legacy: la carpeta anual ahora usa el flujo canónico por sección
+      // activa en EvidenceFolderView. El enrollment en el path se conserva sólo
+      // para no romper deep links antiguos.
       GoRoute(
         path: RouteNames.annualFolder,
-        pageBuilder: (context, state) {
-          final enrollmentId =
-              int.tryParse(state.pathParameters['enrollmentId']!) ?? 0;
-          return _sharedAxisBuild(
-            context,
-            state,
-            AnnualFolderView(enrollmentId: enrollmentId),
-          );
-        },
+        pageBuilder: (context, state) =>
+            _sharedAxisBuild(context, state, const _EvidenceFolderShell()),
       ),
 
       // Lista de informes mensuales de un enrollment

--- a/lib/features/classes/presentation/roadmap/widgets/roadmap_screen.dart
+++ b/lib/features/classes/presentation/roadmap/widgets/roadmap_screen.dart
@@ -53,8 +53,9 @@ class _RoadmapScreenState extends State<RoadmapScreen> {
     if (!mounted) return;
 
     final ctx = _currentNodeKey.currentContext;
-    if (ctx == null)
+    if (ctx == null) {
       return; // No hay clase actual o el widget no está en el árbol.
+    }
 
     // Verificar que el RenderObject esté realmente laid out antes de llamar
     // ensureVisible. Si todavía está en NEEDS-LAYOUT la llamada lanzaría

--- a/lib/features/classes/presentation/views/requirement_detail_view.dart
+++ b/lib/features/classes/presentation/views/requirement_detail_view.dart
@@ -759,10 +759,12 @@ class _ObservationCard extends StatelessWidget {
   String _timeAgo(DateTime dt) {
     final now = DateTime.now();
     final diff = now.difference(dt);
-    if (diff.inDays >= 1)
+    if (diff.inDays >= 1) {
       return 'hace ${diff.inDays} día${diff.inDays == 1 ? '' : 's'}';
-    if (diff.inHours >= 1)
+    }
+    if (diff.inHours >= 1) {
       return 'hace ${diff.inHours} hora${diff.inHours == 1 ? '' : 's'}';
+    }
     if (diff.inMinutes >= 1) {
       return 'hace ${diff.inMinutes} minuto${diff.inMinutes == 1 ? '' : 's'}';
     }
@@ -915,10 +917,12 @@ class _FileRow extends StatelessWidget {
   String _timeAgo(DateTime dt) {
     final now = DateTime.now();
     final diff = now.difference(dt);
-    if (diff.inDays >= 1)
+    if (diff.inDays >= 1) {
       return 'Hace ${diff.inDays} día${diff.inDays == 1 ? '' : 's'}';
-    if (diff.inHours >= 1)
+    }
+    if (diff.inHours >= 1) {
       return 'Hace ${diff.inHours} hora${diff.inHours == 1 ? '' : 's'}';
+    }
     return 'Hace un momento';
   }
 }

--- a/lib/features/coordinator/data/datasources/coordinator_remote_data_source.dart
+++ b/lib/features/coordinator/data/datasources/coordinator_remote_data_source.dart
@@ -14,7 +14,7 @@ abstract class CoordinatorRemoteDataSource {
   /// GET /admin/analytics/sla-dashboard
   Future<SlaDashboardModel> getSlaDashboard({CancelToken? cancelToken});
 
-  /// GET /evidence-review/pending?page=1&limit=20&type=folder|class|honor
+  /// GET /evidence-review/pending?page=1&limit=20&type=class|honor
   Future<List<EvidenceReviewItemModel>> getPendingEvidence({
     int page = 1,
     int limit = 20,
@@ -191,6 +191,10 @@ class CoordinatorRemoteDataSourceImpl implements CoordinatorRemoteDataSource {
       list = raw;
     } else if (raw is Map && raw['data'] is List) {
       list = raw['data'] as List;
+    } else if (raw is Map &&
+        raw['data'] is Map &&
+        (raw['data'] as Map)['data'] is List) {
+      list = (raw['data'] as Map)['data'] as List;
     } else {
       list = [];
     }
@@ -280,9 +284,10 @@ class CoordinatorRemoteDataSourceImpl implements CoordinatorRemoteDataSource {
       );
 
       if (_isOk(response.statusCode)) {
-        final data = response.data is Map
-            ? response.data as Map<String, dynamic>
-            : (response.data['data'] as Map<String, dynamic>);
+        final raw = response.data;
+        final data = raw is Map<String, dynamic> && raw['data'] is Map
+            ? Map<String, dynamic>.from(raw['data'] as Map)
+            : Map<String, dynamic>.from(raw as Map);
         return EvidenceReviewItemModel.fromJson(data);
       }
       throw ServerException(

--- a/lib/features/coordinator/data/models/evidence_review_model.dart
+++ b/lib/features/coordinator/data/models/evidence_review_model.dart
@@ -105,7 +105,7 @@ class EvidenceReviewItemModel extends Equatable {
 
   factory EvidenceReviewItemModel.fromJson(Map<String, dynamic> json) {
     final typeStr =
-        (json['type'] ?? json['evidence_type'] ?? 'folder') as String;
+        (json['type'] ?? json['evidence_type'] ?? 'class') as String;
     final statusStr =
         (json['status'] ?? json['review_status'] ?? 'pending') as String;
 

--- a/lib/features/coordinator/domain/entities/evidence_review_item.dart
+++ b/lib/features/coordinator/domain/entities/evidence_review_item.dart
@@ -3,27 +3,22 @@ import 'package:equatable/equatable.dart';
 
 /// Tipo de evidencia que puede ser revisada.
 enum EvidenceReviewType {
-  folder,
   classType,
   honor;
 
   static EvidenceReviewType fromString(String value) {
     switch (value.toLowerCase()) {
-      case 'folder':
-        return EvidenceReviewType.folder;
       case 'class':
         return EvidenceReviewType.classType;
       case 'honor':
         return EvidenceReviewType.honor;
       default:
-        return EvidenceReviewType.folder;
+        return EvidenceReviewType.classType;
     }
   }
 
   String get apiValue {
     switch (this) {
-      case EvidenceReviewType.folder:
-        return 'folder';
       case EvidenceReviewType.classType:
         return 'class';
       case EvidenceReviewType.honor:
@@ -33,8 +28,6 @@ enum EvidenceReviewType {
 
   String get displayLabel {
     switch (this) {
-      case EvidenceReviewType.folder:
-        return tr('coordinator.evidence_type.folder');
       case EvidenceReviewType.classType:
         return tr('coordinator.evidence_type.class_type');
       case EvidenceReviewType.honor:
@@ -52,9 +45,13 @@ enum EvidenceReviewStatus {
   static EvidenceReviewStatus fromString(String value) {
     switch (value.toLowerCase()) {
       case 'approved':
+      case 'validated':
         return EvidenceReviewStatus.approved;
       case 'rejected':
         return EvidenceReviewStatus.rejected;
+      case 'submitted':
+      case 'pending_review':
+      case 'pending':
       default:
         return EvidenceReviewStatus.pending;
     }

--- a/lib/features/coordinator/domain/repositories/coordinator_repository.dart
+++ b/lib/features/coordinator/domain/repositories/coordinator_repository.dart
@@ -18,7 +18,7 @@ abstract class CoordinatorRepository {
   // ── Evidence Review ───────────────────────────────────────────────────────
 
   /// Devuelve la lista paginada de evidencias pendientes de revisión.
-  /// GET /evidence-review/pending?page=1&limit=20&type=folder|class|honor
+  /// GET /evidence-review/pending?page=1&limit=20&type=class|honor
   Future<Either<Failure, List<EvidenceReviewItem>>> getPendingEvidence({
     int page = 1,
     int limit = 20,

--- a/lib/features/coordinator/presentation/views/evidence_review_detail_view.dart
+++ b/lib/features/coordinator/presentation/views/evidence_review_detail_view.dart
@@ -374,8 +374,6 @@ class _MemberHeader extends StatelessWidget {
 
   Color _typeColor(EvidenceReviewType type) {
     switch (type) {
-      case EvidenceReviewType.folder:
-        return AppColors.accent;
       case EvidenceReviewType.classType:
         return AppColors.info;
       case EvidenceReviewType.honor:

--- a/lib/features/coordinator/presentation/views/evidence_review_list_view.dart
+++ b/lib/features/coordinator/presentation/views/evidence_review_list_view.dart
@@ -237,10 +237,6 @@ class _FilterChips extends StatelessWidget {
     final filters = <({String label, EvidenceReviewType? value})>[
       (label: 'coordinator.evidence_review.list.filter_all'.tr(), value: null),
       (
-        label: 'coordinator.evidence_review.list.filter_folders'.tr(),
-        value: EvidenceReviewType.folder
-      ),
-      (
         label: 'coordinator.evidence_review.list.filter_classes'.tr(),
         value: EvidenceReviewType.classType
       ),

--- a/lib/features/coordinator/presentation/widgets/evidence_review_card.dart
+++ b/lib/features/coordinator/presentation/widgets/evidence_review_card.dart
@@ -149,8 +149,6 @@ class EvidenceReviewCard extends StatelessWidget {
 
   Color _typeColor(EvidenceReviewType type) {
     switch (type) {
-      case EvidenceReviewType.folder:
-        return AppColors.accent;
       case EvidenceReviewType.classType:
         return AppColors.info;
       case EvidenceReviewType.honor:

--- a/lib/features/evidence_folder/data/models/evidence_section_model.dart
+++ b/lib/features/evidence_folder/data/models/evidence_section_model.dart
@@ -87,7 +87,9 @@ class EvidenceSectionModel extends EvidenceSection {
     // Se lee el campo `status` del JSON directamente. Si el campo no está
     // presente (rollout parcial), se usa PENDING como fallback seguro.
     final storedStatus =
-        EvidenceSectionStatusX.fromJson(json['status']?.toString());
+        EvidenceSectionStatusX.fromJson(
+      (json['status'] ?? evaluation?['status'])?.toString(),
+    );
 
     // ── Actores de aprobación dual-level ────────────────────────────────────
     final lfApproverName =

--- a/lib/features/evidence_folder/data/models/evidence_section_model.dart
+++ b/lib/features/evidence_folder/data/models/evidence_section_model.dart
@@ -86,8 +86,7 @@ class EvidenceSectionModel extends EvidenceSection {
     // ── Status almacenado (fuente de verdad: servidor) ──────────────────────
     // Se lee el campo `status` del JSON directamente. Si el campo no está
     // presente (rollout parcial), se usa PENDING como fallback seguro.
-    final storedStatus =
-        EvidenceSectionStatusX.fromJson(
+    final storedStatus = EvidenceSectionStatusX.fromJson(
       (json['status'] ?? evaluation?['status'])?.toString(),
     );
 


### PR DESCRIPTION
## Summary
- Removes folder review from the mobile coordinator Evidence Review flow.
- Keeps the annual folder route pointing to the canonical evidence folder shell.
- Hardens coordinator evidence parsing for nested API wrappers.

## Test Plan
- [x] `flutter analyze`
- [x] `flutter test test/features/evidence_folder/evidence_section_model_test.dart`
