### PR TITLE
chore(app): remove obsolete Supabase SharedPreferences one-shot cleanup

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -197,12 +197,6 @@ Future<void> main() async {
           ),
         ),
       );
-
-      // La verificación de sesión no necesita bloquear el primer frame.
-      // Reutilizamos la instancia ya cargada para evitar un segundo getInstance().
-      WidgetsBinding.instance.addPostFrameCallback((_) {
-        _checkAndCleanSessionAtStartup(sharedPreferences);
-      });
     },
   );
 }
@@ -226,36 +220,6 @@ Future<void> _initializeFirebaseExtras() async {
     if (kDebugMode) {
       AppLogger.w('FirebaseAppCheck no pudo activarse', tag: tag, error: e);
     }
-  }
-}
-
-/// Verifica y limpia sesiones inválidas o corruptas al inicio.
-///
-/// Con Better Auth / Option C no hay cliente Supabase. Simplemente
-/// verificamos si el access token almacenado localmente existe. La
-/// validación real contra el servidor ocurre en [AuthNotifier.build()]
-/// mediante GET /auth/me.
-///
-/// Recibe la instancia de [SharedPreferences] ya cargada en [main] para
-/// evitar un segundo [SharedPreferences.getInstance]. La limpieza de
-/// residuos de Supabase se ejecuta una única vez gracias al flag
-/// `supabase_migration_done`.
-Future<void> _checkAndCleanSessionAtStartup(SharedPreferences prefs) async {
-  try {
-    // La limpieza de residuos de Supabase solo necesita ocurrir una vez.
-    if (prefs.getBool('supabase_migration_done') == true) return;
-
-    final keys = prefs.getKeys().toList();
-    for (final key in keys) {
-      // Eliminar residuos de sesiones Supabase previas
-      if (key.contains('supabase')) {
-        await prefs.remove(key);
-      }
-    }
-
-    await prefs.setBool('supabase_migration_done', true);
-  } catch (e) {
-    // Silenciar errores de verificación de sesión
   }
 }
 


### PR DESCRIPTION
## Summary
- Drop `_checkAndCleanSessionAtStartup` and its post-frame trigger in `lib/main.dart`.
- The helper was a one-shot migration that scrubbed `supabase_*` SharedPreferences keys, gated by `supabase_migration_done`. The flag is already set on production users, so the code is dead on existing installs and irrelevant on fresh installs (no Supabase client since Wave 3).
- No behavior change for users. Net: 36 deletions in a single file.

## Test plan
- [x] `dart analyze lib/main.dart` — No issues found
- [x] `flutter test test/` — 294/294 pass
- [x] `rg "supabase_migration_done"` — zero remaining references in `lib/` and `test/`