### PR TITLE
fix(ui): P0 visual polish — touch targets + HugeIcons + dark mode

### DIFF
--- a/lib/features/activities/presentation/views/activities_list_view.dart
+++ b/lib/features/activities/presentation/views/activities_list_view.dart
@@ -571,12 +571,12 @@ class _ActivitiesListViewState extends ConsumerState<ActivitiesListView> {
                                           _scrollToToday(animate: true);
                                         },
                                         child: Container(
-                                          width: 44,
-                                          height: 24,
+                                          width: 60,
+                                          height: 44,
                                           decoration: BoxDecoration(
                                             color: AppColors.primary,
                                             borderRadius:
-                                                BorderRadius.circular(12),
+                                                BorderRadius.circular(22),
                                           ),
                                           child: Center(
                                             child: Text(

--- a/lib/features/dashboard/presentation/widgets/welcome_header.dart
+++ b/lib/features/dashboard/presentation/widgets/welcome_header.dart
@@ -76,7 +76,7 @@ class WelcomeHeader extends StatelessWidget {
               icon: HugeIcon(
                 icon: HugeIcons.strokeRoundedNotification01,
                 size: 24,
-                color: AppColors.lightText,
+                color: context.sac.text,
               ),
               tooltip: tr('dashboard.notifications_tooltip'),
             ),

--- a/lib/features/honors/presentation/views/honors_catalog_view.dart
+++ b/lib/features/honors/presentation/views/honors_catalog_view.dart
@@ -244,15 +244,15 @@ class _HonorsCatalogViewState extends ConsumerState<HonorsCatalogView> {
                     color: Colors.white.withAlpha(120),
                     fontSize: 14,
                   ),
-                  prefixIcon: Icon(
-                    Icons.search_rounded,
+                  prefixIcon: HugeIcon(
+                    icon: HugeIcons.strokeRoundedSearch01,
                     color: Colors.white.withAlpha(120),
                     size: 20,
                   ),
                   suffixIcon: _searchController.text.isNotEmpty
                       ? IconButton(
-                          icon: Icon(
-                            Icons.close_rounded,
+                          icon: HugeIcon(
+                            icon: HugeIcons.strokeRoundedCancel01,
                             color: Colors.white.withAlpha(120),
                             size: 18,
                           ),
@@ -339,7 +339,7 @@ class _HonorsCatalogViewState extends ConsumerState<HonorsCatalogView> {
             HugeIcon(
               icon: HugeIcons.strokeRoundedAward01,
               size: 56,
-              color: AppColors.sacGrey,
+              color: context.sac.textTertiary,
             ),
             const SizedBox(height: 12),
             Text(
@@ -355,7 +355,7 @@ class _HonorsCatalogViewState extends ConsumerState<HonorsCatalogView> {
     }
 
     return RefreshIndicator(
-      color: AppColors.sacBlue,
+      color: AppColors.primary,
       onRefresh: () async {
         ref.invalidate(honorsGroupedByCategoryProvider);
         ref.invalidate(allHonorsProvider);
@@ -401,10 +401,14 @@ class _HonorsCatalogViewState extends ConsumerState<HonorsCatalogView> {
               ref.invalidate(allHonorsProvider);
               ref.invalidate(userHonorsProvider);
             },
-            icon: const Icon(Icons.refresh, size: 18),
+            icon: const HugeIcon(
+              icon: HugeIcons.strokeRoundedRefresh,
+              size: 18,
+              color: Colors.white,
+            ),
             label: Text('honors.catalog.retry'.tr()),
             style: FilledButton.styleFrom(
-              backgroundColor: AppColors.sacBlue,
+              backgroundColor: AppColors.primary,
               foregroundColor: Colors.white,
               shape: RoundedRectangleBorder(
                 borderRadius: BorderRadius.circular(12),

--- a/lib/features/members/presentation/views/members_view.dart
+++ b/lib/features/members/presentation/views/members_view.dart
@@ -120,8 +120,8 @@ class _MembersViewState extends ConsumerState<MembersView>
                                 .refresh();
                           },
                     child: Container(
-                      width: 36,
-                      height: 36,
+                      width: 44,
+                      height: 44,
                       decoration: BoxDecoration(
                         color: c.surface,
                         borderRadius: BorderRadius.circular(10),

--- a/lib/features/profile/presentation/views/profile_view.dart
+++ b/lib/features/profile/presentation/views/profile_view.dart
@@ -523,8 +523,8 @@ class _ProfileScrollBody extends StatelessWidget {
                             ),
                           ),
                           child: const Center(
-                            child: Icon(
-                              Icons.add_rounded,
+                            child: HugeIcon(
+                              icon: HugeIcons.strokeRoundedAdd01,
                               color: AppColors.sacBlue,
                               size: 18,
                             ),


### PR DESCRIPTION
## Summary
P0 visual fixes from UX/visual audit reviews. 5 files, 7 individual fixes. No functional changes.

### Touch targets (Material 44dp minimum)
- `members_view.dart`: refresh button 36→44dp
- `activities_list_view.dart`: today pill 24→44dp + width 60 + radius 22

### HugeIcons mandate (replace Material Icons)
- `honors_catalog_view.dart:247,257`: search/close icons
- `honors_catalog_view.dart:404`: retry refresh icon
- `profile_view.dart:526`: add-honor icon

### Color cleanup (legacy sac* → semantic tokens)
- `welcome_header.dart:79`: notification icon `AppColors.lightText`→`context.sac.text` (fixes dark mode invisibility)
- `honors_catalog_view.dart:343`: empty state icon `sacGrey` (pinkish)→`context.sac.textTertiary`
- `honors_catalog_view.dart:358,407`: RefreshIndicator + FilledButton `sacBlue`→`AppColors.primary`

## Test plan
- [x] flutter test — 294/294 pass
- [x] flutter analyze — no issues
- [x] dart format — clean
- [ ] Manual visual check: dark mode notification icon visible; touch targets responsive; honor catalog search bar icons render