### PR TITLE
refactor(nav): extract shared destinations catalog + drift guard

### DIFF
--- a/lib/core/nav/destinations.dart
+++ b/lib/core/nav/destinations.dart
@@ -1,0 +1,175 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:hugeicons/hugeicons.dart';
+import 'package:sacdia_app/core/config/route_names.dart';
+import 'package:sacdia_app/core/theme/app_colors.dart';
+import 'package:sacdia_app/core/utils/icon_helper.dart';
+import 'package:sacdia_app/features/members/presentation/providers/members_providers.dart';
+
+/// A single navigable destination used across all navigation surfaces
+/// (quick-access grid, «Más» bottom sheet, etc.).
+///
+/// Const-constructible so the [appDestinations] list is a compile-time
+/// constant and avoids repeated allocation on rebuild.
+class NavDestination {
+  /// Translation key resolved at render time via `tr(labelKey)`.
+  final String labelKey;
+
+  /// HugeIcons icon constant. Always [HugeIconData] — never `Icons.*`.
+  final HugeIconData icon;
+
+  /// Optional tint color. Falls back to the theme text color when null.
+  final Color? color;
+
+  /// Static route path. Use for routes that do not depend on runtime context.
+  /// Leave empty and provide [routeResolver] for dynamic routes.
+  final String route;
+
+  /// Optional resolver for routes that need runtime data (e.g. sectionId from
+  /// [clubContextProvider]). Called at render time with a [WidgetRef]. Return
+  /// `null` to hide the card / item when context data is unavailable.
+  final String? Function(WidgetRef ref)? routeResolver;
+
+  /// Permission keys required to show this destination. Checked via
+  /// [hasAnyPermission]. Leave empty when gating is role-based only.
+  final Set<String> requiredPermissions;
+
+  /// Canonical role names that gate this destination when it cannot be
+  /// modelled as a single permission (e.g. `coordinator`, `admin`). Leave
+  /// empty when gating is permission-based only.
+  final Set<String> requiredRoles;
+
+  const NavDestination({
+    required this.labelKey,
+    required this.icon,
+    this.color,
+    this.route = '',
+    this.routeResolver,
+    this.requiredPermissions = const {},
+    this.requiredRoles = const {},
+  });
+}
+
+/// Single source of truth for all navigable app destinations.
+///
+/// Every surface that exposes navigation items (quick-access grid, «Más»
+/// sheet, etc.) MUST consume this list and apply RBAC / slot-dedup at render
+/// time. Do NOT maintain parallel copies.
+///
+/// Adding a new destination:
+///   1. Add an entry here with appropriate [requiredPermissions] / [requiredRoles].
+///   2. Ensure the route is declared in [RouteNames].
+///   3. Run `flutter test test/core/nav/destinations_drift_test.dart` to
+///      verify the invariants are met.
+// ignore: prefer_const_declarations
+final List<NavDestination> appDestinations = [
+  // Coordination hub — gated by GLOBAL role only. The concept "is the user a
+  // coordinator / admin" does not map to a single permission, because club
+  // directors also hold operational permissions like `investiture:validate`;
+  // using those would incorrectly reveal the hub to directors.
+  NavDestination(
+    labelKey: 'dashboard.quick_access.coordination',
+    icon: HugeIcons.strokeRoundedAnalytics01,
+    color: AppColors.info,
+    route: RouteNames.coordinator,
+    requiredRoles: {'coordinator', 'admin', 'super-admin', 'assistant-admin'},
+  ),
+  // Administrative: member list — users:read_detail is held by counselor+
+  NavDestination(
+    labelKey: 'dashboard.quick_access.members',
+    icon: HugeIcons.strokeRoundedUserGroup,
+    color: AppColors.primary,
+    route: RouteNames.homeMembers,
+    requiredPermissions: {'users:read_detail'},
+  ),
+  // Administrative: club management — clubs:update is held by secretary+
+  NavDestination(
+    labelKey: 'dashboard.quick_access.club',
+    icon: HugeIcons.strokeRoundedBuilding01,
+    color: AppColors.secondary,
+    route: RouteNames.homeClub,
+    requiredPermissions: {'clubs:update'},
+  ),
+  // Administrative: evidence folder management — uses users:read_detail.
+  // Members access their OWN evidence via the profile screen, not this view.
+  NavDestination(
+    labelKey: 'dashboard.quick_access.evidence_folder',
+    icon: HugeIcons.strokeRoundedFolder01,
+    color: AppColors.accent,
+    route: RouteNames.homeEvidences,
+    requiredPermissions: {'users:read_detail'},
+  ),
+  // Administrative: financial records — finances:read is held by treasurer+
+  NavDestination(
+    labelKey: 'dashboard.quick_access.finances',
+    icon: HugeIcons.strokeRoundedCreditCard,
+    color: AppColors.info,
+    route: RouteNames.homeFinances,
+    requiredPermissions: {'finances:read'},
+  ),
+  // Administrative: unit management — units:update is held by counselor+
+  NavDestination(
+    labelKey: 'dashboard.quick_access.units',
+    icon: HugeIcons.strokeRoundedCompass01,
+    color: AppColors.secondary,
+    route: RouteNames.homeUnits,
+    requiredPermissions: {'units:update'},
+  ),
+  // Administrative: group class management — classes:submit_progress is held by counselor+
+  NavDestination(
+    labelKey: 'dashboard.quick_access.grouped_class',
+    icon: HugeIcons.strokeRoundedBookOpen01,
+    color: AppColors.primary,
+    route: RouteNames.homeGroupedClass,
+    requiredPermissions: {'classes:submit_progress'},
+  ),
+  // Administrative: insurance management
+  NavDestination(
+    labelKey: 'dashboard.quick_access.insurance',
+    icon: HugeIcons.strokeRoundedShield01,
+    color: AppColors.secondaryDark,
+    route: RouteNames.homeInsurance,
+    requiredPermissions: {'insurance:read'},
+  ),
+  // Administrative: inventory management
+  NavDestination(
+    labelKey: 'dashboard.quick_access.inventory',
+    icon: HugeIcons.strokeRoundedPackage,
+    color: AppColors.accent,
+    route: RouteNames.homeInventory,
+    requiredPermissions: {'inventory:read'},
+  ),
+  // Club-wide shared resources — folders:read is granted to every club role.
+  NavDestination(
+    labelKey: 'dashboard.quick_access.resources',
+    icon: HugeIcons.strokeRoundedFiles01,
+    route: RouteNames.homeResources,
+    requiredPermissions: {'folders:read'},
+  ),
+  // Mi ranking — only visible to roles that hold member_rankings:read_self
+  // (MEMBER club-scope, ADMIN global, SUPER_ADMIN global). Other club roles
+  // (director, counselor, secretary, treasurer…) do not have this permission
+  // and must not see the entry.
+  NavDestination(
+    labelKey: 'dashboard.quick_access.my_ranking',
+    icon: HugeIcons.strokeRoundedRanking,
+    color: AppColors.accent,
+    route: RouteNames.homeMyRanking,
+    requiredPermissions: {'member_rankings:read_self'},
+  ),
+  // Ranking de sección — gated by units:update (counselor+). Route is
+  // resolved at render time because it requires the active sectionId from
+  // clubContextProvider. Card is hidden when context is unavailable.
+  NavDestination(
+    labelKey: 'dashboard.quick_access.section_ranking',
+    icon: HugeIcons.strokeRoundedAward01,
+    color: AppColors.primary,
+    routeResolver: (ref) {
+      final ctxAsync = ref.watch(clubContextProvider);
+      final sectionId = ctxAsync.valueOrNull?.sectionId;
+      if (sectionId == null) return null;
+      return RouteNames.sectionRankingPath(sectionId);
+    },
+    requiredPermissions: {'units:update'},
+  ),
+];

