### PR TITLE
chore: cascade dev->preprod nav/theme refactor batch 2026-05-11

### DIFF
--- a/lib/core/config/router.dart
+++ b/lib/core/config/router.dart
@@ -1275,18 +1275,25 @@ class _MainShell extends ConsumerWidget {
         selectedIndex: selectedIndex,
         onDestinationSelected: (uiIndex) =>
             navigationShell.goBranch(slots[uiIndex].branchIndex),
+        // Each destination is wrapped in Semantics to explicitly declare the
+        // Spanish label and button role, mirroring the NavigationRail label
+        // pattern for screen-reader parity (PR-2 a11y WARNING fix).
         destinations: slots
             .map(
-              (slot) => NavigationDestination(
-                icon: NavBadge(
-                  source: slot.badgeSource,
-                  child: HugeIcon(icon: slot.icon),
-                ),
-                selectedIcon: NavBadge(
-                  source: slot.badgeSource,
-                  child: HugeIcon(icon: slot.icon),
-                ),
+              (slot) => Semantics(
                 label: tr(slot.labelKey),
+                button: true,
+                child: NavigationDestination(
+                  icon: NavBadge(
+                    source: slot.badgeSource,
+                    child: HugeIcon(icon: slot.icon),
+                  ),
+                  selectedIcon: NavBadge(
+                    source: slot.badgeSource,
+                    child: HugeIcon(icon: slot.icon),
+                  ),
+                  label: tr(slot.labelKey),
+                ),
               ),
             )
             .toList(),

--- a/lib/core/nav/destinations.dart
+++ b/lib/core/nav/destinations.dart
@@ -1,0 +1,175 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:hugeicons/hugeicons.dart';
+import 'package:sacdia_app/core/config/route_names.dart';
+import 'package:sacdia_app/core/theme/app_colors.dart';
+import 'package:sacdia_app/core/utils/icon_helper.dart';
+import 'package:sacdia_app/features/members/presentation/providers/members_providers.dart';
+
+/// A single navigable destination used across all navigation surfaces
+/// (quick-access grid, «Más» bottom sheet, etc.).
+///
+/// Const-constructible so the [appDestinations] list is a compile-time
+/// constant and avoids repeated allocation on rebuild.
+class NavDestination {
+  /// Translation key resolved at render time via `tr(labelKey)`.
+  final String labelKey;
+
+  /// HugeIcons icon constant. Always [HugeIconData] — never `Icons.*`.
+  final HugeIconData icon;
+
+  /// Optional tint color. Falls back to the theme text color when null.
+  final Color? color;
+
+  /// Static route path. Use for routes that do not depend on runtime context.
+  /// Leave empty and provide [routeResolver] for dynamic routes.
+  final String route;
+
+  /// Optional resolver for routes that need runtime data (e.g. sectionId from
+  /// [clubContextProvider]). Called at render time with a [WidgetRef]. Return
+  /// `null` to hide the card / item when context data is unavailable.
+  final String? Function(WidgetRef ref)? routeResolver;
+
+  /// Permission keys required to show this destination. Checked via
+  /// [hasAnyPermission]. Leave empty when gating is role-based only.
+  final Set<String> requiredPermissions;
+
+  /// Canonical role names that gate this destination when it cannot be
+  /// modelled as a single permission (e.g. `coordinator`, `admin`). Leave
+  /// empty when gating is permission-based only.
+  final Set<String> requiredRoles;
+
+  const NavDestination({
+    required this.labelKey,
+    required this.icon,
+    this.color,
+    this.route = '',
+    this.routeResolver,
+    this.requiredPermissions = const {},
+    this.requiredRoles = const {},
+  });
+}
+
+/// Single source of truth for all navigable app destinations.
+///
+/// Every surface that exposes navigation items (quick-access grid, «Más»
+/// sheet, etc.) MUST consume this list and apply RBAC / slot-dedup at render
+/// time. Do NOT maintain parallel copies.
+///
+/// Adding a new destination:
+///   1. Add an entry here with appropriate [requiredPermissions] / [requiredRoles].
+///   2. Ensure the route is declared in [RouteNames].
+///   3. Run `flutter test test/core/nav/destinations_drift_test.dart` to
+///      verify the invariants are met.
+// ignore: prefer_const_declarations
+final List<NavDestination> appDestinations = [
+  // Coordination hub — gated by GLOBAL role only. The concept "is the user a
+  // coordinator / admin" does not map to a single permission, because club
+  // directors also hold operational permissions like `investiture:validate`;
+  // using those would incorrectly reveal the hub to directors.
+  NavDestination(
+    labelKey: 'dashboard.quick_access.coordination',
+    icon: HugeIcons.strokeRoundedAnalytics01,
+    color: AppColors.info,
+    route: RouteNames.coordinator,
+    requiredRoles: {'coordinator', 'admin', 'super-admin', 'assistant-admin'},
+  ),
+  // Administrative: member list — users:read_detail is held by counselor+
+  NavDestination(
+    labelKey: 'dashboard.quick_access.members',
+    icon: HugeIcons.strokeRoundedUserGroup,
+    color: AppColors.primary,
+    route: RouteNames.homeMembers,
+    requiredPermissions: {'users:read_detail'},
+  ),
+  // Administrative: club management — clubs:update is held by secretary+
+  NavDestination(
+    labelKey: 'dashboard.quick_access.club',
+    icon: HugeIcons.strokeRoundedBuilding01,
+    color: AppColors.secondary,
+    route: RouteNames.homeClub,
+    requiredPermissions: {'clubs:update'},
+  ),
+  // Administrative: evidence folder management — uses users:read_detail.
+  // Members access their OWN evidence via the profile screen, not this view.
+  NavDestination(
+    labelKey: 'dashboard.quick_access.evidence_folder',
+    icon: HugeIcons.strokeRoundedFolder01,
+    color: AppColors.accent,
+    route: RouteNames.homeEvidences,
+    requiredPermissions: {'users:read_detail'},
+  ),
+  // Administrative: financial records — finances:read is held by treasurer+
+  NavDestination(
+    labelKey: 'dashboard.quick_access.finances',
+    icon: HugeIcons.strokeRoundedCreditCard,
+    color: AppColors.info,
+    route: RouteNames.homeFinances,
+    requiredPermissions: {'finances:read'},
+  ),
+  // Administrative: unit management — units:update is held by counselor+
+  NavDestination(
+    labelKey: 'dashboard.quick_access.units',
+    icon: HugeIcons.strokeRoundedCompass01,
+    color: AppColors.secondary,
+    route: RouteNames.homeUnits,
+    requiredPermissions: {'units:update'},
+  ),
+  // Administrative: group class management — classes:submit_progress is held by counselor+
+  NavDestination(
+    labelKey: 'dashboard.quick_access.grouped_class',
+    icon: HugeIcons.strokeRoundedBookOpen01,
+    color: AppColors.primary,
+    route: RouteNames.homeGroupedClass,
+    requiredPermissions: {'classes:submit_progress'},
+  ),
+  // Administrative: insurance management
+  NavDestination(
+    labelKey: 'dashboard.quick_access.insurance',
+    icon: HugeIcons.strokeRoundedShield01,
+    color: AppColors.secondaryDark,
+    route: RouteNames.homeInsurance,
+    requiredPermissions: {'insurance:read'},
+  ),
+  // Administrative: inventory management
+  NavDestination(
+    labelKey: 'dashboard.quick_access.inventory',
+    icon: HugeIcons.strokeRoundedPackage,
+    color: AppColors.accent,
+    route: RouteNames.homeInventory,
+    requiredPermissions: {'inventory:read'},
+  ),
+  // Club-wide shared resources — folders:read is granted to every club role.
+  NavDestination(
+    labelKey: 'dashboard.quick_access.resources',
+    icon: HugeIcons.strokeRoundedFiles01,
+    route: RouteNames.homeResources,
+    requiredPermissions: {'folders:read'},
+  ),
+  // Mi ranking — only visible to roles that hold member_rankings:read_self
+  // (MEMBER club-scope, ADMIN global, SUPER_ADMIN global). Other club roles
+  // (director, counselor, secretary, treasurer…) do not have this permission
+  // and must not see the entry.
+  NavDestination(
+    labelKey: 'dashboard.quick_access.my_ranking',
+    icon: HugeIcons.strokeRoundedRanking,
+    color: AppColors.accent,
+    route: RouteNames.homeMyRanking,
+    requiredPermissions: {'member_rankings:read_self'},
+  ),
+  // Ranking de sección — gated by units:update (counselor+). Route is
+  // resolved at render time because it requires the active sectionId from
+  // clubContextProvider. Card is hidden when context is unavailable.
+  NavDestination(
+    labelKey: 'dashboard.quick_access.section_ranking',
+    icon: HugeIcons.strokeRoundedAward01,
+    color: AppColors.primary,
+    routeResolver: (ref) {
+      final ctxAsync = ref.watch(clubContextProvider);
+      final sectionId = ctxAsync.valueOrNull?.sectionId;
+      if (sectionId == null) return null;
+      return RouteNames.sectionRankingPath(sectionId);
+    },
+    requiredPermissions: {'units:update'},
+  ),
+];

--- a/lib/core/persona/widgets/more_sheet.dart
+++ b/lib/core/persona/widgets/more_sheet.dart
@@ -3,164 +3,27 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:hugeicons/hugeicons.dart';
-import 'package:sacdia_app/core/config/route_names.dart';
+import 'package:sacdia_app/core/nav/destinations.dart';
 import 'package:sacdia_app/core/persona/persona.dart';
 import 'package:sacdia_app/core/persona/persona_nav_config.dart';
 import 'package:sacdia_app/core/persona/persona_providers.dart';
-import 'package:sacdia_app/core/theme/app_colors.dart';
 import 'package:sacdia_app/core/theme/sac_colors.dart';
-import 'package:sacdia_app/core/utils/icon_helper.dart';
 import 'package:sacdia_app/features/auth/domain/entities/user_entity.dart';
 import 'package:sacdia_app/features/auth/domain/utils/authorization_utils.dart';
 import 'package:sacdia_app/features/auth/presentation/providers/auth_providers.dart';
 
-// ─── Data model ───────────────────────────────────────────────────────────────
-
-/// A single navigable destination exposed in the «Más» sheet.
-///
-/// Mirrors the structure of the private `_QuickAccessItemConfig` in
-/// `quick_access_grid.dart` so that the sheet can reuse the same RBAC
-/// predicates ([hasAnyPermission] / [hasAnyRole]) without coupling to the
-/// dashboard widget's private types.
-@visibleForTesting
-class MoreSheetDestination {
-  final String labelKey;
-  final HugeIconData icon;
-  final Color? color;
-
-  /// Static route path. Use when the route does not depend on runtime context.
-  final String route;
-
-  /// Optional resolver for routes that need runtime data (e.g. sectionId).
-  /// Return `null` to hide the item when context data is unavailable.
-  final String? Function(WidgetRef ref)? routeResolver;
-
-  final Set<String> requiredPermissions;
-  final Set<String> requiredRoles;
-
-  const MoreSheetDestination({
-    required this.labelKey,
-    required this.icon,
-    this.color,
-    this.route = '',
-    this.routeResolver,
-    this.requiredPermissions = const {},
-    this.requiredRoles = const {},
-  });
-}
-
-/// Master list of all navigable destinations that can appear in the «Más» sheet.
-///
-/// This list intentionally mirrors [_quickAccessItemsConfig] from
-/// `quick_access_grid.dart` so the same destinations are reachable from both
-/// surfaces. RBAC gating is applied at render time via [hasAnyPermission] /
-/// [hasAnyRole]. Persona-nav-slot dedup is applied per [_buildSheetItems].
-///
-/// NOTE: Do NOT add new routes here unless they are also present in
-/// [_quickAccessItemsConfig]. The «Más» sheet is a secondary surface for
-/// out-of-band navigation, not a primary feature launcher.
-const List<MoreSheetDestination> moreSheetDestinations = [
-  // Coordination hub — gated by GLOBAL role only.
-  MoreSheetDestination(
-    labelKey: 'dashboard.quick_access.coordination',
-    icon: HugeIcons.strokeRoundedAnalytics01,
-    color: AppColors.info,
-    route: RouteNames.coordinator,
-    requiredRoles: {'coordinator', 'admin', 'super-admin', 'assistant-admin'},
-  ),
-  // Member list — users:read_detail is held by counselor+
-  MoreSheetDestination(
-    labelKey: 'dashboard.quick_access.members',
-    icon: HugeIcons.strokeRoundedUserGroup,
-    color: AppColors.primary,
-    route: RouteNames.homeMembers,
-    requiredPermissions: {'users:read_detail'},
-  ),
-  // Club management — clubs:update is held by secretary+
-  MoreSheetDestination(
-    labelKey: 'dashboard.quick_access.club',
-    icon: HugeIcons.strokeRoundedBuilding01,
-    color: AppColors.secondary,
-    route: RouteNames.homeClub,
-    requiredPermissions: {'clubs:update'},
-  ),
-  // Evidence folder management — users:read_detail
-  MoreSheetDestination(
-    labelKey: 'dashboard.quick_access.evidence_folder',
-    icon: HugeIcons.strokeRoundedFolder01,
-    color: AppColors.accent,
-    route: RouteNames.homeEvidences,
-    requiredPermissions: {'users:read_detail'},
-  ),
-  // Financial records — finances:read is held by treasurer+
-  MoreSheetDestination(
-    labelKey: 'dashboard.quick_access.finances',
-    icon: HugeIcons.strokeRoundedCreditCard,
-    color: AppColors.info,
-    route: RouteNames.homeFinances,
-    requiredPermissions: {'finances:read'},
-  ),
-  // Unit management — units:update is held by counselor+
-  MoreSheetDestination(
-    labelKey: 'dashboard.quick_access.units',
-    icon: HugeIcons.strokeRoundedCompass01,
-    color: AppColors.secondary,
-    route: RouteNames.homeUnits,
-    requiredPermissions: {'units:update'},
-  ),
-  // Group class management — classes:submit_progress is held by counselor+
-  MoreSheetDestination(
-    labelKey: 'dashboard.quick_access.grouped_class',
-    icon: HugeIcons.strokeRoundedBookOpen01,
-    color: AppColors.primary,
-    route: RouteNames.homeGroupedClass,
-    requiredPermissions: {'classes:submit_progress'},
-  ),
-  // Insurance management
-  MoreSheetDestination(
-    labelKey: 'dashboard.quick_access.insurance',
-    icon: HugeIcons.strokeRoundedShield01,
-    color: AppColors.secondaryDark,
-    route: RouteNames.homeInsurance,
-    requiredPermissions: {'insurance:read'},
-  ),
-  // Inventory management
-  MoreSheetDestination(
-    labelKey: 'dashboard.quick_access.inventory',
-    icon: HugeIcons.strokeRoundedPackage,
-    color: AppColors.accent,
-    route: RouteNames.homeInventory,
-    requiredPermissions: {'inventory:read'},
-  ),
-  // Club-wide shared resources — folders:read is granted to every club role
-  MoreSheetDestination(
-    labelKey: 'dashboard.quick_access.resources',
-    icon: HugeIcons.strokeRoundedFiles01,
-    route: RouteNames.homeResources,
-    requiredPermissions: {'folders:read'},
-  ),
-  // My ranking — member_rankings:read_self (member scope)
-  MoreSheetDestination(
-    labelKey: 'dashboard.quick_access.my_ranking',
-    icon: HugeIcons.strokeRoundedRanking,
-    color: AppColors.accent,
-    route: RouteNames.homeMyRanking,
-    requiredPermissions: {'member_rankings:read_self'},
-  ),
-];
-
 // ─── Sheet logic ──────────────────────────────────────────────────────────────
 
-/// Value object that pairs a [MoreSheetDestination] with its resolved route.
+/// Value object that pairs a [NavDestination] with its resolved route.
 class MoreSheetResolvedItem {
-  final MoreSheetDestination dest;
+  final NavDestination dest;
   final String resolvedRoute;
 
   const MoreSheetResolvedItem(
       {required this.dest, required this.resolvedRoute});
 }
 
-/// Pure filtering function: returns items from [moreSheetDestinations] that
+/// Pure filtering function: returns items from [appDestinations] that
 /// pass the persona-slot dedup and RBAC checks.
 ///
 /// Filtering rules (applied in order):
@@ -178,7 +41,7 @@ List<MoreSheetResolvedItem> filterSheetDestinations({
   WidgetRef? ref,
 }) {
   final result = <MoreSheetResolvedItem>[];
-  for (final dest in moreSheetDestinations) {
+  for (final dest in appDestinations) {
     // 1. Skip if static route is already in persona nav slots.
     if (dest.routeResolver == null && navRoutes.contains(dest.route)) continue;
 
@@ -364,7 +227,7 @@ class _MoreSheetContent extends ConsumerWidget {
 // ─── Individual tile ──────────────────────────────────────────────────────────
 
 class _MoreSheetTile extends StatelessWidget {
-  final MoreSheetDestination item;
+  final NavDestination item;
   final String resolvedRoute;
 
   const _MoreSheetTile({

--- a/lib/core/persona/widgets/nav_badge.dart
+++ b/lib/core/persona/widgets/nav_badge.dart
@@ -2,6 +2,7 @@ import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:sacdia_app/core/persona/nav_slot.dart';
+import 'package:sacdia_app/core/theme/sac_colors.dart';
 import 'package:sacdia_app/features/notifications/presentation/providers/unread_notifications_count_provider.dart';
 
 /// Wraps [child] with a notification badge driven by [source].
@@ -12,7 +13,7 @@ import 'package:sacdia_app/features/notifications/presentation/providers/unread_
 /// top-right corner when the count is greater than zero.
 ///
 /// Design constraints (NFR-3, NFR-4):
-/// - Badge uses `Theme.of(context).colorScheme.error` (Material 3 semantic token).
+/// - Badge uses `context.sac.error` (SacColors semantic token).
 /// - Badge counter is capped at 99+.
 /// - Touch target maintained by parent [NavigationDestination] / [NavigationRailDestination].
 ///
@@ -64,13 +65,13 @@ class NavBadge extends ConsumerWidget {
               ),
               padding: const EdgeInsets.symmetric(horizontal: 4),
               decoration: BoxDecoration(
-                color: Theme.of(context).colorScheme.error,
+                color: context.sac.error,
                 borderRadius: BorderRadius.circular(8),
               ),
               child: Text(
                 badgeLabel,
                 style: TextStyle(
-                  color: Theme.of(context).colorScheme.onError,
+                  color: context.sac.onError,
                   fontSize: 10,
                   fontWeight: FontWeight.w600,
                   height: 1.6,

--- a/lib/core/theme/club_type.dart
+++ b/lib/core/theme/club_type.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/material.dart';
+
+import 'app_colors.dart';
+
+/// Canonical set of club organization types recognised by SACDIA.
+///
+/// This is the single source of truth for the club-type → accent-color mapping.
+/// Any feature that needs to resolve a color from a club type name must go
+/// through [clubTypeFromName] + [ClubColorX.color] rather than duplicating the
+/// string-matching logic.
+enum ClubType {
+  conquistadores,
+  aventureros,
+  guiasMayores,
+}
+
+/// Extension that binds each [ClubType] to its canonical accent color.
+///
+/// Colors are pulled directly from [AppColors] constants so both sources stay
+/// in sync automatically — changing a constant here propagates everywhere.
+extension ClubColorX on ClubType {
+  Color get color {
+    switch (this) {
+      case ClubType.conquistadores:
+        return AppColors.primary; // SACDIA Red
+      case ClubType.aventureros:
+        return AppColors.sacBlue; // SACDIA Blue
+      case ClubType.guiasMayores:
+        return AppColors.secondary; // SACDIA Green
+    }
+  }
+}
+
+/// Resolves a raw club-type string (as it arrives from the API / grants) to a
+/// [ClubType] enum value.
+///
+/// Matching is:
+/// - case-insensitive
+/// - whitespace-trimmed
+/// - substring-based (mirrors the original [_getClubColor] logic)
+///
+/// Returns `null` for unknown / empty inputs so call sites can apply their own
+/// fallback instead of silently receiving a wrong color.
+ClubType? clubTypeFromName(String? name) {
+  if (name == null) return null;
+  final lower = name.trim().toLowerCase();
+  if (lower.contains('conquistador')) return ClubType.conquistadores;
+  if (lower.contains('aventurer')) return ClubType.aventureros;
+  if (lower.contains('guía') || lower.contains('guia')) {
+    return ClubType.guiasMayores;
+  }
+  return null;
+}
+
+/// Convenience helper: resolves [name] to a [Color], falling back to
+/// [AppColors.primary] for unknown inputs — identical behaviour to the
+/// original private `_getClubColor` method in [ClubInfoCard].
+Color clubColorFromName(String? name) =>
+    clubTypeFromName(name)?.color ?? AppColors.primary;

--- a/lib/features/dashboard/presentation/widgets/club_info_card.dart
+++ b/lib/features/dashboard/presentation/widgets/club_info_card.dart
@@ -2,7 +2,7 @@ import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:hugeicons/hugeicons.dart';
-import 'package:sacdia_app/core/theme/app_colors.dart';
+import 'package:sacdia_app/core/theme/club_type.dart';
 import 'package:sacdia_app/core/theme/sac_colors.dart';
 import 'package:sacdia_app/core/utils/role_utils.dart';
 import 'package:sacdia_app/core/widgets/sac_badge.dart';
@@ -43,17 +43,6 @@ class ClubInfoCard extends ConsumerWidget {
     this.userRole,
   });
 
-  Color _getClubColor(String? type) {
-    if (type == null) return AppColors.primary;
-    final lower = type.toLowerCase();
-    if (lower.contains('conquistador')) return AppColors.primary;
-    if (lower.contains('aventurer')) return AppColors.sacBlue;
-    if (lower.contains('guía') || lower.contains('guia')) {
-      return AppColors.secondary;
-    }
-    return AppColors.primary;
-  }
-
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final authState = ref.watch(authNotifierProvider);
@@ -73,7 +62,7 @@ class ClubInfoCard extends ConsumerWidget {
         ? RoleUtils.translate(activeGrant!.roleName, gender: userGender)
         : userRole;
 
-    final clubColor = _getClubColor(resolvedClubType);
+    final Color clubColor = clubColorFromName(resolvedClubType);
 
     return SacCard(
       accentColor: clubColor,

--- a/lib/features/dashboard/presentation/widgets/quick_access_grid.dart
+++ b/lib/features/dashboard/presentation/widgets/quick_access_grid.dart
@@ -3,159 +3,10 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:hugeicons/hugeicons.dart';
-import 'package:sacdia_app/core/config/route_names.dart';
-import 'package:sacdia_app/core/theme/app_colors.dart';
+import 'package:sacdia_app/core/nav/destinations.dart';
 import 'package:sacdia_app/core/theme/sac_colors.dart';
 import 'package:sacdia_app/features/auth/domain/utils/authorization_utils.dart';
 import 'package:sacdia_app/features/auth/presentation/providers/auth_providers.dart';
-import 'package:sacdia_app/features/members/presentation/providers/members_providers.dart';
-
-class _QuickAccessItemConfig {
-  /// Translation key resolved at render time via tr(labelKey).
-  final String labelKey;
-  final List<List<dynamic>> icon;
-  final Color? color;
-
-  /// Static route path. Use this for routes that do not depend on runtime
-  /// context. For dynamic routes, leave empty and provide [routeResolver].
-  final String route;
-
-  /// Optional resolver for routes that need runtime data (e.g. sectionId from
-  /// clubContextProvider). Called at render time with a [WidgetRef]. Return
-  /// null to hide the card when context data is unavailable.
-  final String? Function(WidgetRef ref)? routeResolver;
-
-  final Set<String> requiredPermissions;
-
-  /// Canonical role names to gate against when the item is not permission-based.
-  /// Only used for global roles whose authority cannot be modeled as a single
-  /// permission (e.g. `coordinator`, `admin`). Leave empty when the item is
-  /// gated purely by [requiredPermissions].
-  final Set<String> requiredRoles;
-
-  const _QuickAccessItemConfig({
-    required this.labelKey,
-    required this.icon,
-    this.color,
-    this.route = '',
-    this.routeResolver,
-    this.requiredPermissions = const {},
-    this.requiredRoles = const {},
-  });
-}
-
-// ignore: prefer_const_declarations
-final List<_QuickAccessItemConfig> _quickAccessItemsConfig = [
-  // Coordination hub — gated by GLOBAL role only. The concept "is the user a
-  // coordinator / admin" does not map to a single permission, because club
-  // directors also hold operational permissions like `investiture:validate`;
-  // using those would incorrectly reveal the hub to directors.
-  _QuickAccessItemConfig(
-    labelKey: 'dashboard.quick_access.coordination',
-    icon: HugeIcons.strokeRoundedAnalytics01,
-    color: AppColors.info,
-    route: RouteNames.coordinator,
-    requiredRoles: {'coordinator', 'admin', 'super-admin', 'assistant-admin'},
-  ),
-  // Administrative: member list — users:read_detail is held by counselor+
-  _QuickAccessItemConfig(
-    labelKey: 'dashboard.quick_access.members',
-    icon: HugeIcons.strokeRoundedUserGroup,
-    color: AppColors.primary,
-    route: RouteNames.homeMembers,
-    requiredPermissions: {'users:read_detail'},
-  ),
-  // Administrative: club management — clubs:update is held by secretary+
-  _QuickAccessItemConfig(
-    labelKey: 'dashboard.quick_access.club',
-    icon: HugeIcons.strokeRoundedBuilding01,
-    color: AppColors.secondary,
-    route: RouteNames.homeClub,
-    requiredPermissions: {'clubs:update'},
-  ),
-  // Administrative: evidence folder management — uses users:read_detail.
-  // Members access their OWN evidence via the profile screen, not this view.
-  _QuickAccessItemConfig(
-    labelKey: 'dashboard.quick_access.evidence_folder',
-    icon: HugeIcons.strokeRoundedFolder01,
-    color: AppColors.accent,
-    route: RouteNames.homeEvidences,
-    requiredPermissions: {'users:read_detail'},
-  ),
-  // Administrative: financial records — finances:read is held by treasurer+
-  _QuickAccessItemConfig(
-    labelKey: 'dashboard.quick_access.finances',
-    icon: HugeIcons.strokeRoundedCreditCard,
-    color: AppColors.info,
-    route: RouteNames.homeFinances,
-    requiredPermissions: {'finances:read'},
-  ),
-  // Administrative: unit management — units:update is held by counselor+
-  _QuickAccessItemConfig(
-    labelKey: 'dashboard.quick_access.units',
-    icon: HugeIcons.strokeRoundedCompass01,
-    color: AppColors.secondary,
-    route: RouteNames.homeUnits,
-    requiredPermissions: {'units:update'},
-  ),
-  // Administrative: group class management — classes:submit_progress is held by counselor+
-  _QuickAccessItemConfig(
-    labelKey: 'dashboard.quick_access.grouped_class',
-    icon: HugeIcons.strokeRoundedBookOpen01,
-    color: AppColors.primary,
-    route: RouteNames.homeGroupedClass,
-    requiredPermissions: {'classes:submit_progress'},
-  ),
-  // Administrative: insurance management
-  _QuickAccessItemConfig(
-    labelKey: 'dashboard.quick_access.insurance',
-    icon: HugeIcons.strokeRoundedShield01,
-    color: AppColors.secondaryDark,
-    route: RouteNames.homeInsurance,
-    requiredPermissions: {'insurance:read'},
-  ),
-  // Administrative: inventory management
-  _QuickAccessItemConfig(
-    labelKey: 'dashboard.quick_access.inventory',
-    icon: HugeIcons.strokeRoundedPackage,
-    color: AppColors.accent,
-    route: RouteNames.homeInventory,
-    requiredPermissions: {'inventory:read'},
-  ),
-  // Club-wide shared resources — folders:read is granted to every club role.
-  _QuickAccessItemConfig(
-    labelKey: 'dashboard.quick_access.resources',
-    icon: HugeIcons.strokeRoundedFiles01,
-    route: RouteNames.homeResources,
-    requiredPermissions: {'folders:read'},
-  ),
-  // Mi ranking — only visible to roles that hold member_rankings:read_self
-  // (MEMBER club-scope, ADMIN global, SUPER_ADMIN global). Other club roles
-  // (director, counselor, secretary, treasurer…) do not have this permission
-  // and must not see the entry.
-  _QuickAccessItemConfig(
-    labelKey: 'dashboard.quick_access.my_ranking',
-    icon: HugeIcons.strokeRoundedRanking,
-    color: AppColors.accent,
-    route: RouteNames.homeMyRanking,
-    requiredPermissions: {'member_rankings:read_self'},
-  ),
-  // Ranking de sección — gated by units:update (counselor+). Route is
-  // resolved at render time because it requires the active sectionId from
-  // clubContextProvider. Card is hidden when context is unavailable.
-  _QuickAccessItemConfig(
-    labelKey: 'dashboard.quick_access.section_ranking',
-    icon: HugeIcons.strokeRoundedAward01,
-    color: AppColors.primary,
-    routeResolver: (ref) {
-      final ctxAsync = ref.watch(clubContextProvider);
-      final sectionId = ctxAsync.valueOrNull?.sectionId;
-      if (sectionId == null) return null;
-      return RouteNames.sectionRankingPath(sectionId);
-    },
-    requiredPermissions: {'units:update'},
-  ),
-];
 
 /// Grid 2xN de acceso rápido a los módulos principales del sistema.
 ///
@@ -188,7 +39,7 @@ class QuickAccessGrid extends ConsumerWidget {
       return const SizedBox.shrink();
     }
 
-    final filteredItems = _quickAccessItemsConfig.where((item) {
+    final filteredItems = appDestinations.where((item) {
       // Ungated items (no permissions AND no roles) are visible to every
       // authenticated user — used only when authorization is not a concern.
       if (item.requiredPermissions.isEmpty && item.requiredRoles.isEmpty) {
@@ -305,7 +156,7 @@ class _QuickAccessSkeleton extends StatelessWidget {
 }
 
 class _QuickAccessTile extends StatelessWidget {
-  final _QuickAccessItemConfig item;
+  final NavDestination item;
 
   /// Pre-resolved navigation path (static route or resolved dynamic route).
   final String resolvedRoute;

--- a/test/core/nav/destinations_drift_test.dart
+++ b/test/core/nav/destinations_drift_test.dart
@@ -1,0 +1,65 @@
+/// Drift guard for [appDestinations] (T-32).
+///
+/// These tests act as a compile-time + runtime invariant check: they verify
+/// that the shared destinations catalog never silently drifts into an
+/// inconsistent state (empty list, ungated items, destinations with no
+/// navigation target).
+///
+/// Run with:
+///   flutter test test/core/nav/destinations_drift_test.dart
+library;
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sacdia_app/core/nav/destinations.dart';
+
+void main() {
+  group('appDestinations drift guard (T-32)', () {
+    test('catalog is non-empty', () {
+      expect(
+        appDestinations,
+        isNotEmpty,
+        reason: 'appDestinations must contain at least one destination',
+      );
+    });
+
+    test('every destination has a route target (static OR resolver)', () {
+      for (final dest in appDestinations) {
+        final hasStaticRoute = dest.route.isNotEmpty;
+        final hasResolver = dest.routeResolver != null;
+        expect(
+          hasStaticRoute || hasResolver,
+          isTrue,
+          reason:
+              '"${dest.labelKey}" has neither a non-empty route nor a routeResolver — '
+              'the card/item would be un-navigable',
+        );
+      }
+    });
+
+    test('every destination is gated (requiredPermissions OR requiredRoles)',
+        () {
+      for (final dest in appDestinations) {
+        final hasPermissions = dest.requiredPermissions.isNotEmpty;
+        final hasRoles = dest.requiredRoles.isNotEmpty;
+        expect(
+          hasPermissions || hasRoles,
+          isTrue,
+          reason:
+              '"${dest.labelKey}" has neither requiredPermissions nor requiredRoles — '
+              'ungated destinations are visible to all authenticated users, '
+              'which is not allowed per project RBAC policy',
+        );
+      }
+    });
+
+    test('no duplicate labelKeys', () {
+      final keys = appDestinations.map((d) => d.labelKey).toList();
+      final unique = keys.toSet();
+      expect(
+        keys.length,
+        equals(unique.length),
+        reason: 'Duplicate labelKey found in appDestinations',
+      );
+    });
+  });
+}

--- a/test/core/theme/club_color_test.dart
+++ b/test/core/theme/club_color_test.dart
@@ -1,0 +1,135 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sacdia_app/core/theme/app_colors.dart';
+import 'package:sacdia_app/core/theme/club_type.dart';
+
+void main() {
+  group('clubTypeFromName', () {
+    group('known club types — exact canonical names', () {
+      test('resolves Conquistadores', () {
+        expect(clubTypeFromName('Conquistadores'), ClubType.conquistadores);
+      });
+
+      test('resolves Aventureros', () {
+        expect(clubTypeFromName('Aventureros'), ClubType.aventureros);
+      });
+
+      test('resolves Guías Mayores (with accent)', () {
+        expect(clubTypeFromName('Guías Mayores'), ClubType.guiasMayores);
+      });
+
+      test('resolves Guias Mayores (without accent)', () {
+        expect(clubTypeFromName('Guias Mayores'), ClubType.guiasMayores);
+      });
+    });
+
+    group('case insensitivity', () {
+      test('CONQUISTADORES uppercase', () {
+        expect(clubTypeFromName('CONQUISTADORES'), ClubType.conquistadores);
+      });
+
+      test('aventureros lowercase', () {
+        expect(clubTypeFromName('aventureros'), ClubType.aventureros);
+      });
+
+      test('GUÍA MAYOR uppercase with accent', () {
+        expect(clubTypeFromName('GUÍA MAYOR'), ClubType.guiasMayores);
+      });
+
+      test('mixed case Conquistador (singular)', () {
+        expect(clubTypeFromName('Conquistador'), ClubType.conquistadores);
+      });
+    });
+
+    group('whitespace handling', () {
+      test('trims leading and trailing spaces', () {
+        expect(
+          clubTypeFromName('  Conquistadores  '),
+          ClubType.conquistadores,
+        );
+      });
+
+      test('trims spaces around Aventureros', () {
+        expect(clubTypeFromName(' aventureros '), ClubType.aventureros);
+      });
+
+      test('trims spaces around Guía', () {
+        expect(clubTypeFromName(' Guía Mayor '), ClubType.guiasMayores);
+      });
+    });
+
+    group('fallback for unknown or null input', () {
+      test('returns null for null', () {
+        expect(clubTypeFromName(null), isNull);
+      });
+
+      test('returns null for empty string', () {
+        expect(clubTypeFromName(''), isNull);
+      });
+
+      test('returns null for whitespace-only string', () {
+        expect(clubTypeFromName('   '), isNull);
+      });
+
+      test('returns null for an unknown name', () {
+        expect(clubTypeFromName('Pathfinders'), isNull);
+      });
+    });
+  });
+
+  group('ClubColorX.color', () {
+    test('conquistadores → AppColors.primary', () {
+      expect(ClubType.conquistadores.color, AppColors.primary);
+    });
+
+    test('aventureros → AppColors.sacBlue', () {
+      expect(ClubType.aventureros.color, AppColors.sacBlue);
+    });
+
+    test('guiasMayores → AppColors.secondary', () {
+      expect(ClubType.guiasMayores.color, AppColors.secondary);
+    });
+  });
+
+  group('clubColorFromName — convenience helper', () {
+    test('known name returns the correct color', () {
+      expect(clubColorFromName('Conquistadores'), AppColors.primary);
+      expect(clubColorFromName('Aventureros'), AppColors.sacBlue);
+      expect(clubColorFromName('Guías Mayores'), AppColors.secondary);
+    });
+
+    test('null input falls back to AppColors.primary', () {
+      expect(clubColorFromName(null), AppColors.primary);
+    });
+
+    test('unknown name falls back to AppColors.primary', () {
+      expect(clubColorFromName('UnknownClub'), AppColors.primary);
+    });
+
+    test('behavior is identical to original _getClubColor for all known inputs',
+        () {
+      // This documents the behavioral contract exactly as it was before
+      // the refactor: same string in → same Color out.
+      final cases = {
+        'Conquistadores': AppColors.primary,
+        'conquistador': AppColors.primary,
+        'CONQUISTADORES': AppColors.primary,
+        'Aventureros': AppColors.sacBlue,
+        'aventurero': AppColors.sacBlue,
+        'AVENTUREROS': AppColors.sacBlue,
+        'Guías Mayores': AppColors.secondary,
+        'guia mayor': AppColors.secondary,
+        'GUÍA': AppColors.secondary,
+        'Unknown': AppColors.primary,
+        '': AppColors.primary,
+      };
+
+      for (final entry in cases.entries) {
+        expect(
+          clubColorFromName(entry.key),
+          entry.value,
+          reason: 'Input "${entry.key}" should map to ${entry.value}',
+        );
+      }
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Cascade batch post #69 + #70 + #71 + #72 from `development` to `preproduction`.

## Included PRs

- #69 fix(persona-nav): NavBadge uses context.sac.error token
- #70 fix(a11y): explicit Semantics on NavigationBar destinations
- #71 refactor(nav): extract shared destinations catalog + drift guard
- #72 refactor(theme): unify club color resolution

## Scope

Navigation + theme refactors only. No business logic changes. Tests added: T-32 destinations drift guard (4 invariants) and 22 unit tests for club color resolution. Full suite remained green on each PR (Analyze & Format, Test, Build APK, Check Secrets).

## Test plan

- [ ] CI green on preproduction
- [ ] Smoke test nav surfaces (NavigationBar + NavigationRail + Mas sheet)
- [ ] Verify club color resolution on ClubInfoCard for Conquistadores / Aventureros / Guias Mayores