### PR TITLE
feat(persona-nav): _MainShell consumes personaNavSlotsProvider

### DIFF
--- a/lib/core/config/router.dart
+++ b/lib/core/config/router.dart
@@ -56,9 +56,6 @@ import 'package:sacdia_app/features/rankings/presentation/screens/member_breakdo
 import 'package:sacdia_app/features/rankings/presentation/screens/my_ranking_screen.dart';
 import 'package:sacdia_app/features/rankings/presentation/screens/section_ranking_screen.dart';
 
-import '../../features/auth/domain/entities/authorization_snapshot.dart';
-import '../../features/auth/domain/entities/user_entity.dart';
-import '../../features/auth/domain/utils/authorization_utils.dart';
 import '../../features/auth/presentation/providers/auth_providers.dart';
 import '../providers/app_bootstrap_provider.dart';
 import '../notifications/push_notification_provider.dart';
@@ -77,6 +74,7 @@ import '../../features/profile/presentation/views/profile_view.dart';
 import '../../features/profile/presentation/views/medical_info_view.dart';
 import '../animations/page_transitions.dart';
 import '../utils/responsive.dart';
+import '../persona/index.dart';
 import 'route_names.dart';
 
 /// Shared-axis slide for standard forward/back navigation.
@@ -1073,70 +1071,20 @@ final routerProvider = Provider<GoRouter>((ref) {
 });
 
 // ── Navigation destination data ───────────────────────────────────────────────
-
-class _NavItemConfig {
-  /// The shell branch index for this tab. Must match the branch position in
-  /// the StatefulShellRoute.indexedStack branches list.
-  final int branchIndex;
-  final String route;
-  final List<List<dynamic>> icon;
-
-  /// i18n key resolved via tr() at build time.
-  final String labelKey;
-  final Set<String> requiredPermissions;
-
-  const _NavItemConfig({
-    required this.branchIndex,
-    required this.route,
-    required this.icon,
-    required this.labelKey,
-    this.requiredPermissions = const {},
-  });
-
-  String get label => tr(labelKey);
-}
-
-const List<_NavItemConfig> _navItemsConfig = [
-  _NavItemConfig(
-    branchIndex: 0,
-    route: RouteNames.homeDashboard,
-    icon: HugeIcons.strokeRoundedHome01,
-    labelKey: 'router.nav.home',
-  ),
-  _NavItemConfig(
-    branchIndex: 1,
-    route: RouteNames.homeClasses,
-    icon: HugeIcons.strokeRoundedSchool,
-    labelKey: 'router.nav.classes',
-    requiredPermissions: {'classes:read'},
-  ),
-  _NavItemConfig(
-    branchIndex: 2,
-    route: RouteNames.homeActivities,
-    icon: HugeIcons.strokeRoundedCalendar01,
-    labelKey: 'router.nav.activities',
-    requiredPermissions: {'activities:read'},
-  ),
-  _NavItemConfig(
-    branchIndex: 3,
-    route: RouteNames.homeProfile,
-    icon: HugeIcons.strokeRoundedUser,
-    labelKey: 'router.nav.profile',
-  ),
-];
-
-List<_NavItemConfig> _filterNavItems(
-  List<_NavItemConfig> items,
-  UserEntity? user,
-  AuthorizationSnapshot? authorization,
-) {
-  if (authorization == null) return items;
-
-  return items.where((item) {
-    if (item.requiredPermissions.isEmpty) return true;
-    return hasAnyPermission(user, item.requiredPermissions);
-  }).toList();
-}
+//
+// MIGRATED (PR-2): _NavItemConfig, _navItemsConfig, and _filterNavItems have
+// been replaced by the persona module. Nav slot configuration now lives in
+// lib/core/persona/persona_nav_config.dart and is consumed via
+// personaNavSlotsProvider (see _MainShell below).
+//
+// Slot definitions per persona:
+//   Miembro     → Dashboard | Clases | Actividades | Ranking  | Perfil
+//   Consejero   → Mi Unidad | Clases | Miembros    | Actividades | Perfil
+//   Director    → Miembros  | Club   | Finanzas    | Actividades | Perfil
+//   Tesorero    → Finanzas  | Seguros| Club        | Actividades | Perfil
+//   Coordinador → Hub       | Clubes | Reportes    | Actividades | Perfil  (PR-4 shell)
+//
+// All 18 StatefulShellBranch indices (0–17) are preserved unchanged (NFR-5).
 
 // ── Main shell — adaptive navigation ─────────────────────────────────────────
 
