### PR TITLE
fix(audit): code-fixable findings from app-audit.md

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,4 +143,12 @@ jobs:
           fi
 
       - name: Build APK (release)
-        run: flutter build apk --release
+        env:
+          GOOGLE_MAPS_API_KEY: ${{ secrets.GOOGLE_MAPS_API_KEY }}
+          GOOGLE_MAPS_GRADLE_KEY: ${{ secrets.GOOGLE_MAPS_API_KEY }}
+        run: |
+          # Pass GOOGLE_MAPS_API_KEY both as a dart-define (for Static Maps REST)
+          # and as a gradle property (for the interactive Maps SDK manifest placeholder).
+          flutter build apk --release \
+            --dart-define=GOOGLE_MAPS_API_KEY="${GOOGLE_MAPS_API_KEY}" \
+            -P GOOGLE_MAPS_API_KEY="${GOOGLE_MAPS_GRADLE_KEY}"

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -46,9 +46,14 @@ android {
         targetSdk = flutter.targetSdkVersion
         versionCode = flutter.versionCode
         versionName = flutter.versionName
-        // GOOGLE_MAPS_API_KEY: override via gradle.properties or CI environment variable.
-        // The hardcoded value is a safe fallback for local development only.
-        manifestPlaceholders += [GOOGLE_MAPS_API_KEY: project.findProperty("GOOGLE_MAPS_API_KEY") ?: "AIzaSyAQoO0HmAfSdbRs-T0cqtCXEGNn7TtMGZk"]
+        // GOOGLE_MAPS_API_KEY must be set in android/gradle.properties or as a CI
+        // environment variable. Never hardcode the key here.
+        // Local dev: add `GOOGLE_MAPS_API_KEY=<key>` to android/gradle.properties (gitignored).
+        def mapsKey = project.findProperty("GOOGLE_MAPS_API_KEY") ?: ""
+        if (mapsKey.isEmpty()) {
+            logger.warn("WARNING: GOOGLE_MAPS_API_KEY is not set. Google Maps will not render. Set it in android/gradle.properties or as a CI environment variable.")
+        }
+        manifestPlaceholders += [GOOGLE_MAPS_API_KEY: mapsKey]
     }
 
     signingConfigs {

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -8,11 +8,14 @@ import GoogleMaps
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
   ) -> Bool {
-    if let mapsKey = Bundle.main.infoDictionary?["GOOGLE_MAPS_API_KEY"] as? String, !mapsKey.isEmpty {
-      GMSServices.provideAPIKey(mapsKey)
-    } else {
-      GMSServices.provideAPIKey("AIzaSyAQoO0HmAfSdbRs-T0cqtCXEGNn7TtMGZk")
+    // GOOGLE_MAPS_API_KEY must be set in Xcode build settings or via xcconfig.
+    // Never hardcode the key here — use the Info.plist placeholder $(GOOGLE_MAPS_API_KEY).
+    guard let mapsKey = Bundle.main.infoDictionary?["GOOGLE_MAPS_API_KEY"] as? String,
+          !mapsKey.isEmpty else {
+      assertionFailure("GOOGLE_MAPS_API_KEY is missing from Info.plist. Set it in Xcode build settings or via xcconfig.")
+      return super.application(application, didFinishLaunchingWithOptions: launchOptions)
     }
+    GMSServices.provideAPIKey(mapsKey)
 
     // Forzar renderer OpenGL en simuladores — Metal no renderiza en iOS Simulator
     #if targetEnvironment(simulator)

--- a/lib/core/constants/maps_constants.dart
+++ b/lib/core/constants/maps_constants.dart
@@ -9,12 +9,26 @@
 ///
 /// SECURITY: La API key NO se hardcodea en el código fuente.
 /// Proveer mediante build config:
-///   Android: gradle.properties → GOOGLE_MAPS_API_KEY=<key>
-///   iOS:     Xcode build settings → GOOGLE_MAPS_API_KEY=<key>
+///   Android: gradle.properties → GOOGLE_MAPS_API_KEY=YOUR_KEY
+///   iOS:     Xcode build settings → GOOGLE_MAPS_API_KEY=YOUR_KEY
 ///   CI:      Variable de entorno GOOGLE_MAPS_API_KEY en el runner.
 /// ─────────────────────────────────────────────────────────────────
 class MapsConstants {
   MapsConstants._();
+
+  /// Google Maps API key, injected at compile-time via:
+  ///   `--dart-define=GOOGLE_MAPS_API_KEY=<key>`
+  ///
+  /// For the Interactive Maps SDK (android/iOS) the key is configured
+  /// natively via gradle.properties / Xcode build settings. This Dart
+  /// constant is used ONLY for the Static Maps REST API (image tiles).
+  ///
+  /// If the key is empty the static map URL will 403 and the cached_network_image
+  /// errorWidget is shown — a graceful degradation with no crash.
+  static const String googleMapsApiKey = String.fromEnvironment(
+    'GOOGLE_MAPS_API_KEY',
+    defaultValue: '',
+  );
 
   /// Ubicación por defecto cuando no hay ubicación del dispositivo disponible.
   /// Centro de México (Ciudad de México).

--- a/lib/core/constants/maps_constants.dart
+++ b/lib/core/constants/maps_constants.dart
@@ -6,19 +6,15 @@
 /// El geocoding usa los geocoders nativos del dispositivo:
 ///   - iOS: CLGeocoder (Apple)
 ///   - Android: Android Geocoder (Google Play Services)
+///
+/// SECURITY: La API key NO se hardcodea en el código fuente.
+/// Proveer mediante build config:
+///   Android: gradle.properties → GOOGLE_MAPS_API_KEY=<key>
+///   iOS:     Xcode build settings → GOOGLE_MAPS_API_KEY=<key>
+///   CI:      Variable de entorno GOOGLE_MAPS_API_KEY en el runner.
 /// ─────────────────────────────────────────────────────────────────
 class MapsConstants {
   MapsConstants._();
-
-  /// Google Maps API key — used for Static Maps API image requests.
-  ///
-  /// The same key is configured in:
-  ///   - ios/Runner/AppDelegate.swift  (GMSServices.provideAPIKey)
-  ///   - android/app/src/main/AndroidManifest.xml  (com.google.android.geo.API_KEY)
-  ///
-  /// TODO: Move to --dart-define=GOOGLE_MAPS_API_KEY to avoid committing the key.
-  static const String googleMapsApiKey =
-      'AIzaSyAQoO0HmAfSdbRs-T0cqtCXEGNn7TtMGZk';
 
   /// Ubicación por defecto cuando no hay ubicación del dispositivo disponible.
   /// Centro de México (Ciudad de México).

--- a/lib/features/activities/presentation/widgets/activity_hero_section.dart
+++ b/lib/features/activities/presentation/widgets/activity_hero_section.dart
@@ -46,6 +46,14 @@ class ActivityHeroSection extends StatelessWidget {
       final lat = activity.lat!;
       final lng = activity.longitude!;
 
+      // Skip the network request when the API key is not configured.
+      // The key is empty when the build was launched without
+      // --dart-define=GOOGLE_MAPS_API_KEY. Firing the request would 403 and
+      // waste bandwidth, so we fall back immediately to the static fallback UI.
+      if (MapsConstants.googleMapsApiKey.isEmpty) {
+        return _buildLocationFallback(context);
+      }
+
       return GestureDetector(
         onTap: () => _openInMaps(),
         child: CachedNetworkImage(

--- a/lib/features/units/presentation/views/units_list_view.dart
+++ b/lib/features/units/presentation/views/units_list_view.dart
@@ -326,6 +326,8 @@ class _MemberOfMonthCard extends StatelessWidget {
   Widget build(BuildContext context) {
     final c = context.sac;
     final members = memberOfMonth.members;
+    // Guard: backend may return an empty members list in edge cases.
+    if (members.isEmpty) return const SizedBox.shrink();
     final isTie = members.length > 1;
     final primary = members.first;
 


### PR DESCRIPTION
## Summary

Implements all code-fixable findings from `docs/audit/app-audit.md` (dated 2026-03-14). The prior audit round (commit 622424e, 2026-04-01) addressed 3 CRITICAL + 5 HIGH + 6 MEDIUM. This PR addresses the remaining code-fixable items discovered on 2026-05-11.

## Findings addressed (5)

| # | Severity | Finding | Audit ref | Commit |
|---|----------|---------|-----------|--------|
| 1 | SECURITY HIGH | Hardcoded Google Maps API key in `maps_constants.dart` (dead code, committed to git) | Notas #3 | 98f32ed |
| 2 | SECURITY HIGH | Hardcoded API key fallback in `ios/Runner/AppDelegate.swift` | Notas #3 | 98f32ed |
| 3 | SECURITY MED | Hardcoded API key fallback in `android/app/build.gradle` | Notas #3 | 98f32ed |
| 4 | BUG | `_MemberOfMonthCard.build()` calls `.first` on `members` list without empty guard — RangeError crash if backend returns empty array | Code smell scan | 47cf2c6 |
| 5 | SECURITY/CONFIG | `MapsConstants.googleMapsApiKey` is now `String.fromEnvironment` so key never lands in APK/IPA binary | Notas #3 | d261a50 |
| 6 | CI CONFIG | `build-android` CI job did not pass `GOOGLE_MAPS_API_KEY` secret — release APKs built on CI had empty key | CI audit | 3a521ca |
| 7 | PERF | `ActivityHeroSection` fired Static Maps API request even when key is empty, causing unnecessary 403 + bandwidth waste | Perf scan | ef2909e |

## Deferred — platform access required

- iOS push notification certificates (APNS) — requires Apple Developer portal
- App Store submission signing — requires Xcode provisioning profile
- Firebase console configuration — requires Firebase project access

## Deferred — product decision

- WhatsApp support number `525555555555` is still a placeholder (`contact_view.dart:22`) — needs real business number from team

## Test plan

- [ ] `flutter analyze` → No issues found
- [ ] `flutter test` → 294/294 pass
- [ ] Verify Google Maps renders on Android after adding `GOOGLE_MAPS_API_KEY` to `android/gradle.properties`
- [ ] Verify iOS Simulator: Xcode must have `GOOGLE_MAPS_API_KEY` in build settings → otherwise app asserts in debug and returns early in release (graceful)
- [ ] Verify `ActivityHeroSection` shows fallback immediately (no spinner) when launched without `--dart-define=GOOGLE_MAPS_API_KEY`
- [ ] Verify units screen does not crash when `MemberOfMonth.members` is empty