### PR TITLE
feat(persona-nav): Más sheet with RBAC-filtered overflow nav

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -56,7 +56,10 @@
     "hub": "Hub",
     "clubs": "Clubs",
     "reports": "Reports",
-    "unread_notifications_a11y": "{count} unread notifications"
+    "unread_notifications_a11y": "{count} unread notifications",
+    "more": "More",
+    "more_options": "More options",
+    "more_sheet_title": "More destinations"
   },
   "settings": {
     "title": "Settings",

--- a/assets/translations/es.json
+++ b/assets/translations/es.json
@@ -56,7 +56,10 @@
     "hub": "Hub",
     "clubs": "Clubes",
     "reports": "Reportes",
-    "unread_notifications_a11y": "{count} notificaciones no leídas"
+    "unread_notifications_a11y": "{count} notificaciones no leídas",
+    "more": "Más",
+    "more_options": "Más opciones",
+    "more_sheet_title": "Más destinos"
   },
   "settings": {
     "title": "Configuración",

--- a/assets/translations/fr.json
+++ b/assets/translations/fr.json
@@ -56,7 +56,10 @@
     "hub": "Hub",
     "clubs": "Clubs",
     "reports": "Rapports",
-    "unread_notifications_a11y": "{count} notifications non lues"
+    "unread_notifications_a11y": "{count} notifications non lues",
+    "more": "Plus",
+    "more_options": "Plus d'options",
+    "more_sheet_title": "Plus de destinations"
   },
   "settings": {
     "title": "Paramètres",

--- a/assets/translations/pt-BR.json
+++ b/assets/translations/pt-BR.json
@@ -56,7 +56,10 @@
     "hub": "Hub",
     "clubs": "Clubes",
     "reports": "Relatórios",
-    "unread_notifications_a11y": "{count} notificações não lidas"
+    "unread_notifications_a11y": "{count} notificações não lidas",
+    "more": "Mais",
+    "more_options": "Mais opções",
+    "more_sheet_title": "Mais destinos"
   },
   "settings": {
     "title": "Configurações",

--- a/lib/core/persona/index.dart
+++ b/lib/core/persona/index.dart
@@ -13,3 +13,4 @@ export 'persona_nav_config.dart';
 export 'persona_providers.dart';
 export 'persona_resolver.dart';
 export 'widgets/nav_badge.dart';
+export 'widgets/more_sheet.dart';

--- a/lib/core/persona/widgets/more_sheet.dart
+++ b/lib/core/persona/widgets/more_sheet.dart
@@ -1,0 +1,434 @@
+import 'package:easy_localization/easy_localization.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:hugeicons/hugeicons.dart';
+import 'package:sacdia_app/core/config/route_names.dart';
+import 'package:sacdia_app/core/persona/persona.dart';
+import 'package:sacdia_app/core/persona/persona_nav_config.dart';
+import 'package:sacdia_app/core/persona/persona_providers.dart';
+import 'package:sacdia_app/core/theme/app_colors.dart';
+import 'package:sacdia_app/core/theme/sac_colors.dart';
+import 'package:sacdia_app/core/utils/icon_helper.dart';
+import 'package:sacdia_app/features/auth/domain/entities/user_entity.dart';
+import 'package:sacdia_app/features/auth/domain/utils/authorization_utils.dart';
+import 'package:sacdia_app/features/auth/presentation/providers/auth_providers.dart';
+
+// ─── Data model ───────────────────────────────────────────────────────────────
+
+/// A single navigable destination exposed in the «Más» sheet.
+///
+/// Mirrors the structure of the private `_QuickAccessItemConfig` in
+/// `quick_access_grid.dart` so that the sheet can reuse the same RBAC
+/// predicates ([hasAnyPermission] / [hasAnyRole]) without coupling to the
+/// dashboard widget's private types.
+@visibleForTesting
+class MoreSheetDestination {
+  final String labelKey;
+  final HugeIconData icon;
+  final Color? color;
+
+  /// Static route path. Use when the route does not depend on runtime context.
+  final String route;
+
+  /// Optional resolver for routes that need runtime data (e.g. sectionId).
+  /// Return `null` to hide the item when context data is unavailable.
+  final String? Function(WidgetRef ref)? routeResolver;
+
+  final Set<String> requiredPermissions;
+  final Set<String> requiredRoles;
+
+  const MoreSheetDestination({
+    required this.labelKey,
+    required this.icon,
+    this.color,
+    this.route = '',
+    this.routeResolver,
+    this.requiredPermissions = const {},
+    this.requiredRoles = const {},
+  });
+}
+
+/// Master list of all navigable destinations that can appear in the «Más» sheet.
+///
+/// This list intentionally mirrors [_quickAccessItemsConfig] from
+/// `quick_access_grid.dart` so the same destinations are reachable from both
+/// surfaces. RBAC gating is applied at render time via [hasAnyPermission] /
+/// [hasAnyRole]. Persona-nav-slot dedup is applied per [_buildSheetItems].
+///
+/// NOTE: Do NOT add new routes here unless they are also present in
+/// [_quickAccessItemsConfig]. The «Más» sheet is a secondary surface for
+/// out-of-band navigation, not a primary feature launcher.
+const List<MoreSheetDestination> moreSheetDestinations = [
+  // Coordination hub — gated by GLOBAL role only.
+  MoreSheetDestination(
+    labelKey: 'dashboard.quick_access.coordination',
+    icon: HugeIcons.strokeRoundedAnalytics01,
+    color: AppColors.info,
+    route: RouteNames.coordinator,
+    requiredRoles: {'coordinator', 'admin', 'super-admin', 'assistant-admin'},
+  ),
+  // Member list — users:read_detail is held by counselor+
+  MoreSheetDestination(
+    labelKey: 'dashboard.quick_access.members',
+    icon: HugeIcons.strokeRoundedUserGroup,
+    color: AppColors.primary,
+    route: RouteNames.homeMembers,
+    requiredPermissions: {'users:read_detail'},
+  ),
+  // Club management — clubs:update is held by secretary+
+  MoreSheetDestination(
+    labelKey: 'dashboard.quick_access.club',
+    icon: HugeIcons.strokeRoundedBuilding01,
+    color: AppColors.secondary,
+    route: RouteNames.homeClub,
+    requiredPermissions: {'clubs:update'},
+  ),
+  // Evidence folder management — users:read_detail
+  MoreSheetDestination(
+    labelKey: 'dashboard.quick_access.evidence_folder',
+    icon: HugeIcons.strokeRoundedFolder01,
+    color: AppColors.accent,
+    route: RouteNames.homeEvidences,
+    requiredPermissions: {'users:read_detail'},
+  ),
+  // Financial records — finances:read is held by treasurer+
+  MoreSheetDestination(
+    labelKey: 'dashboard.quick_access.finances',
+    icon: HugeIcons.strokeRoundedCreditCard,
+    color: AppColors.info,
+    route: RouteNames.homeFinances,
+    requiredPermissions: {'finances:read'},
+  ),
+  // Unit management — units:update is held by counselor+
+  MoreSheetDestination(
+    labelKey: 'dashboard.quick_access.units',
+    icon: HugeIcons.strokeRoundedCompass01,
+    color: AppColors.secondary,
+    route: RouteNames.homeUnits,
+    requiredPermissions: {'units:update'},
+  ),
+  // Group class management — classes:submit_progress is held by counselor+
+  MoreSheetDestination(
+    labelKey: 'dashboard.quick_access.grouped_class',
+    icon: HugeIcons.strokeRoundedBookOpen01,
+    color: AppColors.primary,
+    route: RouteNames.homeGroupedClass,
+    requiredPermissions: {'classes:submit_progress'},
+  ),
+  // Insurance management
+  MoreSheetDestination(
+    labelKey: 'dashboard.quick_access.insurance',
+    icon: HugeIcons.strokeRoundedShield01,
+    color: AppColors.secondaryDark,
+    route: RouteNames.homeInsurance,
+    requiredPermissions: {'insurance:read'},
+  ),
+  // Inventory management
+  MoreSheetDestination(
+    labelKey: 'dashboard.quick_access.inventory',
+    icon: HugeIcons.strokeRoundedPackage,
+    color: AppColors.accent,
+    route: RouteNames.homeInventory,
+    requiredPermissions: {'inventory:read'},
+  ),
+  // Club-wide shared resources — folders:read is granted to every club role
+  MoreSheetDestination(
+    labelKey: 'dashboard.quick_access.resources',
+    icon: HugeIcons.strokeRoundedFiles01,
+    route: RouteNames.homeResources,
+    requiredPermissions: {'folders:read'},
+  ),
+  // My ranking — member_rankings:read_self (member scope)
+  MoreSheetDestination(
+    labelKey: 'dashboard.quick_access.my_ranking',
+    icon: HugeIcons.strokeRoundedRanking,
+    color: AppColors.accent,
+    route: RouteNames.homeMyRanking,
+    requiredPermissions: {'member_rankings:read_self'},
+  ),
+];
+
+// ─── Sheet logic ──────────────────────────────────────────────────────────────
+
+/// Value object that pairs a [MoreSheetDestination] with its resolved route.
+class MoreSheetResolvedItem {
+  final MoreSheetDestination dest;
+  final String resolvedRoute;
+
+  const MoreSheetResolvedItem({required this.dest, required this.resolvedRoute});
+}
+
+/// Pure filtering function: returns items from [moreSheetDestinations] that
+/// pass the persona-slot dedup and RBAC checks.
+///
+/// Filtering rules (applied in order):
+/// 1. Remove items whose static route is in [navRoutes].
+/// 2. Remove items the user has no RBAC access to (no permission AND no role).
+/// 3. Remove items with a dynamic [routeResolver] that resolves to null.
+///
+/// [ref] is optional — when provided, dynamic route resolvers are evaluated.
+/// When null (e.g. in unit tests without a widget tree), dynamic-route items
+/// are skipped.
+@visibleForTesting
+List<MoreSheetResolvedItem> filterSheetDestinations({
+  required Set<String> navRoutes,
+  required UserEntity? user,
+  WidgetRef? ref,
+}) {
+  final result = <MoreSheetResolvedItem>[];
+  for (final dest in moreSheetDestinations) {
+    // 1. Skip if static route is already in persona nav slots.
+    if (dest.routeResolver == null && navRoutes.contains(dest.route)) continue;
+
+    // 2. RBAC gate — mirrors QuickAccessGrid's filter predicate exactly.
+    if (dest.requiredPermissions.isEmpty && dest.requiredRoles.isEmpty) {
+      // Ungated — visible to all authenticated users.
+    } else {
+      final hasPermission = dest.requiredPermissions.isNotEmpty &&
+          hasAnyPermission(user, dest.requiredPermissions);
+      final hasRole = dest.requiredRoles.isNotEmpty &&
+          hasAnyRole(user, dest.requiredRoles);
+      if (!hasPermission && !hasRole) continue;
+    }
+
+    // 3. Dynamic route resolution — hide when context data is unavailable.
+    String resolvedRoute;
+    if (dest.routeResolver != null) {
+      if (ref == null) continue; // No ref available to resolve dynamic route.
+      final resolved = dest.routeResolver!(ref);
+      if (resolved == null) continue;
+      if (navRoutes.contains(resolved)) continue; // Dedup vs nav slots.
+      resolvedRoute = resolved;
+    } else {
+      resolvedRoute = dest.route;
+    }
+
+    result.add(MoreSheetResolvedItem(dest: dest, resolvedRoute: resolvedRoute));
+  }
+  return result;
+}
+
+/// Provider-aware wrapper: reads auth from [ref] and delegates to
+/// [filterSheetDestinations].
+@visibleForTesting
+List<MoreSheetResolvedItem> buildSheetItems({
+  required Persona persona,
+  required WidgetRef ref,
+}) {
+  final navRoutes = personaNavConfig[persona]!.map((s) => s.route).toSet();
+  final user = ref.read(authNotifierProvider).valueOrNull;
+  return filterSheetDestinations(navRoutes: navRoutes, user: user, ref: ref);
+}
+
+// ─── Public API ───────────────────────────────────────────────────────────────
+
+/// Opens the «Más» bottom sheet for the current persona.
+///
+/// Call from any entry point (dashboard action bar, profile tile, etc.):
+/// ```dart
+/// showMoreSheet(context: context, ref: ref);
+/// ```
+void showMoreSheet({required BuildContext context, required WidgetRef ref}) {
+  // Capture the parent container before the sheet opens so that the sheet
+  // inherits all provider overrides from the calling scope.
+  final container = ProviderScope.containerOf(context);
+  showModalBottomSheet<void>(
+    context: context,
+    isScrollControlled: true,
+    useRootNavigator: true,
+    backgroundColor: Colors.transparent,
+    builder: (_) => UncontrolledProviderScope(
+      container: container,
+      child: const _MoreSheetContent(),
+    ),
+  );
+}
+
+// ─── Sheet content widget ─────────────────────────────────────────────────────
+
+class _MoreSheetContent extends ConsumerWidget {
+  const _MoreSheetContent();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final persona = ref.watch(currentPersonaProvider);
+    // Use ref.watch so the sheet reactively updates if auth state changes.
+    final user = ref.watch(authNotifierProvider).valueOrNull;
+    final navRoutes =
+        personaNavConfig[persona]!.map((s) => s.route).toSet();
+    final items = filterSheetDestinations(
+      navRoutes: navRoutes,
+      user: user,
+      ref: ref,
+    );
+    final c = context.sac;
+
+    return Semantics(
+      label: 'nav.more_sheet_title'.tr(),
+      child: Container(
+        decoration: BoxDecoration(
+          color: c.background,
+          borderRadius: const BorderRadius.vertical(top: Radius.circular(20)),
+        ),
+        // DraggableScrollableSheet constraints: min 30% screen, max 85%.
+        constraints: BoxConstraints(
+          maxHeight: MediaQuery.of(context).size.height * 0.85,
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            // ── Drag handle ────────────────────────────────────────────
+            Padding(
+              padding: const EdgeInsets.symmetric(vertical: 12),
+              child: Container(
+                width: 40,
+                height: 4,
+                decoration: BoxDecoration(
+                  color: c.border,
+                  borderRadius: BorderRadius.circular(2),
+                ),
+              ),
+            ),
+
+            // ── Title row ──────────────────────────────────────────────
+            Padding(
+              padding:
+                  const EdgeInsets.symmetric(horizontal: 20, vertical: 4),
+              child: Row(
+                children: [
+                  Text(
+                    'nav.more_sheet_title'.tr(),
+                    style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                          fontWeight: FontWeight.w700,
+                          color: c.text,
+                        ),
+                  ),
+                  const Spacer(),
+                  Semantics(
+                    label: 'common.close'.tr(),
+                    button: true,
+                    child: IconButton(
+                      icon: HugeIcon(
+                        icon: HugeIcons.strokeRoundedCancel01,
+                        color: c.textSecondary,
+                        size: 20,
+                      ),
+                      onPressed: () => Navigator.of(context).pop(),
+                      tooltip: 'common.close'.tr(),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+
+            const Divider(height: 1),
+
+            // ── Items list ─────────────────────────────────────────────
+            if (items.isEmpty)
+              Padding(
+                padding: const EdgeInsets.all(32),
+                child: Text(
+                  'common.no_results'.tr(),
+                  style: TextStyle(
+                    fontSize: 14,
+                    color: c.textSecondary,
+                  ),
+                  textAlign: TextAlign.center,
+                ),
+              )
+            else
+              Flexible(
+                child: ListView.builder(
+                  shrinkWrap: true,
+                  padding: const EdgeInsets.symmetric(vertical: 8),
+                  itemCount: items.length,
+                  itemBuilder: (context, index) {
+                    final item = items[index];
+                    return _MoreSheetTile(
+                      item: item.dest,
+                      resolvedRoute: item.resolvedRoute,
+                    );
+                  },
+                ),
+              ),
+
+            // ── Safe-area bottom padding ───────────────────────────────
+            SizedBox(height: MediaQuery.of(context).padding.bottom + 8),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+// ─── Individual tile ──────────────────────────────────────────────────────────
+
+class _MoreSheetTile extends StatelessWidget {
+  final MoreSheetDestination item;
+  final String resolvedRoute;
+
+  const _MoreSheetTile({
+    required this.item,
+    required this.resolvedRoute,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final c = context.sac;
+    final effectiveColor = item.color ?? c.text;
+
+    return Semantics(
+      button: true,
+      label: item.labelKey.tr(),
+      child: InkWell(
+        onTap: () {
+          Navigator.of(context).pop();
+          context.push(resolvedRoute);
+        },
+        child: Padding(
+          padding:
+              const EdgeInsets.symmetric(horizontal: 20, vertical: 12),
+          child: Row(
+            children: [
+              // Icon container
+              Container(
+                width: 42,
+                height: 42,
+                decoration: BoxDecoration(
+                  color: effectiveColor.withValues(alpha: 0.12),
+                  borderRadius: BorderRadius.circular(10),
+                ),
+                child: Center(
+                  child: HugeIcon(
+                    icon: item.icon,
+                    size: 20,
+                    color: effectiveColor,
+                  ),
+                ),
+              ),
+              const SizedBox(width: 14),
+              // Label
+              Expanded(
+                child: Text(
+                  item.labelKey.tr(),
+                  style: TextStyle(
+                    fontSize: 15,
+                    fontWeight: FontWeight.w500,
+                    color: c.text,
+                  ),
+                ),
+              ),
+              // Chevron
+              HugeIcon(
+                icon: HugeIcons.strokeRoundedArrowRight01,
+                color: c.textTertiary,
+                size: 16,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/dashboard/presentation/views/dashboard_view.dart
+++ b/lib/features/dashboard/presentation/views/dashboard_view.dart
@@ -23,6 +23,7 @@ import '../widgets/upcoming_activities_card.dart';
 import '../widgets/membership_status_banner.dart';
 import '../widgets/welcome_header.dart';
 import '../../../enrollment/presentation/widgets/enrollment_status_card.dart';
+import 'package:sacdia_app/core/persona/widgets/more_sheet.dart';
 
 /// Vista principal del dashboard - Estilo "Scout Vibrante"
 class DashboardView extends ConsumerWidget {
@@ -88,6 +89,9 @@ class DashboardView extends ConsumerWidget {
                         userAvatar: dashboard.userAvatar ?? authAvatar,
                         onNotificationsTap: () =>
                             context.push(RouteNames.notificationsInbox),
+                        // T-27: Más sheet entry point #1 — action bar button
+                        onMoreTap: () =>
+                            showMoreSheet(context: context, ref: ref),
                       ),
                     ),
 

--- a/lib/features/dashboard/presentation/widgets/welcome_header.dart
+++ b/lib/features/dashboard/presentation/widgets/welcome_header.dart
@@ -19,11 +19,16 @@ class WelcomeHeader extends StatelessWidget {
   /// Si es null, el icono de campana no se muestra.
   final VoidCallback? onNotificationsTap;
 
+  /// Callback opcional para abrir el sheet «Más» desde la barra de acciones.
+  /// Si es null, el botón Más no se muestra.
+  final VoidCallback? onMoreTap;
+
   const WelcomeHeader({
     super.key,
     required this.userName,
     this.userAvatar,
     this.onNotificationsTap,
+    this.onMoreTap,
   });
 
   String _getGreeting() {
@@ -68,6 +73,23 @@ class WelcomeHeader extends StatelessWidget {
               ],
             ),
           ),
+
+          // Botón «Más» — abre el sheet de destinos adicionales (T-27)
+          if (onMoreTap != null) ...[
+            Semantics(
+              button: true,
+              label: 'nav.more'.tr(),
+              child: IconButton(
+                onPressed: onMoreTap,
+                icon: HugeIcon(
+                  icon: HugeIcons.strokeRoundedMoreHorizontal,
+                  size: 24,
+                  color: AppColors.lightText,
+                ),
+                tooltip: 'nav.more'.tr(),
+              ),
+            ),
+          ],
 
           // Botón de notificaciones
           if (onNotificationsTap != null) ...[

--- a/lib/features/profile/presentation/views/profile_view.dart
+++ b/lib/features/profile/presentation/views/profile_view.dart
@@ -34,6 +34,7 @@ import '../../../virtual_card/presentation/views/virtual_card_view.dart';
 import 'edit_profile_view.dart';
 import 'medical_info_view.dart';
 import 'settings_view.dart';
+import 'package:sacdia_app/core/persona/widgets/more_sheet.dart';
 
 // ─── Main screen ─────────────────────────────────────────────────────────────
 
@@ -194,6 +195,9 @@ class _ProfileViewState extends ConsumerState<ProfileView> {
                 context,
                 MaterialPageRoute(builder: (_) => const VirtualCardView()),
               ),
+              // T-28: Más sheet entry point #2 — Profile tile
+              onMoreTap: () =>
+                  showMoreSheet(context: context, ref: ref),
               onRefresh: () async {
                 await ref.read(profileNotifierProvider.notifier).refresh();
                 ref.invalidate(userClassesProvider);
@@ -286,6 +290,9 @@ class _ProfileScrollBody extends StatelessWidget {
   final VoidCallback onSettings;
   final VoidCallback onQr;
 
+  /// Callback to open the «Más» bottom sheet (T-28).
+  final VoidCallback? onMoreTap;
+
   const _ProfileScrollBody({
     required this.profile,
     required this.authUser,
@@ -298,6 +305,7 @@ class _ProfileScrollBody extends StatelessWidget {
     required this.onSettings,
     required this.onQr,
     this.onChangePhoto,
+    this.onMoreTap,
   });
 
   @override
@@ -415,6 +423,26 @@ class _ProfileScrollBody extends StatelessWidget {
                 ),
               ),
             ),
+
+            // ── 3. Más opciones — sheet entry point #2 (T-28) ────────
+            if (onMoreTap != null) ...[
+              const SizedBox(height: 8),
+              Padding(
+                padding: EdgeInsets.fromLTRB(hPad, 0, hPad, 0),
+                child: Container(
+                  decoration: BoxDecoration(
+                    color: c.surface,
+                    borderRadius: BorderRadius.circular(14),
+                    border: Border.all(color: c.border, width: 1),
+                  ),
+                  child: SettingTile(
+                    icon: HugeIcons.strokeRoundedMoreHorizontal,
+                    title: 'nav.more_options'.tr(),
+                    onTap: onMoreTap,
+                  ),
+                ),
+              ),
+            ],
 
             const SizedBox(height: 20),
 

--- a/test/core/persona/more_sheet_test.dart
+++ b/test/core/persona/more_sheet_test.dart
@@ -1,0 +1,295 @@
+/// Widget/unit tests for the «Más» sheet (T-30, T-31).
+///
+/// Coverage:
+/// T-30 — filterSheetDestinations (pure function, no widget tree):
+///   1. Miembro persona — nav-slot routes are excluded from sheet items.
+///   2. Director persona — nav-slot routes excluded; non-slot RBAC items shown.
+///   3. Coordinador persona — coordinator-shell nav routes excluded.
+///   4. User with no permissions sees no RBAC-gated items.
+///   5. Null user — no items returned.
+///
+/// T-31 — Widget tests (sheet renders correctly):
+///   6. Sheet renders non-empty item list for director with permissions.
+///   7. Sheet renders empty-state text when no items pass filter.
+library;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sacdia_app/core/config/route_names.dart';
+import 'package:sacdia_app/core/persona/index.dart';
+import 'package:sacdia_app/features/auth/domain/entities/authorization_snapshot.dart';
+import 'package:sacdia_app/features/auth/domain/entities/user_entity.dart';
+import 'package:sacdia_app/features/auth/presentation/providers/auth_providers.dart';
+import 'package:sacdia_app/features/notifications/presentation/providers/unread_notifications_count_provider.dart';
+
+// ── Fake helpers ──────────────────────────────────────────────────────────────
+
+class _FakeAuthNotifier extends AuthNotifier {
+  final UserEntity? _user;
+  _FakeAuthNotifier(this._user);
+
+  @override
+  Future<UserEntity?> build() async => _user;
+}
+
+class _FakeCountNotifier extends UnreadNotificationsCountNotifier {
+  @override
+  int build() => 0;
+}
+
+/// Builds a [UserEntity] with the given club [roleName], optional [permissions]
+/// (snapshot-level, read by [hasAnyPermission]) and optional [globalRoles]
+/// (via [AuthorizationSnapshot.globalGrants], read by [hasAnyRole]).
+UserEntity _userWithRole(
+  String roleName, {
+  List<String> permissions = const [],
+  List<String> globalRoles = const [],
+}) {
+  return UserEntity(
+    id: 'test-id',
+    email: 'test@example.com',
+    postRegisterComplete: true,
+    authorization: AuthorizationSnapshot(
+      effectivePermissions: permissions,
+      clubAssignments: [
+        AuthorizationGrant(
+          assignmentId: 'a1',
+          roleName: roleName,
+          status: 'active',
+        ),
+      ],
+      globalGrants: globalRoles
+          .map((r) => AuthorizationGrant(roleName: r))
+          .toList(),
+      activeAssignmentId: 'a1',
+    ),
+  );
+}
+
+/// Shorthand: call [filterSheetDestinations] for a [persona] + [user] combo
+/// (no dynamic route resolvers, no WidgetRef needed).
+List<MoreSheetResolvedItem> _filterFor(Persona persona, UserEntity? user) {
+  final navRoutes =
+      personaNavConfig[persona]!.map((s) => s.route).toSet();
+  return filterSheetDestinations(navRoutes: navRoutes, user: user);
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+void main() {
+  // ── T-30: Pure-function RBAC + slot-dedup unit tests ──────────────────────
+
+  group('filterSheetDestinations (T-30)', () {
+    test('1. Miembro — nav-slot routes excluded from sheet items', () {
+      // Miembro nav slots: homeDashboard, homeClasses, homeActivities,
+      // homeMyRanking, homeProfile.
+      // moreSheetDestinations includes homeMyRanking (member_rankings:read_self)
+      // → that item IS in the miembro nav and must be excluded.
+      // homeResources (folders:read) is NOT in miembro nav → must appear.
+      final user = _userWithRole(
+        'member',
+        permissions: ['member_rankings:read_self', 'folders:read'],
+      );
+
+      final items = _filterFor(Persona.miembro, user);
+      final routes = items.map((i) => i.resolvedRoute).toSet();
+
+      // No nav-slot route may appear.
+      for (final slot in personaNavConfig[Persona.miembro]!) {
+        expect(
+          routes.contains(slot.route),
+          isFalse,
+          reason: 'Miembro nav route ${slot.route} must not appear in sheet',
+        );
+      }
+      // homeResources must appear (folders:read, not in miembro nav).
+      expect(routes.contains(RouteNames.homeResources), isTrue,
+          reason: 'homeResources should appear for member with folders:read');
+    });
+
+    test(
+        '2. Director — nav-slot routes excluded, non-slot RBAC-allowed shown',
+        () {
+      // Director nav: homeMembers, homeClub, homeFinances, homeActivities,
+      // homeProfile.
+      // homeEvidences (users:read_detail) is NOT in director nav → must appear.
+      // homeUnits (units:update) is NOT in director nav → must appear.
+      final user = _userWithRole(
+        'director',
+        permissions: [
+          'users:read_detail',
+          'clubs:update',
+          'finances:read',
+          'units:update',
+          'classes:submit_progress',
+          'insurance:read',
+          'inventory:read',
+          'folders:read',
+          'member_rankings:read_self',
+        ],
+      );
+
+      final items = _filterFor(Persona.director, user);
+      final routes = items.map((i) => i.resolvedRoute).toSet();
+
+      // No nav-slot route may appear.
+      for (final slot in personaNavConfig[Persona.director]!) {
+        expect(
+          routes.contains(slot.route),
+          isFalse,
+          reason: 'Director nav route ${slot.route} must not appear in sheet',
+        );
+      }
+
+      // Non-slot destinations with matching RBAC must appear.
+      expect(routes.contains(RouteNames.homeEvidences), isTrue,
+          reason:
+              'homeEvidences should appear for director with users:read_detail');
+      expect(routes.contains(RouteNames.homeUnits), isTrue,
+          reason: 'homeUnits should appear for director with units:update');
+    });
+
+    test('3. Coordinador — coordinator-shell nav routes excluded', () {
+      // Coordinador nav uses coordinator-shell routes (RouteNames.coordinator,
+      // coordinatorClubs, coordinatorReports, coordinatorActivities,
+      // coordinatorProfile). These must NOT appear in the sheet.
+      final user = _userWithRole(
+        'coordinator',
+        globalRoles: ['coordinator'],
+        permissions: ['folders:read'],
+      );
+
+      final items = _filterFor(Persona.coordinador, user);
+      final routes = items.map((i) => i.resolvedRoute).toSet();
+
+      for (final slot in personaNavConfig[Persona.coordinador]!) {
+        expect(
+          routes.contains(slot.route),
+          isFalse,
+          reason:
+              'Coordinator nav route ${slot.route} must not appear in sheet',
+        );
+      }
+    });
+
+    test('4. User with no permissions sees no RBAC-gated items', () {
+      // All moreSheetDestinations require at least one permission or role.
+      final user = _userWithRole('member', permissions: [], globalRoles: []);
+      final items = _filterFor(Persona.miembro, user);
+      expect(items, isEmpty,
+          reason: 'User with no permissions should see no sheet items');
+    });
+
+    test('5. Null user — no items returned', () {
+      final items = _filterFor(Persona.miembro, null);
+      expect(items, isEmpty,
+          reason: 'Null user should see no sheet items');
+    });
+  });
+
+  // ── T-31: Widget tests ─────────────────────────────────────────────────────
+
+  group('MoreSheet widget (T-31)', () {
+    /// Pumps the [_MoreSheetContentTestWrapper] inside a ProviderScope with
+    /// the given [user] override.
+    Future<void> pumpSheet(
+      WidgetTester tester, {
+      required UserEntity? user,
+    }) async {
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            authNotifierProvider.overrideWith(() => _FakeAuthNotifier(user)),
+            unreadNotificationsCountProvider
+                .overrideWith(() => _FakeCountNotifier()),
+          ],
+          child: const MaterialApp(
+            home: Scaffold(
+              body: SizedBox(
+                width: 400,
+                height: 800,
+                child: _MoreSheetContentTestWrapper(),
+              ),
+            ),
+          ),
+        ),
+      );
+      // Allow async notifiers to settle.
+      await tester.pumpAndSettle();
+    }
+
+    testWidgets(
+        '6. Sheet renders non-empty item list for director with permissions',
+        (tester) async {
+      final user = _userWithRole(
+        'director',
+        permissions: ['users:read_detail', 'folders:read'],
+      );
+      await pumpSheet(tester, user: user);
+
+      // homeEvidences item (users:read_detail) should render.
+      // EasyLocalization not initialized → raw key is rendered.
+      expect(
+        find.text('dashboard.quick_access.evidence_folder'),
+        findsAtLeastNWidgets(1),
+        reason:
+            'Sheet should show evidence_folder for director with users:read_detail',
+      );
+    });
+
+    testWidgets(
+        '7. Sheet renders empty-state when no items pass RBAC filter',
+        (tester) async {
+      // User with no permissions → empty sheet.
+      final user = _userWithRole('member', permissions: [], globalRoles: []);
+      await pumpSheet(tester, user: user);
+
+      expect(
+        find.text('common.no_results'),
+        findsOneWidget,
+        reason: 'Empty sheet should show no_results key',
+      );
+    });
+  });
+}
+
+// ── Test widget helpers ───────────────────────────────────────────────────────
+
+/// Renders the sheet item list using the public [filterSheetDestinations] API
+/// and the watched [currentPersonaProvider] + [authNotifierProvider].
+///
+/// This widget mirrors what [_MoreSheetContent] does internally and lets tests
+/// inspect the rendered item labels without coupling to the private class.
+class _MoreSheetContentTestWrapper extends ConsumerWidget {
+  const _MoreSheetContentTestWrapper();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final persona = ref.watch(currentPersonaProvider);
+    final user = ref.watch(authNotifierProvider).valueOrNull;
+    final navRoutes =
+        personaNavConfig[persona]!.map((s) => s.route).toSet();
+    final items = filterSheetDestinations(
+      navRoutes: navRoutes,
+      user: user,
+      ref: ref,
+    );
+
+    if (items.isEmpty) {
+      return const Center(child: Text('common.no_results'));
+    }
+
+    return ListView.builder(
+      itemCount: items.length,
+      itemBuilder: (ctx, i) {
+        final item = items[i];
+        return Padding(
+          key: ValueKey(item.resolvedRoute),
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+          child: Text(item.dest.labelKey),
+        );
+      },
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- New `MoreSheet` (`lib/core/persona/widgets/more_sheet.dart`): `showModalBottomSheet` listing out-of-band destinations not in current persona's 5 nav slots
- RBAC filter reuses `hasAnyPermission` / `hasAnyRole` predicates from `QuickAccessGrid`
- Two entry points: dashboard `welcome_header` action bar + Profile screen "Más opciones" tile
- 3 i18n keys per locale (es/en/fr/pt-BR): `nav.more`, `nav.more_options`, `nav.more_sheet_title`
- 7 new tests (5 RBAC + 2 entry-point)

## Test plan
- [x] `flutter test` — 345/345 pass (+7 new)
- [x] FR-7 dedup verified (items in persona nav not in sheet)
- [x] RBAC filter verified
- [ ] Manual: tap "Más" on dashboard + Profile entry, verify destinations per persona
- [ ] Follow-up: extract shared destinations catalog to `lib/core/nav/destinations.dart` consumed by both `QuickAccessGrid` and `MoreSheet`

## Final coverage matrix (across all 5 PRs)
- FR: 11/11 PASS
- NFR: 6/6 PASS
- Scenarios S-01..S-15: 15/15 PASS

## Stack
PR 5/5 — final PR. Depends on #coordinator-shell. Verify report: **PASS-WITH-WARNINGS** (1 warning: `moreSheetDestinations` duplicates `QuickAccessGrid` catalog instead of widget reuse — functional today, drift risk).