### PR TITLE
fix(a11y): explicit Semantics on NavigationBar destinations

### DIFF
--- a/lib/core/config/router.dart
+++ b/lib/core/config/router.dart
@@ -1275,18 +1275,25 @@ class _MainShell extends ConsumerWidget {
         selectedIndex: selectedIndex,
         onDestinationSelected: (uiIndex) =>
             navigationShell.goBranch(slots[uiIndex].branchIndex),
+        // Each destination is wrapped in Semantics to explicitly declare the
+        // Spanish label and button role, mirroring the NavigationRail label
+        // pattern for screen-reader parity (PR-2 a11y WARNING fix).
         destinations: slots
             .map(
-              (slot) => NavigationDestination(
-                icon: NavBadge(
-                  source: slot.badgeSource,
-                  child: HugeIcon(icon: slot.icon),
-                ),
-                selectedIcon: NavBadge(
-                  source: slot.badgeSource,
-                  child: HugeIcon(icon: slot.icon),
-                ),
+              (slot) => Semantics(
                 label: tr(slot.labelKey),
+                button: true,
+                child: NavigationDestination(
+                  icon: NavBadge(
+                    source: slot.badgeSource,
+                    child: HugeIcon(icon: slot.icon),
+                  ),
+                  selectedIcon: NavBadge(
+                    source: slot.badgeSource,
+                    child: HugeIcon(icon: slot.icon),
+                  ),
+                  label: tr(slot.labelKey),
+                ),
               ),
             )
             .toList(),


### PR DESCRIPTION
## Summary

- Wraps each `NavigationDestination` in a `Semantics(label: ..., button: true)` widget in `_MainShell`'s phone `NavigationBar`.
- Mirrors the existing `NavigationRailDestination` label pattern where `Semantics` already wraps the `Text` widget for tablet layout.
- `NavigationDestination.label` is `String`-typed, so the wrapper goes around the whole destination widget (valid because `NavigationBar.destinations` is `List<Widget>`).
- Closes PR-2 verify report WARNING: inconsistent a11y between phone and tablet navigation paths.

## Scope

Single file: `lib/core/config/router.dart` — `_MainShell` phone path only. `_CoordinatorShell` is out of scope per task brief.

## Test plan

- [x] `flutter analyze lib/core/config/router.dart` — no issues
- [x] `flutter test test/core/persona/main_shell_widget_test.dart` — 16/16 pass (Semantics wrapper is transparent to existing slot-count and label-key tests)