--- a/lib/core/persona/widgets/more_sheet.dart
+++ b/lib/core/persona/widgets/more_sheet.dart
@@ -3,164 +3,27 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:hugeicons/hugeicons.dart';
-import 'package:sacdia_app/core/config/route_names.dart';
+import 'package:sacdia_app/core/nav/destinations.dart';
 import 'package:sacdia_app/core/persona/persona.dart';
 import 'package:sacdia_app/core/persona/persona_nav_config.dart';
 import 'package:sacdia_app/core/persona/persona_providers.dart';
-import 'package:sacdia_app/core/theme/app_colors.dart';
 import 'package:sacdia_app/core/theme/sac_colors.dart';
-import 'package:sacdia_app/core/utils/icon_helper.dart';
 import 'package:sacdia_app/features/auth/domain/entities/user_entity.dart';
 import 'package:sacdia_app/features/auth/domain/utils/authorization_utils.dart';
 import 'package:sacdia_app/features/auth/presentation/providers/auth_providers.dart';
 
-// ─── Data model ───────────────────────────────────────────────────────────────
-
-/// A single navigable destination exposed in the «Más» sheet.
-///
-/// Mirrors the structure of the private `_QuickAccessItemConfig` in
-/// `quick_access_grid.dart` so that the sheet can reuse the same RBAC
-/// predicates ([hasAnyPermission] / [hasAnyRole]) without coupling to the
-/// dashboard widget's private types.
-@visibleForTesting
-class MoreSheetDestination {
-  final String labelKey;
-  final HugeIconData icon;
-  final Color? color;
-
-  /// Static route path. Use when the route does not depend on runtime context.
-  final String route;
-
-  /// Optional resolver for routes that need runtime data (e.g. sectionId).
-  /// Return `null` to hide the item when context data is unavailable.
-  final String? Function(WidgetRef ref)? routeResolver;
-
-  final Set<String> requiredPermissions;
-  final Set<String> requiredRoles;
-
-  const MoreSheetDestination({
-    required this.labelKey,
-    required this.icon,
-    this.color,
-    this.route = '',
-    this.routeResolver,
-    this.requiredPermissions = const {},
-    this.requiredRoles = const {},
-  });
-}
-
-/// Master list of all navigable destinations that can appear in the «Más» sheet.
-///
-/// This list intentionally mirrors [_quickAccessItemsConfig] from
-/// `quick_access_grid.dart` so the same destinations are reachable from both
-/// surfaces. RBAC gating is applied at render time via [hasAnyPermission] /
-/// [hasAnyRole]. Persona-nav-slot dedup is applied per [_buildSheetItems].
-///
-/// NOTE: Do NOT add new routes here unless they are also present in
-/// [_quickAccessItemsConfig]. The «Más» sheet is a secondary surface for
-/// out-of-band navigation, not a primary feature launcher.
-const List<MoreSheetDestination> moreSheetDestinations = [
-  // Coordination hub — gated by GLOBAL role only.
-  MoreSheetDestination(
-    labelKey: 'dashboard.quick_access.coordination',
-    icon: HugeIcons.strokeRoundedAnalytics01,
-    color: AppColors.info,
-    route: RouteNames.coordinator,
-    requiredRoles: {'coordinator', 'admin', 'super-admin', 'assistant-admin'},
-  ),
-  // Member list — users:read_detail is held by counselor+
-  MoreSheetDestination(
-    labelKey: 'dashboard.quick_access.members',
-    icon: HugeIcons.strokeRoundedUserGroup,
-    color: AppColors.primary,
-    route: RouteNames.homeMembers,
-    requiredPermissions: {'users:read_detail'},
-  ),
-  // Club management — clubs:update is held by secretary+
-  MoreSheetDestination(
-    labelKey: 'dashboard.quick_access.club',
-    icon: HugeIcons.strokeRoundedBuilding01,
-    color: AppColors.secondary,
-    route: RouteNames.homeClub,
-    requiredPermissions: {'clubs:update'},
-  ),
-  // Evidence folder management — users:read_detail
-  MoreSheetDestination(
-    labelKey: 'dashboard.quick_access.evidence_folder',
-    icon: HugeIcons.strokeRoundedFolder01,
-    color: AppColors.accent,
-    route: RouteNames.homeEvidences,
-    requiredPermissions: {'users:read_detail'},
-  ),
-  // Financial records — finances:read is held by treasurer+
-  MoreSheetDestination(
-    labelKey: 'dashboard.quick_access.finances',
-    icon: HugeIcons.strokeRoundedCreditCard,
-    color: AppColors.info,
-    route: RouteNames.homeFinances,
-    requiredPermissions: {'finances:read'},
-  ),
-  // Unit management — units:update is held by counselor+
-  MoreSheetDestination(
-    labelKey: 'dashboard.quick_access.units',
-    icon: HugeIcons.strokeRoundedCompass01,
-    color: AppColors.secondary,
-    route: RouteNames.homeUnits,
-    requiredPermissions: {'units:update'},
-  ),
-  // Group class management — classes:submit_progress is held by counselor+
-  MoreSheetDestination(
-    labelKey: 'dashboard.quick_access.grouped_class',
-    icon: HugeIcons.strokeRoundedBookOpen01,
-    color: AppColors.primary,
-    route: RouteNames.homeGroupedClass,
-    requiredPermissions: {'classes:submit_progress'},
-  ),
-  // Insurance management
-  MoreSheetDestination(
-    labelKey: 'dashboard.quick_access.insurance',
-    icon: HugeIcons.strokeRoundedShield01,
-    color: AppColors.secondaryDark,
-    route: RouteNames.homeInsurance,
-    requiredPermissions: {'insurance:read'},
-  ),
-  // Inventory management
-  MoreSheetDestination(
-    labelKey: 'dashboard.quick_access.inventory',
-    icon: HugeIcons.strokeRoundedPackage,
-    color: AppColors.accent,
-    route: RouteNames.homeInventory,
-    requiredPermissions: {'inventory:read'},
-  ),
-  // Club-wide shared resources — folders:read is granted to every club role
-  MoreSheetDestination(
-    labelKey: 'dashboard.quick_access.resources',
-    icon: HugeIcons.strokeRoundedFiles01,
-    route: RouteNames.homeResources,
-    requiredPermissions: {'folders:read'},
-  ),
-  // My ranking — member_rankings:read_self (member scope)
-  MoreSheetDestination(
-    labelKey: 'dashboard.quick_access.my_ranking',
-    icon: HugeIcons.strokeRoundedRanking,
-    color: AppColors.accent,
-    route: RouteNames.homeMyRanking,
-    requiredPermissions: {'member_rankings:read_self'},
-  ),
-];
-
 // ─── Sheet logic ──────────────────────────────────────────────────────────────
 
