### PR TITLE
chore(test): add integration_test package + persona-nav S-15 sample

### DIFF
--- a/integration_test/README.md
+++ b/integration_test/README.md
@@ -1,0 +1,43 @@
+# Integration Tests
+
+This directory contains Flutter integration tests that exercise the full widget and
+provider graph in a near-production context, using `IntegrationTestWidgetsFlutterBinding`.
+
+## What is covered
+
+- `persona_nav_context_switch_test.dart` — S-15 acceptance scenario:
+  boots as director (Miembros shell), then simulates a context switch to
+  coordinator; verifies that `personaNavSlotsProvider` rebuilds and the nav
+  bar swaps from director slots to coordinator slots (Hub first, branchIndex 0–4).
+
+## How to run
+
+**Headless (flutter-tester VM, no device required):**
+
+```bash
+flutter test --device-id flutter-tester integration_test/persona_nav_context_switch_test.dart
+```
+
+**Full integration suite:**
+
+```bash
+flutter test --device-id flutter-tester integration_test/
+```
+
+**On a real device or simulator (full drive mode):**
+
+```bash
+flutter drive \
+  --driver=test_driver/integration_test.dart \
+  --target=integration_test/persona_nav_context_switch_test.dart
+```
+
+## Headless execution note
+
+Flutter 3.x treats any file under `integration_test/` as a device test when
+`flutter test` is invoked without `--device-id`. Passing `--device-id flutter-tester`
+explicitly selects the VM-based host runner and does not require a connected device.
+
+The tests in this directory do not invoke platform channels, so `flutter-tester`
+is sufficient. A physical device or simulator is only needed for future tests that
+add native interactions (camera, biometrics, etc.).

--- a/integration_test/persona_nav_context_switch_test.dart
+++ b/integration_test/persona_nav_context_switch_test.dart
@@ -1,0 +1,198 @@
+/// S-15 integration test: persona-nav context switch triggers shell swap.
+///
+/// Acceptance scenario (S-15, PR-4 verify report):
+///   Boot as director → main shell renders director nav slots (Miembros first).
+///   Switch activeAssignmentId to coordinator assignment → currentPersonaProvider
+///   resolves to Persona.coordinador → nav slots rebuild to coordinator config
+///   (Hub first, branchIndex 0–4).
+///
+/// Architecture note:
+///   This test exercises the live Riverpod provider graph: authNotifierProvider
+///   → currentPersonaProvider → personaNavSlotsProvider. The widget layer is a
+///   _TestNavShell that mirrors the NavigationBar build path used in the real
+///   _MainShell and _CoordinatorShell (same pattern as existing widget tests).
+///
+/// Headless execution:
+///   Runs with IntegrationTestWidgetsFlutterBinding in pure host-mode.
+///   No real device is required. No platform channels are invoked.
+///   Run with: flutter test integration_test/persona_nav_context_switch_test.dart
+library;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:sacdia_app/core/persona/index.dart';
+import 'package:sacdia_app/features/auth/domain/entities/authorization_snapshot.dart';
+import 'package:sacdia_app/features/auth/domain/entities/user_entity.dart';
+import 'package:sacdia_app/features/auth/presentation/providers/auth_providers.dart';
+import 'package:sacdia_app/features/notifications/presentation/providers/unread_notifications_count_provider.dart';
+
+// ── Fake notifiers ────────────────────────────────────────────────────────────
+
+/// Overridable AuthNotifier that exposes a [setUser] mutator so the test can
+/// simulate a context switch without touching real secure storage or network.
+class _MutableAuthNotifier extends AuthNotifier {
+  UserEntity? _user;
+
+  _MutableAuthNotifier(this._user);
+
+  @override
+  Future<UserEntity?> build() async => _user;
+
+  /// Simulate a persona/context switch by replacing the user snapshot and
+  /// re-emitting. Mirrors the effect of AuthNotifier.switchContext() which
+  /// builds a new UserEntity with an updated activeAssignmentId.
+  void setUser(UserEntity? user) {
+    _user = user;
+    state = AsyncData(user);
+  }
+}
+
+class _FakeCountNotifier extends UnreadNotificationsCountNotifier {
+  @override
+  int build() => 0;
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/// Builds a [UserEntity] with a single [AuthorizationGrant] for [roleName].
+UserEntity _userWith(String roleName, {String assignmentId = 'a1'}) {
+  return UserEntity(
+    id: 'test-$roleName',
+    email: 'test@sacdia.app',
+    postRegisterComplete: true,
+    authorization: AuthorizationSnapshot(
+      clubAssignments: [
+        AuthorizationGrant(
+          assignmentId: assignmentId,
+          roleName: roleName,
+          status: 'active',
+        ),
+      ],
+      activeAssignmentId: assignmentId,
+    ),
+  );
+}
+
+/// Mirrors the NavigationBar portion of _MainShell / _CoordinatorShell.
+///
+/// Reads [personaNavSlotsProvider] — the same provider the production shells
+/// consume — so slot rebuilds are exercised through the live provider graph.
+/// Uses raw [NavSlot.labelKey] strings as labels (no locale setup needed).
+class _TestNavShell extends ConsumerWidget {
+  const _TestNavShell();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final slots = ref.watch(personaNavSlotsProvider);
+
+    return Scaffold(
+      body: const SizedBox.shrink(),
+      bottomNavigationBar: NavigationBar(
+        selectedIndex: 0,
+        onDestinationSelected: (_) {},
+        destinations: slots
+            .map(
+              (slot) => NavigationDestination(
+                icon: NavBadge(
+                  source: slot.badgeSource,
+                  child: const Icon(Icons.circle),
+                ),
+                selectedIcon: NavBadge(
+                  source: slot.badgeSource,
+                  child: const Icon(Icons.circle),
+                ),
+                label: slot.labelKey,
+              ),
+            )
+            .toList(),
+      ),
+    );
+  }
+}
+
+// ── Test entry point ──────────────────────────────────────────────────────────
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  group('S-15: persona-nav context switch — shell swap (integration)', () {
+    late _MutableAuthNotifier authNotifier;
+
+    setUp(() {
+      authNotifier = _MutableAuthNotifier(_userWith('director'));
+    });
+
+    testWidgets(
+      'director nav → coordinator nav on activeAssignmentId switch',
+      (tester) async {
+        // ── Phase 1: boot as director ─────────────────────────────────────
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              authNotifierProvider.overrideWith(() => authNotifier),
+              unreadNotificationsCountProvider.overrideWith(
+                () => _FakeCountNotifier(),
+              ),
+            ],
+            child: const MaterialApp(home: _TestNavShell()),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        // Director shell: first slot is Miembros (nav.members), 5 destinations.
+        expect(
+          find.byType(NavigationDestination),
+          findsNWidgets(5),
+          reason: 'Director nav must have exactly 5 slots (FR-2)',
+        );
+        expect(
+          find.text('nav.members'),
+          findsWidgets,
+          reason: 'Director first slot must be Miembros (nav.members)',
+        );
+        // Coordinator Hub label must NOT be visible in director shell.
+        expect(
+          find.text('nav.hub'),
+          findsNothing,
+          reason: 'Director shell must NOT show coordinator Hub slot',
+        );
+
+        // ── Phase 2: context switch to coordinator ────────────────────────
+        // Simulate AuthNotifier.switchContext(): emit a new UserEntity with
+        // coordinator role. currentPersonaProvider reacts → slots rebuild.
+        authNotifier.setUser(_userWith('coordinator', assignmentId: 'coord-1'));
+
+        // One pump propagates the state change through the provider graph.
+        // pumpAndSettle ensures all reactive rebuilds complete.
+        await tester.pump();
+        await tester.pumpAndSettle();
+
+        // Coordinator shell: 5 slots, first is Hub (nav.hub).
+        expect(
+          find.byType(NavigationDestination),
+          findsNWidgets(5),
+          reason: 'Coordinator nav must have exactly 5 slots (FR-2)',
+        );
+        expect(
+          find.text('nav.hub'),
+          findsWidgets,
+          reason: 'Coordinator first slot must be Hub (nav.hub) after switch',
+        );
+        // Miembros label must NOT be visible in coordinator shell.
+        expect(
+          find.text('nav.members'),
+          findsNothing,
+          reason: 'Coordinator shell must NOT show main-shell Miembros slot',
+        );
+
+        // Verify all 5 coordinator slot keys are present.
+        expect(find.text('nav.clubs'), findsWidgets);
+        expect(find.text('nav.reports'), findsWidgets);
+        expect(find.text('nav.activities'), findsWidgets);
+        expect(find.text('nav.profile'), findsWidgets);
+      },
+    );
+  });
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -494,6 +494,11 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.4.1"
+  flutter_driver:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   flutter_lints:
     dependency: "direct dev"
     description:
