### PR TITLE
refactor(ui): InkWell replaces GestureDetector + type scale cleanup

### DIFF
--- a/lib/features/activities/presentation/views/activities_list_view.dart
+++ b/lib/features/activities/presentation/views/activities_list_view.dart
@@ -320,86 +320,98 @@ class _ActivitiesListViewState extends ConsumerState<ActivitiesListView> {
                     ),
                   ),
                   if (_canCreateActivities())
-                    GestureDetector(
-                      onTap: () {
-                        Navigator.push(
-                          context,
-                          SacSlideUpRoute(
-                            builder: (context) => CreateActivityView(
-                              clubId: resolvedClubId ?? 0,
-                              clubSectionId: resolvedSectionId ?? 0,
-                            ),
-                          ),
-                        ).then((created) {
-                          // Si la actividad fue creada, refrescar la lista
-                          if (created == true && mounted) {
-                            ref.invalidate(clubActivitiesProvider);
-                          }
-                        });
-                      },
-                      child: AnimatedContainer(
-                        duration: const Duration(milliseconds: 200),
-                        padding: const EdgeInsets.all(9),
-                        decoration: BoxDecoration(
-                          color: c.surface,
+                    Semantics(
+                      label: 'activities.list.add'.tr(),
+                      button: true,
+                      child: Material(
+                        color: c.surface,
+                        shape: RoundedRectangleBorder(
                           borderRadius: BorderRadius.circular(12),
-                          border: Border.all(
-                            color: c.border,
-                          ),
+                          side: BorderSide(color: c.border),
                         ),
-                        child: Row(
-                          children: [
-                            HugeIcon(
-                              icon: HugeIcons.strokeRoundedCalendarAdd01,
-                              size: 20,
-                              color: c.textSecondary,
+                        child: InkWell(
+                          borderRadius: BorderRadius.circular(12),
+                          onTap: () {
+                            Navigator.push(
+                              context,
+                              SacSlideUpRoute(
+                                builder: (context) => CreateActivityView(
+                                  clubId: resolvedClubId ?? 0,
+                                  clubSectionId: resolvedSectionId ?? 0,
+                                ),
+                              ),
+                            ).then((created) {
+                              // Si la actividad fue creada, refrescar la lista
+                              if (created == true && mounted) {
+                                ref.invalidate(clubActivitiesProvider);
+                              }
+                            });
+                          },
+                          child: Padding(
+                            padding: const EdgeInsets.all(9),
+                            child: Row(
+                              children: [
+                                HugeIcon(
+                                  icon: HugeIcons.strokeRoundedCalendarAdd01,
+                                  size: 20,
+                                  color: c.textSecondary,
+                                ),
+                                const SizedBox(width: 5),
+                                Text('activities.list.add'.tr()),
+                              ],
                             ),
-                            const SizedBox(width: 5),
-                            Text('activities.list.add'.tr())
-                          ],
+                          ),
                         ),
                       ),
                     ),
                   const SizedBox(width: 8),
-                  GestureDetector(
-                    onTap: () {
-                      setState(() {
-                        _isChronologicalView = !_isChronologicalView;
-                        if (_isChronologicalView) _shouldScrollToToday = true;
-                      });
-                    },
-                    child: AnimatedContainer(
-                      duration: const Duration(milliseconds: 200),
-                      padding: const EdgeInsets.all(9),
-                      decoration: BoxDecoration(
-                        color: _isChronologicalView
-                            ? AppColors.primary
-                            : c.surface,
-                        borderRadius: BorderRadius.circular(12),
-                        border: Border.all(
-                          color: _isChronologicalView
-                              ? AppColors.primary
-                              : c.border,
-                        ),
-                        boxShadow: _isChronologicalView
-                            ? [
-                                BoxShadow(
-                                  color:
-                                      AppColors.primary.withValues(alpha: 0.3),
-                                  blurRadius: 8,
-                                  offset: const Offset(0, 3),
-                                )
-                              ]
-                            : null,
+                  AnimatedContainer(
+                    duration: const Duration(milliseconds: 200),
+                    decoration: BoxDecoration(
+                      color:
+                          _isChronologicalView ? AppColors.primary : c.surface,
+                      borderRadius: BorderRadius.circular(12),
+                      border: Border.all(
+                        color:
+                            _isChronologicalView ? AppColors.primary : c.border,
                       ),
-                      child: HugeIcon(
-                        icon: _isChronologicalView
-                            ? HugeIcons.strokeRoundedCalendar01
-                            : HugeIcons.strokeRoundedListView,
-                        size: 20,
-                        color: _isChronologicalView
-                            ? Colors.white
-                            : c.textSecondary,
+                      boxShadow: _isChronologicalView
+                          ? [
+                              BoxShadow(
+                                color: AppColors.primary.withValues(alpha: 0.3),
+                                blurRadius: 8,
+                                offset: const Offset(0, 3),
+                              )
+                            ]
+                          : null,
+                    ),
+                    child: Material(
+                      color: Colors.transparent,
+                      child: InkWell(
+                        borderRadius: BorderRadius.circular(12),
+                        splashColor: _isChronologicalView
+                            ? Colors.white.withValues(alpha: 0.2)
+                            : null,
+                        onTap: () {
+                          setState(() {
+                            _isChronologicalView = !_isChronologicalView;
+                            if (_isChronologicalView) {
+                              _shouldScrollToToday = true;
+                            }
+                          });
+                        },
+                        child: Padding(
+                          padding: const EdgeInsets.all(9),
+                          child: HugeIcon(
+                            icon: _isChronologicalView
+                                ? HugeIcons.strokeRoundedCalendar01
+                                : HugeIcons.strokeRoundedListView,
+                            size: 20,
+                            color: _isChronologicalView
+                                ? Colors.white
+                                : c.textSecondary,
+                          ),
+                        ),
                       ),
                     ),
                   ),
@@ -447,10 +459,11 @@ class _ActivitiesListViewState extends ConsumerState<ActivitiesListView> {
                                             _selectedDate != null &&
                                                 _isSameDay(day, _selectedDate!);
 
-                                        return GestureDetector(
-                                          onTap: () => setState(() {
-                                            _selectedDate = day;
-                                          }),
+                                        return Semantics(
+                                          label: DateFormat('EEEE d MMMM', 'es')
+                                              .format(day),
+                                          button: true,
+                                          selected: isSelected,
                                           child: AnimatedContainer(
                                             duration: const Duration(
                                                 milliseconds: 200),
@@ -485,40 +498,58 @@ class _ActivitiesListViewState extends ConsumerState<ActivitiesListView> {
                                                     ]
                                                   : null,
                                             ),
-                                            child: Column(
-                                              mainAxisAlignment:
-                                                  MainAxisAlignment.center,
-                                              children: [
-                                                Text(
-                                                  DateFormat('EEE', 'es')
-                                                      .format(day)
-                                                      .substring(0, 2)
-                                                      .toUpperCase(),
-                                                  style: TextStyle(
-                                                    fontSize: 10,
-                                                    fontWeight: FontWeight.w600,
-                                                    color: isSelected
-                                                        ? Colors.white
-                                                            .withValues(
-                                                                alpha: 0.8)
-                                                        : c.textTertiary,
-                                                  ),
+                                            child: Material(
+                                              color: Colors.transparent,
+                                              child: InkWell(
+                                                borderRadius:
+                                                    BorderRadius.circular(16),
+                                                splashColor: isSelected
+                                                    ? Colors.white
+                                                        .withValues(alpha: 0.2)
+                                                    : null,
+                                                onTap: () => setState(() {
+                                                  _selectedDate = day;
+                                                }),
+                                                child: Column(
+                                                  mainAxisAlignment:
+                                                      MainAxisAlignment.center,
+                                                  children: [
+                                                    Text(
+                                                      DateFormat('EEE', 'es')
+                                                          .format(day)
+                                                          .substring(0, 2)
+                                                          .toUpperCase(),
+                                                      style: TextStyle(
+                                                        fontSize: 10,
+                                                        fontWeight:
+                                                            FontWeight.w600,
+                                                        color: isSelected
+                                                            ? Colors.white
+                                                                .withValues(
+                                                                    alpha: 0.8)
+                                                            : c.textTertiary,
+                                                      ),
+                                                    ),
+                                                    const SizedBox(height: 4),
+                                                    Text(
+                                                      DateFormat('d')
+                                                          .format(day),
+                                                      style: TextStyle(
+                                                        fontSize: 20,
+                                                        fontWeight:
+                                                            FontWeight.w700,
+                                                        height: 1,
+                                                        color: isSelected
+                                                            ? Colors.white
+                                                            : isToday
+                                                                ? AppColors
+                                                                    .primary
+                                                                : c.text,
+                                                      ),
+                                                    ),
+                                                  ],
                                                 ),
-                                                const SizedBox(height: 4),
-                                                Text(
-                                                  DateFormat('d').format(day),
-                                                  style: TextStyle(
-                                                    fontSize: 20,
-                                                    fontWeight: FontWeight.w700,
-                                                    height: 1,
-                                                    color: isSelected
-                                                        ? Colors.white
-                                                        : isToday
-                                                            ? AppColors.primary
-                                                            : c.text,
-                                                  ),
-                                                ),
-                                              ],
+                                              ),
                                             ),
                                           ),
                                         );
@@ -532,60 +563,70 @@ class _ActivitiesListViewState extends ConsumerState<ActivitiesListView> {
                                 child: Column(
                                   mainAxisAlignment: MainAxisAlignment.center,
                                   children: [
-                                    GestureDetector(
-                                      onTap: () => _openDatePicker(context),
-                                      child: Container(
-                                        width: 44,
-                                        height: 44,
-                                        decoration: BoxDecoration(
-                                          color: AppColors.primaryLight,
+                                    SizedBox(
+                                      width: 44,
+                                      height: 44,
+                                      child: Material(
+                                        color: AppColors.primaryLight,
+                                        shape: RoundedRectangleBorder(
                                           borderRadius:
                                               BorderRadius.circular(12),
-                                          border: Border.all(
+                                          side: BorderSide(
                                             color: AppColors.primary
                                                 .withValues(alpha: 0.25),
                                           ),
                                         ),
-                                        child: Center(
-                                          child: HugeIcon(
-                                            icon: HugeIcons
-                                                .strokeRoundedCalendar02,
-                                            size: 20,
-                                            color: AppColors.primary,
+                                        child: InkWell(
+                                          borderRadius:
+                                              BorderRadius.circular(12),
+                                          onTap: () => _openDatePicker(context),
+                                          child: const Center(
+                                            child: HugeIcon(
+                                              icon: HugeIcons
+                                                  .strokeRoundedCalendar02,
+                                              size: 20,
+                                              color: AppColors.primary,
+                                            ),
                                           ),
                                         ),
                                       ),
                                     ),
                                     if (_showTodayButton) ...[
                                       const SizedBox(height: 4),
-                                      GestureDetector(
-                                        onTap: () {
-                                          final now = DateTime.now();
-                                          setState(() {
-                                            _selectedDate = DateTime(
-                                                now.year, now.month, now.day);
-                                            _showTodayButton = false;
-                                            _visibleMonth =
-                                                DateTime(now.year, now.month);
-                                          });
-                                          _scrollToToday(animate: true);
-                                        },
-                                        child: Container(
-                                          width: 60,
-                                          height: 44,
-                                          decoration: BoxDecoration(
-                                            color: AppColors.primary,
+                                      SizedBox(
+                                        width: 60,
+                                        height: 44,
+                                        child: Material(
+                                          color: AppColors.primary,
+                                          borderRadius:
+                                              BorderRadius.circular(22),
+                                          child: InkWell(
                                             borderRadius:
                                                 BorderRadius.circular(22),
-                                          ),
-                                          child: Center(
-                                            child: Text(
-                                              'activities.list.today_label'
-                                                  .tr(),
-                                              style: const TextStyle(
-                                                color: Colors.white,
-                                                fontSize: 11,
-                                                fontWeight: FontWeight.w600,
+                                            splashColor: Colors.white
+                                                .withValues(alpha: 0.2),
+                                            onTap: () {
+                                              final now = DateTime.now();
+                                              setState(() {
+                                                _selectedDate = DateTime(
+                                                    now.year,
+                                                    now.month,
+                                                    now.day);
+                                                _showTodayButton = false;
+                                                _visibleMonth = DateTime(
+                                                    now.year, now.month);
+                                              });
+                                              _scrollToToday(animate: true);
+                                            },
+                                            child: Center(
+                                              child: Text(
+                                                'activities.list.today_label'
+                                                    .tr(),
+                                                style: const TextStyle(
+                                                  color: Colors.white,
+                                                  fontSize: 11,
+                                                  fontWeight: FontWeight.w600,
+                                                ),
                                               ),
                                             ),
                                           ),
@@ -926,11 +967,12 @@ class _ActivityFilterChip extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return GestureDetector(
-      onTap: onTap,
+    return Semantics(
+      label: label,
+      button: true,
+      selected: isSelected,
       child: AnimatedContainer(
         duration: const Duration(milliseconds: 200),
-        padding: const EdgeInsets.symmetric(horizontal: 16),
         decoration: BoxDecoration(
           color: isSelected ? AppColors.primary : c.surface,
           borderRadius: BorderRadius.circular(20),
@@ -938,13 +980,27 @@ class _ActivityFilterChip extends StatelessWidget {
             color: isSelected ? AppColors.primary : c.border,
           ),
         ),
-        alignment: Alignment.center,
-        child: Text(
-          label,
-          style: TextStyle(
-            fontSize: 13,
-            fontWeight: FontWeight.w600,
-            color: isSelected ? Colors.white : c.textSecondary,
+        child: Material(
+          color: Colors.transparent,
+          child: InkWell(
+            borderRadius: BorderRadius.circular(20),
+            splashColor:
+                isSelected ? Colors.white.withValues(alpha: 0.2) : null,
+            onTap: onTap,
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16),
+              child: Align(
+                alignment: Alignment.center,
+                child: Text(
+                  label,
+                  style: TextStyle(
+                    fontSize: 13,
+                    fontWeight: FontWeight.w600,
+                    color: isSelected ? Colors.white : c.textSecondary,
+                  ),
+                ),
+              ),
+            ),
           ),
         ),
       ),

--- a/lib/features/members/presentation/views/members_view.dart
+++ b/lib/features/members/presentation/views/members_view.dart
@@ -102,46 +102,51 @@ class _MembersViewState extends ConsumerState<MembersView>
                   const SizedBox(width: 12),
                   Text(
                     'members.view.title'.tr(),
-                    style: TextStyle(
-                      fontSize: 22,
-                      fontWeight: FontWeight.w700,
-                      color: c.text,
-                      letterSpacing: -0.4,
-                    ),
+                    style: Theme.of(context)
+                        .textTheme
+                        .headlineSmall
+                        ?.copyWith(color: c.text),
                   ),
                   const Spacer(),
                   // Refresh button
-                  GestureDetector(
-                    onTap: membersAsync.isLoading
-                        ? null
-                        : () {
-                            ref
-                                .read(membersNotifierProvider.notifier)
-                                .refresh();
-                          },
-                    child: Container(
-                      width: 44,
-                      height: 44,
-                      decoration: BoxDecoration(
-                        color: c.surface,
+                  SizedBox(
+                    width: 44,
+                    height: 44,
+                    child: Material(
+                      color: c.surface,
+                      shape: RoundedRectangleBorder(
                         borderRadius: BorderRadius.circular(10),
-                        border: Border.all(color: c.border),
+                        side: BorderSide(color: c.border),
                       ),
-                      child: Center(
-                        child: membersAsync.isLoading
-                            ? SizedBox(
-                                width: 18,
-                                height: 18,
-                                child: CircularProgressIndicator(
-                                  strokeWidth: 2,
-                                  color: c.textTertiary,
-                                ),
-                              )
-                            : HugeIcon(
-                                icon: HugeIcons.strokeRoundedRefresh,
-                                color: c.textTertiary,
-                                size: 18,
-                              ),
+                      child: InkWell(
+                        borderRadius: BorderRadius.circular(10),
+                        onTap: membersAsync.isLoading
+                            ? null
+                            : () {
+                                ref
+                                    .read(membersNotifierProvider.notifier)
+                                    .refresh();
+                              },
+                        child: Semantics(
+                          label: 'common.retry'.tr(),
+                          button: true,
+                          child: Center(
+                            child: membersAsync.isLoading
+                                ? SizedBox(
+                                    width: 18,
+                                    height: 18,
+                                    child: CircularProgressIndicator(
+                                      strokeWidth: 2,
+                                      color: c.textTertiary,
+                                    ),
+                                  )
+                                : HugeIcon(
+                                    icon: HugeIcons.strokeRoundedRefresh,
+                                    color: c.textTertiary,
+                                    size: 18,
+                                  ),
+                          ),
+                        ),
                       ),
                     ),
                   ),
@@ -906,25 +911,33 @@ class _StatusFilterChip extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final c = context.sac;
-    return GestureDetector(
-      onTap: onTap,
-      child: Container(
-        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
-        decoration: BoxDecoration(
-          color: isActive
-              ? AppColors.primary.withValues(alpha: 0.12)
-              : c.surfaceVariant,
+    return Semantics(
+      label: label,
+      button: true,
+      selected: isActive,
+      child: Material(
+        color: isActive
+            ? AppColors.primary.withValues(alpha: 0.12)
+            : c.surfaceVariant,
+        shape: RoundedRectangleBorder(
           borderRadius: BorderRadius.circular(20),
-          border: Border.all(
+          side: BorderSide(
             color: isActive ? AppColors.primaryLight : c.border,
           ),
         ),
-        child: Text(
-          label,
-          style: TextStyle(
-            fontSize: 12,
-            fontWeight: isActive ? FontWeight.w600 : FontWeight.w500,
-            color: isActive ? AppColors.primary : c.textSecondary,
+        child: InkWell(
+          borderRadius: BorderRadius.circular(20),
+          onTap: onTap,
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+            child: Text(
+              label,
+              style: TextStyle(
+                fontSize: 12,
+                fontWeight: isActive ? FontWeight.w600 : FontWeight.w500,
+                color: isActive ? AppColors.primary : c.textSecondary,
+              ),
+            ),
           ),
         ),
       ),

--- a/lib/features/profile/presentation/views/profile_view.dart
+++ b/lib/features/profile/presentation/views/profile_view.dart
@@ -341,12 +341,11 @@ class _ProfileScrollBody extends StatelessWidget {
                       const SizedBox(width: 4),
                       Text(
                         'profile.view.user_profile'.tr(),
-                        style: TextStyle(
-                          fontSize: 16,
-                          fontWeight: FontWeight.w700,
-                          color: c.text,
-                          letterSpacing: -0.2,
-                        ),
+                        style:
+                            Theme.of(context).textTheme.titleMedium?.copyWith(
+                                  fontWeight: FontWeight.w700,
+                                  color: c.text,
+                                ),
                         overflow: TextOverflow.ellipsis,
                       ),
                     ],
@@ -494,23 +493,28 @@ class _ProfileScrollBody extends StatelessWidget {
                 crossAxisAlignment: CrossAxisAlignment.center,
                 children: [
                   _SectionLabel(label: 'profile.view.section_my_classes'.tr()),
-                  GestureDetector(
-                    onTap: onRefreshClasses,
-                    child: Container(
-                      width: 32,
-                      height: 32,
-                      decoration: BoxDecoration(
-                        color: c.surface,
+                  SizedBox(
+                    width: 32,
+                    height: 32,
+                    child: Material(
+                      color: c.surface,
+                      shape: RoundedRectangleBorder(
                         borderRadius: BorderRadius.circular(8),
-                        border: Border.all(
-                          color: c.border,
-                        ),
+                        side: BorderSide(color: c.border),
                       ),
-                      child: Center(
-                        child: HugeIcon(
-                          icon: HugeIcons.strokeRoundedRefresh,
-                          color: c.textTertiary,
-                          size: 16,
+                      child: InkWell(
+                        borderRadius: BorderRadius.circular(8),
+                        onTap: onRefreshClasses,
+                        child: Semantics(
+                          label: 'common.retry'.tr(),
+                          button: true,
+                          child: Center(
+                            child: HugeIcon(
+                              icon: HugeIcons.strokeRoundedRefresh,
+                              color: c.textTertiary,
+                              size: 16,
+                            ),
+                          ),
                         ),
                       ),
                     ),
@@ -535,48 +539,60 @@ class _ProfileScrollBody extends StatelessWidget {
                   Row(
                     children: [
                       // Add honor button
-                      GestureDetector(
-                        onTap: () {
-                          context.push(RouteNames.homeHonors);
-                        },
-                        child: Container(
-                          width: 32,
-                          height: 32,
-                          decoration: BoxDecoration(
-                            color: AppColors.sacBlue.withAlpha(20),
+                      SizedBox(
+                        width: 32,
+                        height: 32,
+                        child: Material(
+                          color: AppColors.sacBlue.withAlpha(20),
+                          shape: RoundedRectangleBorder(
                             borderRadius: BorderRadius.circular(8),
-                            border: Border.all(
+                            side: BorderSide(
                               color: AppColors.sacBlue.withAlpha(40),
                             ),
                           ),
-                          child: const Center(
-                            child: HugeIcon(
-                              icon: HugeIcons.strokeRoundedAdd01,
-                              color: AppColors.sacBlue,
-                              size: 18,
+                          child: InkWell(
+                            borderRadius: BorderRadius.circular(8),
+                            onTap: () {
+                              context.push(RouteNames.homeHonors);
+                            },
+                            child: Semantics(
+                              label: 'profile.view.section_honors'.tr(),
+                              button: true,
+                              child: const Center(
+                                child: HugeIcon(
+                                  icon: HugeIcons.strokeRoundedAdd01,
+                                  color: AppColors.sacBlue,
+                                  size: 18,
+                                ),
+                              ),
                             ),
                           ),
                         ),
                       ),
                       const SizedBox(width: 8),
                       // Refresh button
-                      GestureDetector(
-                        onTap: onRefreshHonors,
-                        child: Container(
-                          width: 32,
-                          height: 32,
-                          decoration: BoxDecoration(
-                            color: c.surface,
+                      SizedBox(
+                        width: 32,
+                        height: 32,
+                        child: Material(
+                          color: c.surface,
+                          shape: RoundedRectangleBorder(
                             borderRadius: BorderRadius.circular(8),
-                            border: Border.all(
-                              color: c.border,
-                            ),
+                            side: BorderSide(color: c.border),
                           ),
-                          child: Center(
-                            child: HugeIcon(
-                              icon: HugeIcons.strokeRoundedRefresh,
-                              color: c.textTertiary,
-                              size: 16,
+                          child: InkWell(
+                            borderRadius: BorderRadius.circular(8),
+                            onTap: onRefreshHonors,
+                            child: Semantics(
+                              label: 'common.retry'.tr(),
+                              button: true,
+                              child: Center(
+                                child: HugeIcon(
+                                  icon: HugeIcons.strokeRoundedRefresh,
+                                  color: c.textTertiary,
+                                  size: 16,
+                                ),
+                              ),
                             ),
                           ),
                         ),
@@ -825,8 +841,6 @@ class _ProfileHeaderCard extends StatelessWidget {
                                 ?.copyWith(
                                   fontWeight: FontWeight.w700,
                                   color: c.text,
-                                  letterSpacing: -0.3,
-                                  fontSize: 20,
                                 ),
                             maxLines: 2,
                             overflow: TextOverflow.ellipsis,
@@ -880,111 +894,116 @@ class _ProfileHeaderCard extends StatelessWidget {
                     const SizedBox(width: 16),
 
                     // ── Right: circular avatar with camera button ──
-                    GestureDetector(
-                      onTap: onEditPhoto,
-                      child: Stack(
-                        clipBehavior: Clip.none,
-                        children: [
-                          Container(
-                            decoration: BoxDecoration(
-                              shape: BoxShape.circle,
-                              border: Border.all(
-                                color: AppColors.primaryLight,
-                                width: 3,
-                              ),
-                              boxShadow: [
-                                BoxShadow(
-                                  color:
-                                      AppColors.primary.withValues(alpha: 0.15),
-                                  blurRadius: 16,
-                                  offset: const Offset(0, 4),
+                    Semantics(
+                      label: 'profile.view.crop_photo_title'.tr(),
+                      button: true,
+                      child: InkWell(
+                        customBorder: const CircleBorder(),
+                        onTap: onEditPhoto,
+                        child: Stack(
+                          clipBehavior: Clip.none,
+                          children: [
+                            Container(
+                              decoration: BoxDecoration(
+                                shape: BoxShape.circle,
+                                border: Border.all(
+                                  color: AppColors.primaryLight,
+                                  width: 3,
                                 ),
-                              ],
-                            ),
-                            child: Stack(
-                              alignment: Alignment.center,
-                              children: [
-                                ClipOval(
-                                  child: SizedBox(
-                                    width: avatarRadius * 2,
-                                    height: avatarRadius * 2,
-                                    child: avatar != null
-                                        ? CachedNetworkImage(
-                                            imageUrl: avatar!,
-                                            fit: BoxFit.cover,
-                                            memCacheWidth: 176,
-                                            memCacheHeight: 176,
-                                            placeholder: (_, __) =>
-                                                _AvatarInitials(
-                                              name: name,
-                                              fontSize: fallbackFontSize,
-                                            ),
-                                            errorWidget: (_, __, ___) =>
-                                                _AvatarInitials(
-                                              name: name,
-                                              fontSize: fallbackFontSize,
-                                            ),
-                                          )
-                                        : _AvatarInitials(
-                                            name: name,
-                                            fontSize: fallbackFontSize,
-                                          ),
+                                boxShadow: [
+                                  BoxShadow(
+                                    color: AppColors.primary
+                                        .withValues(alpha: 0.15),
+                                    blurRadius: 16,
+                                    offset: const Offset(0, 4),
                                   ),
-                                ),
-                                if (isUploadingPhoto)
-                                  Container(
-                                    width: avatarRadius * 2,
-                                    height: avatarRadius * 2,
-                                    decoration: const BoxDecoration(
-                                      shape: BoxShape.circle,
-                                      color: Color(0x80000000),
+                                ],
+                              ),
+                              child: Stack(
+                                alignment: Alignment.center,
+                                children: [
+                                  ClipOval(
+                                    child: SizedBox(
+                                      width: avatarRadius * 2,
+                                      height: avatarRadius * 2,
+                                      child: avatar != null
+                                          ? CachedNetworkImage(
+                                              imageUrl: avatar!,
+                                              fit: BoxFit.cover,
+                                              memCacheWidth: 176,
+                                              memCacheHeight: 176,
+                                              placeholder: (_, __) =>
+                                                  _AvatarInitials(
+                                                name: name,
+                                                fontSize: fallbackFontSize,
+                                              ),
+                                              errorWidget: (_, __, ___) =>
+                                                  _AvatarInitials(
+                                                name: name,
+                                                fontSize: fallbackFontSize,
+                                              ),
+                                            )
+                                          : _AvatarInitials(
+                                              name: name,
+                                              fontSize: fallbackFontSize,
+                                            ),
                                     ),
-                                    child: const Center(
-                                      child: SizedBox(
-                                        width: 24,
-                                        height: 24,
-                                        child: CircularProgressIndicator(
-                                          color: Colors.white,
-                                          strokeWidth: 2.5,
+                                  ),
+                                  if (isUploadingPhoto)
+                                    Container(
+                                      width: avatarRadius * 2,
+                                      height: avatarRadius * 2,
+                                      decoration: const BoxDecoration(
+                                        shape: BoxShape.circle,
+                                        color: Color(0x80000000),
+                                      ),
+                                      child: const Center(
+                                        child: SizedBox(
+                                          width: 24,
+                                          height: 24,
+                                          child: CircularProgressIndicator(
+                                            color: Colors.white,
+                                            strokeWidth: 2.5,
+                                          ),
                                         ),
                                       ),
                                     ),
-                                  ),
-                              ],
+                                ],
+                              ),
                             ),
-                          ),
-                          if (!isUploadingPhoto)
-                            Positioned(
-                              bottom: 2,
-                              right: 2,
-                              child: Container(
-                                width: 28,
-                                height: 28,
-                                decoration: BoxDecoration(
-                                  color: c.background,
-                                  shape: BoxShape.circle,
-                                  border: Border.all(
-                                    color: c.border,
-                                    width: 1.5,
-                                  ),
-                                  boxShadow: [
-                                    BoxShadow(
-                                      color: context.sac.shadow,
-                                      blurRadius: 4,
-                                      offset: const Offset(0, 2),
+                            if (!isUploadingPhoto)
+                              Positioned(
+                                bottom: 2,
+                                right: 2,
+                                child: Container(
+                                  width: 28,
+                                  height: 28,
+                                  decoration: BoxDecoration(
+                                    color: c.background,
+                                    shape: BoxShape.circle,
+                                    border: Border.all(
+                                      color: c.border,
+                                      width: 1.5,
                                     ),
-                                  ],
-                                ),
-                                child: Center(
-                                  child: HugeIcon(
-                                    icon: HugeIcons.strokeRoundedCamera01,
-                                    color: c.textSecondary,
-                                    size: 14,
+                                    boxShadow: [
+                                      BoxShadow(
+                                        color: context.sac.shadow,
+                                        blurRadius: 4,
+                                        offset: const Offset(0, 2),
+                                      ),
+                                    ],
+                                  ),
+                                  child: Center(
+                                    child: HugeIcon(
+                                      icon: HugeIcons.strokeRoundedCamera01,
+                                      color: c.textSecondary,
+                                      size: 14,
+                                    ),
                                   ),
                                 ),
                               ),
-                            ),
-                        ],
+                          ],
+                        ),
                       ),
                     ),
                   ],


### PR DESCRIPTION
## Summary

- **GestureDetector → Material+InkWell** across `members_view`, `activities_list_view`, and `profile_view`: all button-like containers now produce ripple feedback, support focus rings, and carry proper `Semantics(button: true)` annotations
- **Typography collapsed**: ad-hoc `TextStyle(fontSize, fontWeight, letterSpacing)` overrides replaced with `Theme.of(context).textTheme.<role>.copyWith(color)` — drives the theme scale directly
- **Avatar tap** in profile header converted to `InkWell(customBorder: CircleBorder())` preserving the non-clipping `Stack` structure for the camera badge overlay
- **Touch targets preserved**: all 44dp buttons remain 44dp; 32dp icon buttons in profile section headers stay 32dp (pre-existing design decision)
- **No new l10n keys**: `Semantics` labels reuse existing keys (`common.retry`, `profile.view.crop_photo_title`, `activities.list.today_label`, etc.)

## Widgets changed

| File | GestureDetectors replaced | Typography overrides collapsed |
|------|--------------------------|-------------------------------|
| `members_view.dart` | 2 (refresh, `_StatusFilterChip`) | 1 (title `headlineSmall`) |
| `activities_list_view.dart` | 6 (add, toggle, date items, cal picker, today pill, `_ActivityFilterChip`) | 0 (already on theme roles) |
| `profile_view.dart` | 4 (classes refresh, honors add, honors refresh, avatar) | 2 (app bar title `titleMedium`, header name `titleLarge`) |

## Test plan

- [x] `flutter analyze` — no issues
- [x] `flutter test` — 367/367 passed
- [ ] Manual smoke: tap ripple visible on all converted buttons (iOS + Android)
- [ ] TalkBack/VoiceOver: filter chips announce label + selected state; refresh buttons announce via Semantics label
- [ ] Today pill in date strip still navigates and collapses correctly
- [ ] Avatar tap still opens photo picker; camera badge overlay still renders outside clip bounds