@@ -1148,8 +1096,12 @@ List<_NavItemConfig> _filterNavItems(
 /// across tab switches, preventing autoDispose providers from being disposed
 /// on every tab change.
 ///
-/// Watches [authNotifierProvider] scoped to the authorization sub-state so
-/// the tab list rebuilds reactively when permissions change (e.g. context switch).
+/// Watches [personaNavSlotsProvider] which derives the [NavSlot] list from the
+/// current [Persona]. Rebuilds only when the persona changes (e.g. after login
+/// or a context switch via [activeAssignmentId]).
+///
+/// [NavBadge] is applied to each slot icon when [NavSlot.badgeSource] is not
+/// [NavBadgeSource.none], rendering unread notification counts inline.
 class _MainShell extends ConsumerWidget {
   final StatefulNavigationShell navigationShell;
 
@@ -1157,24 +1109,15 @@ class _MainShell extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final user = ref.watch(
-      authNotifierProvider.select((v) => v.valueOrNull),
-    );
-    final authorization = user?.authorization;
+    final slots = ref.watch(personaNavSlotsProvider);
 
-    final filteredItems = _filterNavItems(
-      _navItemsConfig,
-      user,
-      authorization,
-    );
-
-    // Map the shell's current branch index to the filtered UI position.
-    // Quick-access branches (index >= _kNavBranchCount) are not shown in the
-    // nav bar, so we fall back to index 0 (Dashboard) for those cases.
+    // Map the shell's current branch index to the persona-slot UI position.
+    // Branches that are not part of the current persona's nav (quick-access or
+    // other-persona slots) are not shown; we fall back to index 0 in that case.
     final currentBranchIndex = navigationShell.currentIndex;
     final selectedIndex = () {
-      final uiIdx = filteredItems.indexWhere(
-        (item) => item.branchIndex == currentBranchIndex,
+      final uiIdx = slots.indexWhere(
+        (slot) => slot.branchIndex == currentBranchIndex,
       );
       return uiIdx < 0 ? 0 : uiIdx;
     }();
@@ -1189,23 +1132,33 @@ class _MainShell extends ConsumerWidget {
             NavigationRail(
               selectedIndex: selectedIndex,
               onDestinationSelected: (uiIndex) =>
-                  navigationShell.goBranch(filteredItems[uiIndex].branchIndex),
+                  navigationShell.goBranch(slots[uiIndex].branchIndex),
               labelType: NavigationRailLabelType.all,
               useIndicator: true,
-              destinations: filteredItems
+              destinations: slots
                   .map(
-                    (item) => NavigationRailDestination(
-                      icon: HugeIcon(
-                        icon: item.icon,
-                        size: 24,
-                        color: Theme.of(context).colorScheme.onSurfaceVariant,
+                    (slot) => NavigationRailDestination(
+                      icon: NavBadge(
+                        source: slot.badgeSource,
+                        child: HugeIcon(
+                          icon: slot.icon,
+                          size: 24,
+                          color:
+                              Theme.of(context).colorScheme.onSurfaceVariant,
+                        ),
                       ),
-                      selectedIcon: HugeIcon(
-                        icon: item.icon,
-                        size: 24,
-                        color: Theme.of(context).colorScheme.primary,
+                      selectedIcon: NavBadge(
+                        source: slot.badgeSource,
+                        child: HugeIcon(
+                          icon: slot.icon,
+                          size: 24,
+                          color: Theme.of(context).colorScheme.primary,
+                        ),
                       ),
-                      label: Text(item.label),
+                      label: Semantics(
+                        label: tr(slot.labelKey),
+                        child: Text(tr(slot.labelKey)),
+                      ),
                     ),
                   )
                   .toList(),
@@ -1226,13 +1179,19 @@ class _MainShell extends ConsumerWidget {
       bottomNavigationBar: NavigationBar(
         selectedIndex: selectedIndex,
         onDestinationSelected: (uiIndex) =>
-            navigationShell.goBranch(filteredItems[uiIndex].branchIndex),
-        destinations: filteredItems
+            navigationShell.goBranch(slots[uiIndex].branchIndex),
+        destinations: slots
             .map(
-              (item) => NavigationDestination(
-                icon: HugeIcon(icon: item.icon),
-                selectedIcon: HugeIcon(icon: item.icon),
-                label: item.label,
+              (slot) => NavigationDestination(
+                icon: NavBadge(
+                  source: slot.badgeSource,
+                  child: HugeIcon(icon: slot.icon),
+                ),
+                selectedIcon: NavBadge(
+                  source: slot.badgeSource,
+                  child: HugeIcon(icon: slot.icon),
+                ),
+                label: tr(slot.labelKey),
               ),
             )
             .toList(),

--- a/lib/core/persona/index.dart
+++ b/lib/core/persona/index.dart
@@ -12,3 +12,4 @@ export 'persona.dart';
 export 'persona_nav_config.dart';
 export 'persona_providers.dart';
 export 'persona_resolver.dart';
+export 'widgets/nav_badge.dart';

--- a/lib/core/persona/widgets/nav_badge.dart
+++ b/lib/core/persona/widgets/nav_badge.dart
@@ -1,0 +1,84 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:sacdia_app/core/persona/nav_slot.dart';
+import 'package:sacdia_app/features/notifications/presentation/providers/unread_notifications_count_provider.dart';
+
+/// Wraps [child] with a notification badge driven by [source].
+///
+/// When [source] is [NavBadgeSource.none], the child is returned unwrapped.
+/// When [source] is any active value, the widget watches
+/// [unreadNotificationsCountProvider] and overlays a red circular badge in the
+/// top-right corner when the count is greater than zero.
+///
+/// Design constraints (NFR-3, NFR-4):
+/// - Badge uses `Theme.of(context).colorScheme.error` (Material 3 semantic token).
+/// - Badge counter is capped at 99+.
+/// - Touch target maintained by parent [NavigationDestination] / [NavigationRailDestination].
+///
+/// Usage:
+/// ```dart
+/// NavBadge(
+///   source: slot.badgeSource,
+///   child: HugeIcon(icon: slot.icon),
+/// )
+/// ```
+class NavBadge extends ConsumerWidget {
+  const NavBadge({
+    super.key,
+    required this.source,
+    required this.child,
+  });
+
+  final NavBadgeSource source;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    if (source == NavBadgeSource.none) {
+      return child;
+    }
+
+    final count = ref.watch(unreadNotificationsCountProvider);
+
+    if (count <= 0) {
+      return child;
+    }
+
+    final badgeLabel = count > 99 ? '99+' : '$count';
+
+    return Stack(
+      clipBehavior: Clip.none,
+      children: [
+        child,
+        Positioned(
+          top: -4,
+          right: -6,
+          child: Semantics(
+            label: '$badgeLabel notificaciones no leídas',
+            child: Container(
+              constraints: const BoxConstraints(
+                minWidth: 16,
+                minHeight: 16,
+              ),
+              padding: const EdgeInsets.symmetric(horizontal: 4),
+              decoration: BoxDecoration(
+                color: Theme.of(context).colorScheme.error,
+                borderRadius: BorderRadius.circular(8),
+              ),
+              child: Text(
+                badgeLabel,
+                style: TextStyle(
+                  color: Theme.of(context).colorScheme.onError,
+                  fontSize: 10,
+                  fontWeight: FontWeight.w600,
+                  height: 1.6,
+                ),
+                textAlign: TextAlign.center,
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/test/core/persona/main_shell_widget_test.dart
+++ b/test/core/persona/main_shell_widget_test.dart
@@ -1,0 +1,304 @@
+/// Widget tests for the persona-driven navigation shell (T-10/T-14).
+///
+/// These tests verify:
+/// 1. Slot count per persona matches spec FR-2 (exactly 5 slots).
+/// 2. Slot label keys are correct for Miembro and Director personas.
+/// 3. NavigationBar renders the correct number of [NavigationDestination]s.
+///
+/// NOTE: [_MainShell] is a private class inside router.dart and cannot be
+/// imported directly. Instead, we use a [_TestNavShell] widget that mirrors
+/// its NavigationBar build path using the public [personaNavSlotsProvider],
+/// which is the exact provider [_MainShell] consumes in production.
+///
+/// EasyLocalization is intentionally omitted from these tests. Labels are
+/// rendered using the raw [NavSlot.labelKey] string so tests remain
+/// deterministic without locale setup. Production correctness of translated
+/// strings is covered by the i18n key tests in [persona_nav_config_test.dart].
+library;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sacdia_app/core/persona/index.dart';
+import 'package:sacdia_app/features/auth/domain/entities/authorization_snapshot.dart';
+import 'package:sacdia_app/features/auth/domain/entities/user_entity.dart';
+import 'package:sacdia_app/features/auth/presentation/providers/auth_providers.dart';
+import 'package:sacdia_app/features/notifications/presentation/providers/unread_notifications_count_provider.dart';
+
+// ── Fake helpers ──────────────────────────────────────────────────────────────
+
+class _FakeAuthNotifier extends AuthNotifier {
+  final UserEntity? _user;
+  _FakeAuthNotifier(this._user);
+
+  @override
+  Future<UserEntity?> build() async => _user;
+}
+
+class _FakeCountNotifier extends UnreadNotificationsCountNotifier {
+  @override
+  int build() => 0;
+}
+
+UserEntity _userWithRole(String roleName) {
+  return UserEntity(
+    id: 'test-id',
+    email: 'test@example.com',
+    postRegisterComplete: true,
+    authorization: AuthorizationSnapshot(
+      clubAssignments: [
+        AuthorizationGrant(
+          assignmentId: 'a1',
+          roleName: roleName,
+          status: 'active',
+        ),
+      ],
+      activeAssignmentId: 'a1',
+    ),
+  );
+}
+
+// ── Test shell widget ─────────────────────────────────────────────────────────
+
+/// Mirrors the [NavigationBar] portion of [_MainShell] using the same provider.
+///
+/// Uses raw [NavSlot.labelKey] (not translated) so no locale setup is needed.
+class _TestNavShell extends ConsumerWidget {
+  const _TestNavShell();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final slots = ref.watch(personaNavSlotsProvider);
+
+    return Scaffold(
+      body: const SizedBox.shrink(),
+      bottomNavigationBar: NavigationBar(
+        selectedIndex: 0,
+        onDestinationSelected: (_) {},
+        destinations: slots
+            .map(
+              (slot) => NavigationDestination(
+                icon: NavBadge(
+                  source: slot.badgeSource,
+                  child: const Icon(Icons.circle),
+                ),
+                selectedIcon: NavBadge(
+                  source: slot.badgeSource,
+                  child: const Icon(Icons.circle),
+                ),
+                // Use raw labelKey for test stability (no locale needed)
+                label: slot.labelKey,
+              ),
+            )
+            .toList(),
+      ),
+    );
+  }
+}
+
+// ── Test harness ──────────────────────────────────────────────────────────────
+
+Future<void> _pumpShell(
+  WidgetTester tester, {
+  required UserEntity? user,
+}) async {
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        authNotifierProvider.overrideWith(() => _FakeAuthNotifier(user)),
+        unreadNotificationsCountProvider.overrideWith(
+          () => _FakeCountNotifier(),
+        ),
+      ],
+      child: const MaterialApp(
+        home: _TestNavShell(),
+      ),
+    ),
+  );
+
+  await tester.pumpAndSettle();
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+void main() {
+  group('_MainShell navigation bar — persona slot count (T-10, T-14)', () {
+    testWidgets('Miembro persona renders exactly 5 navigation destinations',
+        (tester) async {
+      await _pumpShell(tester, user: _userWithRole('member'));
+
+      expect(
+        find.byType(NavigationDestination),
+        findsNWidgets(5),
+        reason: 'Miembro nav must have exactly 5 slots (FR-2)',
+      );
+    });
+
+    testWidgets('Director persona renders exactly 5 navigation destinations',
+        (tester) async {
+      await _pumpShell(tester, user: _userWithRole('director'));
+
+      expect(
+        find.byType(NavigationDestination),
+        findsNWidgets(5),
+        reason: 'Director nav must have exactly 5 slots (FR-2)',
+      );
+    });
+
+    testWidgets('null user (no auth) renders Miembro nav — 5 destinations',
+        (tester) async {
+      await _pumpShell(tester, user: null);
+
+      expect(find.byType(NavigationDestination), findsNWidgets(5));
+    });
+
+    testWidgets('Consejero persona renders exactly 5 navigation destinations',
+        (tester) async {
+      await _pumpShell(tester, user: _userWithRole('counselor'));
+
+      expect(find.byType(NavigationDestination), findsNWidgets(5));
+    });
+
+    testWidgets('Tesorero persona renders exactly 5 navigation destinations',
+        (tester) async {
+      await _pumpShell(tester, user: _userWithRole('treasurer'));
+
+      expect(find.byType(NavigationDestination), findsNWidgets(5));
+    });
+  });
+
+  group('_MainShell navigation bar — slot labels via labelKey (T-11)', () {
+    testWidgets('Miembro: nav bar shows correct labelKey text for all 5 slots',
+        (tester) async {
+      await _pumpShell(tester, user: _userWithRole('member'));
+
+      // Raw labelKey strings are used as labels in _TestNavShell
+      expect(find.text('nav.dashboard'), findsWidgets);
+      expect(find.text('nav.classes'), findsWidgets);
+      expect(find.text('nav.activities'), findsWidgets);
+      expect(find.text('nav.ranking'), findsWidgets);
+      expect(find.text('nav.profile'), findsWidgets);
+    });
+
+    testWidgets('Director: nav bar shows correct labelKey text for all 5 slots',
+        (tester) async {
+      await _pumpShell(tester, user: _userWithRole('director'));
+
+      expect(find.text('nav.members'), findsWidgets);
+      expect(find.text('nav.club'), findsWidgets);
+      expect(find.text('nav.finances'), findsWidgets);
+      expect(find.text('nav.activities'), findsWidgets);
+      expect(find.text('nav.profile'), findsWidgets);
+    });
+
+    testWidgets(
+        'Consejero: nav bar shows correct labelKey text for all 5 slots',
+        (tester) async {
+      await _pumpShell(tester, user: _userWithRole('counselor'));
+
+      expect(find.text('nav.my_unit'), findsWidgets);
+      expect(find.text('nav.classes'), findsWidgets);
+      expect(find.text('nav.members'), findsWidgets);
+      expect(find.text('nav.activities'), findsWidgets);
+      expect(find.text('nav.profile'), findsWidgets);
+    });
+
+    testWidgets(
+        'Tesorero: nav bar shows correct labelKey text for all 5 slots',
+        (tester) async {
+      await _pumpShell(tester, user: _userWithRole('treasurer'));
+
+      expect(find.text('nav.finances'), findsWidgets);
+      expect(find.text('nav.insurance'), findsWidgets);
+      expect(find.text('nav.club'), findsWidgets);
+      expect(find.text('nav.activities'), findsWidgets);
+      expect(find.text('nav.profile'), findsWidgets);
+    });
+  });
+
+  group('_MainShell navigation bar — slot identity (T-11)', () {
+    test('personaNavSlotsProvider for Director — correct slot label keys',
+        () async {
+      final container = ProviderContainer(
+        overrides: [
+          authNotifierProvider
+              .overrideWith(() => _FakeAuthNotifier(_userWithRole('director'))),
+        ],
+      );
+      addTearDown(container.dispose);
+      await container.read(authNotifierProvider.future);
+
+      final slots = container.read(personaNavSlotsProvider);
+      expect(slots.length, 5);
+      expect(slots[0].labelKey, 'nav.members');
+      expect(slots[1].labelKey, 'nav.club');
+      expect(slots[2].labelKey, 'nav.finances');
+      expect(slots[3].labelKey, 'nav.activities');
+      expect(slots[4].labelKey, 'nav.profile');
+    });
+
+    test('personaNavSlotsProvider for Miembro — correct slot label keys',
+        () async {
+      final container = ProviderContainer(
+        overrides: [
+          authNotifierProvider.overrideWith(
+            () => _FakeAuthNotifier(_userWithRole('member')),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+      await container.read(authNotifierProvider.future);
+
+      final slots = container.read(personaNavSlotsProvider);
+      expect(slots.length, 5);
+      expect(slots[0].labelKey, 'nav.dashboard');
+      expect(slots[1].labelKey, 'nav.classes');
+      expect(slots[2].labelKey, 'nav.activities');
+      expect(slots[3].labelKey, 'nav.ranking');
+      expect(slots[4].labelKey, 'nav.profile');
+    });
+  });
+
+  group('T-13: badgeSource wiring in persona_nav_config', () {
+    test('Activities slot in every persona has badgeSource=activities', () {
+      for (final entry in personaNavConfig.entries) {
+        final activitiesSlot = entry.value.firstWhere(
+          (s) => s.labelKey == 'nav.activities',
+          orElse: () => throw StateError(
+            'Persona ${entry.key} missing Activities slot',
+          ),
+        );
+        expect(
+          activitiesSlot.badgeSource,
+          NavBadgeSource.activities,
+          reason: 'Persona ${entry.key}: Activities slot must badge activities',
+        );
+      }
+    });
+
+    test('Consejero Mi Unidad slot has badgeSource=unit (FR-8)', () {
+      final slots = personaNavConfig[Persona.consejero]!;
+      final unitSlot = slots.firstWhere((s) => s.labelKey == 'nav.my_unit');
+      expect(unitSlot.badgeSource, NavBadgeSource.unit);
+    });
+
+    test('Director Miembros slot has badgeSource=members (FR-8)', () {
+      final slots = personaNavConfig[Persona.director]!;
+      final membersSlot = slots.firstWhere((s) => s.labelKey == 'nav.members');
+      expect(membersSlot.badgeSource, NavBadgeSource.members);
+    });
+
+    test('Tesorero Finanzas slot has badgeSource=finances (FR-8)', () {
+      final slots = personaNavConfig[Persona.tesorero]!;
+      final financesSlot =
+          slots.firstWhere((s) => s.labelKey == 'nav.finances');
+      expect(financesSlot.badgeSource, NavBadgeSource.finances);
+    });
+
+    test('Coordinador Hub slot has badgeSource=hub (FR-8)', () {
+      final slots = personaNavConfig[Persona.coordinador]!;
+      final hubSlot = slots.firstWhere((s) => s.labelKey == 'nav.hub');
+      expect(hubSlot.badgeSource, NavBadgeSource.hub);
+    });
+  });
+}

--- a/test/core/persona/nav_badge_test.dart
+++ b/test/core/persona/nav_badge_test.dart
@@ -1,0 +1,127 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sacdia_app/core/persona/nav_slot.dart';
+import 'package:sacdia_app/core/persona/widgets/nav_badge.dart';
+import 'package:sacdia_app/features/notifications/presentation/providers/unread_notifications_count_provider.dart';
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/// Pumps a [NavBadge] with an overridden [unreadNotificationsCountProvider].
+Future<void> _pumpBadge(
+  WidgetTester tester, {
+  required NavBadgeSource source,
+  required int count,
+}) async {
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        unreadNotificationsCountProvider.overrideWith(
+          () => _FakeCountNotifier(count),
+        ),
+      ],
+      child: MaterialApp(
+        home: Scaffold(
+          body: Center(
+            child: NavBadge(
+              source: source,
+              child: const Icon(Icons.home),
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+}
+
+class _FakeCountNotifier extends UnreadNotificationsCountNotifier {
+  final int _value;
+  _FakeCountNotifier(this._value);
+
+  @override
+  int build() => _value;
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+void main() {
+  group('NavBadge (T-12)', () {
+    testWidgets('shows badge when source=activities and count > 0',
+        (tester) async {
+      await _pumpBadge(
+        tester,
+        source: NavBadgeSource.activities,
+        count: 3,
+      );
+
+      expect(find.text('3'), findsOneWidget);
+    });
+
+    testWidgets('shows badge when source=members and count > 0',
+        (tester) async {
+      await _pumpBadge(
+        tester,
+        source: NavBadgeSource.members,
+        count: 5,
+      );
+
+      expect(find.text('5'), findsOneWidget);
+    });
+
+    testWidgets('does NOT show badge when count == 0', (tester) async {
+      await _pumpBadge(
+        tester,
+        source: NavBadgeSource.activities,
+        count: 0,
+      );
+
+      // Badge text not rendered when count is zero
+      expect(find.text('0'), findsNothing);
+    });
+
+    testWidgets('does NOT show badge when source == none (count ignored)',
+        (tester) async {
+      await _pumpBadge(
+        tester,
+        source: NavBadgeSource.none,
+        count: 99,
+      );
+
+      // Badge should not appear regardless of count when source is none
+      expect(find.text('99'), findsNothing);
+    });
+
+    testWidgets('shows "99+" when count > 99', (tester) async {
+      await _pumpBadge(
+        tester,
+        source: NavBadgeSource.activities,
+        count: 150,
+      );
+
+      expect(find.text('99+'), findsOneWidget);
+      expect(find.text('150'), findsNothing);
+    });
+
+    testWidgets('shows "99" (not 99+) when count == 99', (tester) async {
+      await _pumpBadge(
+        tester,
+        source: NavBadgeSource.activities,
+        count: 99,
+      );
+
+      expect(find.text('99'), findsOneWidget);
+      expect(find.text('99+'), findsNothing);
+    });
+
+    testWidgets('child widget is always rendered', (tester) async {
+      await _pumpBadge(
+        tester,
+        source: NavBadgeSource.none,
+        count: 0,
+      );
+
+      // The Icon child should always be present
+      expect(find.byType(Icon), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Migrate `_MainShell` to `ConsumerWidget` watching `personaNavSlotsProvider`
- Remove `_navItemsConfig`, `_filterNavItems`, `_NavItemConfig` — nav now driven by persona config
- Add `NavBadge` ConsumerWidget at `lib/core/persona/widgets/nav_badge.dart`
- Intentional functional shift: Miembro now sees 5 slots (adds Ranking branchIndex 17) — documented + accepted
- 18 StatefulShellBranch entries preserved unchanged

## Test plan
- [x] `flutter test` — 294/294 pass (+23 new)
- [x] Slot count + label-key assertions per persona
- [ ] Manual goldens (deferred — requires simulator)

## Stack
PR 2/5 — depends on #foundation. See SDD verify report — PASS-WITH-WARNINGS (Semantics + goldens noted).