@@ -621,6 +626,11 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.0"
+  fuchsia_remote_debug_protocol:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   gal:
     dependency: "direct main"
     description:
@@ -933,6 +943,11 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.0"
+  integration_test:
+    dependency: "direct dev"
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   intl:
     dependency: "direct main"
     description:
@@ -1706,6 +1721,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.1"
+  sync_http:
+    dependency: transitive
+    description:
+      name: sync_http
+      sha256: "7f0cd72eca000d2e026bcd6f990b81d0ca06022ef4e32fb257b30d3d1014a961"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.1"
   synchronized:
     dependency: transitive
     description:
@@ -1890,6 +1913,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.3"
+  webdriver:
+    dependency: transitive
+    description:
+      name: webdriver
+      sha256: "2f3a14ca026957870cfd9c635b83507e0e51d8091568e90129fbf805aba7cade"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.0"
   win32:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -94,7 +94,9 @@ dev_dependencies:
   sentry_dart_plugin: ^3.3.0
   flutter_test:
     sdk: flutter
-  
+  integration_test:
+    sdk: flutter
+
   # Linting
   flutter_lints: ^6.0.0
   


### PR DESCRIPTION
## Summary

- Adds `integration_test: sdk: flutter` dev dependency to `pubspec.yaml` (standard Flutter SDK package, no third-party dep)
- New `integration_test/persona_nav_context_switch_test.dart`: end-to-end S-15 scenario — boots as director, asserts Miembros shell, then mutates `authNotifierProvider` to coordinator and asserts coordinator shell renders with Hub slot first
- New `integration_test/README.md`: ~15-line doc with headless run command and drive-mode instructions

Addresses PR-4 verify report suggestion: S-15 (director → coordinator context switch triggers shell swap) was covered only at routing-unit-test level; this adds the full widget+provider-graph integration layer.

## Headless execution note

Flutter 3.x treats `integration_test/` files as device tests by default. The test runs headlessly via:

```bash
flutter test --device-id flutter-tester integration_test/persona_nav_context_switch_test.dart
```

No platform channels are invoked, so no real device is needed. This limitation and the command are documented in `integration_test/README.md`.

## Test plan

- [ ] `flutter pub get` succeeds (pubspec.lock updated)
- [ ] `flutter analyze` — no issues
- [ ] `flutter test --device-id flutter-tester integration_test/persona_nav_context_switch_test.dart` — 1 test passes
- [ ] `flutter test test/` — existing 371 tests all pass