-/// Value object that pairs a [MoreSheetDestination] with its resolved route.
+/// Value object that pairs a [NavDestination] with its resolved route.
 class MoreSheetResolvedItem {
-  final MoreSheetDestination dest;
+  final NavDestination dest;
   final String resolvedRoute;
 
   const MoreSheetResolvedItem(
       {required this.dest, required this.resolvedRoute});
 }
 
-/// Pure filtering function: returns items from [moreSheetDestinations] that
+/// Pure filtering function: returns items from [appDestinations] that
 /// pass the persona-slot dedup and RBAC checks.
 ///
 /// Filtering rules (applied in order):
@@ -178,7 +41,7 @@ List<MoreSheetResolvedItem> filterSheetDestinations({
   WidgetRef? ref,
 }) {
   final result = <MoreSheetResolvedItem>[];
-  for (final dest in moreSheetDestinations) {
+  for (final dest in appDestinations) {
     // 1. Skip if static route is already in persona nav slots.
     if (dest.routeResolver == null && navRoutes.contains(dest.route)) continue;
 
@@ -364,7 +227,7 @@ class _MoreSheetContent extends ConsumerWidget {
 // ─── Individual tile ──────────────────────────────────────────────────────────
 
 class _MoreSheetTile extends StatelessWidget {
-  final MoreSheetDestination item;
+  final NavDestination item;
   final String resolvedRoute;
 
   const _MoreSheetTile({

--- a/lib/features/dashboard/presentation/widgets/quick_access_grid.dart
+++ b/lib/features/dashboard/presentation/widgets/quick_access_grid.dart
@@ -3,159 +3,10 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:hugeicons/hugeicons.dart';
-import 'package:sacdia_app/core/config/route_names.dart';
-import 'package:sacdia_app/core/theme/app_colors.dart';
+import 'package:sacdia_app/core/nav/destinations.dart';
 import 'package:sacdia_app/core/theme/sac_colors.dart';
 import 'package:sacdia_app/features/auth/domain/utils/authorization_utils.dart';
 import 'package:sacdia_app/features/auth/presentation/providers/auth_providers.dart';
-import 'package:sacdia_app/features/members/presentation/providers/members_providers.dart';
-
-class _QuickAccessItemConfig {
-  /// Translation key resolved at render time via tr(labelKey).
-  final String labelKey;
-  final List<List<dynamic>> icon;
-  final Color? color;
-
-  /// Static route path. Use this for routes that do not depend on runtime
-  /// context. For dynamic routes, leave empty and provide [routeResolver].
-  final String route;
-
-  /// Optional resolver for routes that need runtime data (e.g. sectionId from
-  /// clubContextProvider). Called at render time with a [WidgetRef]. Return
-  /// null to hide the card when context data is unavailable.
-  final String? Function(WidgetRef ref)? routeResolver;
-
-  final Set<String> requiredPermissions;
-
-  /// Canonical role names to gate against when the item is not permission-based.
-  /// Only used for global roles whose authority cannot be modeled as a single
-  /// permission (e.g. `coordinator`, `admin`). Leave empty when the item is
-  /// gated purely by [requiredPermissions].
-  final Set<String> requiredRoles;
-
-  const _QuickAccessItemConfig({
-    required this.labelKey,
-    required this.icon,
-    this.color,
-    this.route = '',
-    this.routeResolver,
-    this.requiredPermissions = const {},
-    this.requiredRoles = const {},
-  });
-}
-
-// ignore: prefer_const_declarations
-final List<_QuickAccessItemConfig> _quickAccessItemsConfig = [
-  // Coordination hub — gated by GLOBAL role only. The concept "is the user a
-  // coordinator / admin" does not map to a single permission, because club
-  // directors also hold operational permissions like `investiture:validate`;
-  // using those would incorrectly reveal the hub to directors.
-  _QuickAccessItemConfig(
-    labelKey: 'dashboard.quick_access.coordination',
-    icon: HugeIcons.strokeRoundedAnalytics01,
-    color: AppColors.info,
-    route: RouteNames.coordinator,
-    requiredRoles: {'coordinator', 'admin', 'super-admin', 'assistant-admin'},
-  ),
-  // Administrative: member list — users:read_detail is held by counselor+
-  _QuickAccessItemConfig(
-    labelKey: 'dashboard.quick_access.members',
-    icon: HugeIcons.strokeRoundedUserGroup,
-    color: AppColors.primary,
-    route: RouteNames.homeMembers,
-    requiredPermissions: {'users:read_detail'},
-  ),
-  // Administrative: club management — clubs:update is held by secretary+
-  _QuickAccessItemConfig(
-    labelKey: 'dashboard.quick_access.club',
-    icon: HugeIcons.strokeRoundedBuilding01,
-    color: AppColors.secondary,
-    route: RouteNames.homeClub,
-    requiredPermissions: {'clubs:update'},
-  ),
-  // Administrative: evidence folder management — uses users:read_detail.
-  // Members access their OWN evidence via the profile screen, not this view.
-  _QuickAccessItemConfig(
-    labelKey: 'dashboard.quick_access.evidence_folder',
-    icon: HugeIcons.strokeRoundedFolder01,
-    color: AppColors.accent,
-    route: RouteNames.homeEvidences,
-    requiredPermissions: {'users:read_detail'},
-  ),
-  // Administrative: financial records — finances:read is held by treasurer+
-  _QuickAccessItemConfig(
-    labelKey: 'dashboard.quick_access.finances',
-    icon: HugeIcons.strokeRoundedCreditCard,
-    color: AppColors.info,
-    route: RouteNames.homeFinances,
-    requiredPermissions: {'finances:read'},
-  ),
-  // Administrative: unit management — units:update is held by counselor+
-  _QuickAccessItemConfig(
-    labelKey: 'dashboard.quick_access.units',
-    icon: HugeIcons.strokeRoundedCompass01,
-    color: AppColors.secondary,
-    route: RouteNames.homeUnits,
-    requiredPermissions: {'units:update'},
-  ),
-  // Administrative: group class management — classes:submit_progress is held by counselor+
-  _QuickAccessItemConfig(
-    labelKey: 'dashboard.quick_access.grouped_class',
-    icon: HugeIcons.strokeRoundedBookOpen01,
-    color: AppColors.primary,
-    route: RouteNames.homeGroupedClass,
-    requiredPermissions: {'classes:submit_progress'},
-  ),
-  // Administrative: insurance management
-  _QuickAccessItemConfig(
-    labelKey: 'dashboard.quick_access.insurance',
-    icon: HugeIcons.strokeRoundedShield01,
-    color: AppColors.secondaryDark,
-    route: RouteNames.homeInsurance,
-    requiredPermissions: {'insurance:read'},
-  ),
-  // Administrative: inventory management
-  _QuickAccessItemConfig(
-    labelKey: 'dashboard.quick_access.inventory',
-    icon: HugeIcons.strokeRoundedPackage,
-    color: AppColors.accent,
-    route: RouteNames.homeInventory,
-    requiredPermissions: {'inventory:read'},
-  ),
-  // Club-wide shared resources — folders:read is granted to every club role.
-  _QuickAccessItemConfig(
-    labelKey: 'dashboard.quick_access.resources',
-    icon: HugeIcons.strokeRoundedFiles01,
-    route: RouteNames.homeResources,
-    requiredPermissions: {'folders:read'},
-  ),
-  // Mi ranking — only visible to roles that hold member_rankings:read_self
-  // (MEMBER club-scope, ADMIN global, SUPER_ADMIN global). Other club roles
-  // (director, counselor, secretary, treasurer…) do not have this permission
-  // and must not see the entry.
-  _QuickAccessItemConfig(
-    labelKey: 'dashboard.quick_access.my_ranking',
-    icon: HugeIcons.strokeRoundedRanking,
-    color: AppColors.accent,
-    route: RouteNames.homeMyRanking,
-    requiredPermissions: {'member_rankings:read_self'},
-  ),
-  // Ranking de sección — gated by units:update (counselor+). Route is
-  // resolved at render time because it requires the active sectionId from
-  // clubContextProvider. Card is hidden when context is unavailable.
-  _QuickAccessItemConfig(
-    labelKey: 'dashboard.quick_access.section_ranking',
-    icon: HugeIcons.strokeRoundedAward01,
-    color: AppColors.primary,
-    routeResolver: (ref) {
-      final ctxAsync = ref.watch(clubContextProvider);
-      final sectionId = ctxAsync.valueOrNull?.sectionId;
-      if (sectionId == null) return null;
-      return RouteNames.sectionRankingPath(sectionId);
-    },
-    requiredPermissions: {'units:update'},
-  ),
-];
 
 /// Grid 2xN de acceso rápido a los módulos principales del sistema.
 ///
@@ -188,7 +39,7 @@ class QuickAccessGrid extends ConsumerWidget {
       return const SizedBox.shrink();
     }
 
-    final filteredItems = _quickAccessItemsConfig.where((item) {
+    final filteredItems = appDestinations.where((item) {
       // Ungated items (no permissions AND no roles) are visible to every
       // authenticated user — used only when authorization is not a concern.
       if (item.requiredPermissions.isEmpty && item.requiredRoles.isEmpty) {
@@ -305,7 +156,7 @@ class _QuickAccessSkeleton extends StatelessWidget {
 }
 
 class _QuickAccessTile extends StatelessWidget {
-  final _QuickAccessItemConfig item;
+  final NavDestination item;
 
   /// Pre-resolved navigation path (static route or resolved dynamic route).
   final String resolvedRoute;

--- a/test/core/nav/destinations_drift_test.dart
+++ b/test/core/nav/destinations_drift_test.dart
@@ -1,0 +1,65 @@
+/// Drift guard for [appDestinations] (T-32).
+///
+/// These tests act as a compile-time + runtime invariant check: they verify
+/// that the shared destinations catalog never silently drifts into an
+/// inconsistent state (empty list, ungated items, destinations with no
+/// navigation target).
+///
+/// Run with:
+///   flutter test test/core/nav/destinations_drift_test.dart
+library;
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sacdia_app/core/nav/destinations.dart';
+
+void main() {
+  group('appDestinations drift guard (T-32)', () {
+    test('catalog is non-empty', () {
+      expect(
+        appDestinations,
+        isNotEmpty,
+        reason: 'appDestinations must contain at least one destination',
+      );
+    });
+
+    test('every destination has a route target (static OR resolver)', () {
+      for (final dest in appDestinations) {
+        final hasStaticRoute = dest.route.isNotEmpty;
+        final hasResolver = dest.routeResolver != null;
+        expect(
+          hasStaticRoute || hasResolver,
+          isTrue,
+          reason:
+              '"${dest.labelKey}" has neither a non-empty route nor a routeResolver — '
+              'the card/item would be un-navigable',
+        );
+      }
+    });
+
+    test('every destination is gated (requiredPermissions OR requiredRoles)',
+        () {
+      for (final dest in appDestinations) {
+        final hasPermissions = dest.requiredPermissions.isNotEmpty;
+        final hasRoles = dest.requiredRoles.isNotEmpty;
+        expect(
+          hasPermissions || hasRoles,
+          isTrue,
+          reason:
+              '"${dest.labelKey}" has neither requiredPermissions nor requiredRoles — '
+              'ungated destinations are visible to all authenticated users, '
+              'which is not allowed per project RBAC policy',
+        );
+      }
+    });
+
+    test('no duplicate labelKeys', () {
+      final keys = appDestinations.map((d) => d.labelKey).toList();
+      final unique = keys.toSet();
+      expect(
+        keys.length,
+        equals(unique.length),
+        reason: 'Duplicate labelKey found in appDestinations',
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- Resolves the PR-5 verify WARNING: `_quickAccessItemsConfig` (dashboard widget) and `moreSheetDestinations` (more_sheet) were duplicate catalogs with the same schema, creating a silent drift risk where adding a destination to one surface would silently miss the other.
- Extracts a single `appDestinations: List<NavDestination>` in `lib/core/nav/destinations.dart` that both surfaces now consume.
- Adds a drift guard test suite (T-32) with 4 invariants: non-empty, route target required, RBAC gating required, no duplicate labelKeys.

## Files changed

| File | Change |
|---|---|
| `lib/core/nav/destinations.dart` | NEW — `NavDestination` class + `appDestinations` (13 items) |
| `lib/features/dashboard/presentation/widgets/quick_access_grid.dart` | Removes `_QuickAccessItemConfig` + private list; imports `appDestinations` |
| `lib/core/persona/widgets/more_sheet.dart` | Removes `MoreSheetDestination` + `moreSheetDestinations`; consumes `appDestinations` |
| `test/core/nav/destinations_drift_test.dart` | NEW — T-32 drift guard (4 assertions) |

## Behavior

Zero behavior change. RBAC predicates (`hasAnyPermission`, `hasAnyRole`), `routeResolver` semantics, and persona-slot dedup in `filterSheetDestinations` are all identical. The `section_ranking` item (dynamic route via `clubContextProvider`) was already missing from `moreSheetDestinations`; it is now included in the unified catalog and filtered correctly by the sheet's `routeResolver` skip-if-null logic.

## Test plan

- [ ] `flutter test test/core/nav/destinations_drift_test.dart` — 4 new T-32 tests pass
- [ ] `flutter test test/core/persona/more_sheet_test.dart` — T-30 (5 unit) + T-31 (2 widget) all pass
- [ ] `flutter test` full suite — 371 tests pass
- [ ] `flutter analyze` — no issues