### PR TITLE
refactor(theme): migrate legacy sac* namespace consumers to semantic tokens

### DIFF
--- a/lib/core/theme/club_type.dart
+++ b/lib/core/theme/club_type.dart
@@ -24,7 +24,7 @@ extension ClubColorX on ClubType {
       case ClubType.conquistadores:
         return AppColors.primary; // SACDIA Red
       case ClubType.aventureros:
-        return AppColors.sacBlue; // SACDIA Blue
+        return AppColors.info; // SACDIA Blue
       case ClubType.guiasMayores:
         return AppColors.secondary; // SACDIA Green
     }

--- a/lib/core/widgets/evidence_staging/upload_progress_sheet.dart
+++ b/lib/core/widgets/evidence_staging/upload_progress_sheet.dart
@@ -446,7 +446,7 @@ class _FileProgressRow extends StatelessWidget {
               width: 10,
               height: 10,
               decoration: const BoxDecoration(
-                color: AppColors.sacBlue,
+                color: AppColors.info,
                 shape: BoxShape.circle,
               ),
             ),
@@ -456,7 +456,7 @@ class _FileProgressRow extends StatelessWidget {
               style: const TextStyle(
                 fontSize: 12,
                 fontWeight: FontWeight.w600,
-                color: AppColors.sacBlue,
+                color: AppColors.info,
               ),
             ),
           ],

--- a/lib/core/widgets/section_switcher_sheet.dart
+++ b/lib/core/widgets/section_switcher_sheet.dart
@@ -49,7 +49,7 @@ Color _sectionColor(String? clubTypeName) {
   if (clubTypeName == null) return AppColors.primary;
   final lower = clubTypeName.toLowerCase();
   if (lower.contains('conquistador')) return AppColors.primary;
-  if (lower.contains('aventurer')) return AppColors.sacBlue;
+  if (lower.contains('aventurer')) return AppColors.info;
   if (lower.contains('guía') || lower.contains('guia')) {
     return AppColors.secondary;
   }

--- a/lib/features/activities/presentation/views/activity_detail_view.dart
+++ b/lib/features/activities/presentation/views/activity_detail_view.dart
@@ -72,7 +72,7 @@ class _ActivityDetailViewState extends ConsumerState<ActivityDetailView> {
   Color _typeColor(int type) {
     switch (type) {
       case 1:
-        return AppColors.sacBlue;
+        return AppColors.info;
       case 2:
         return AppColors.accent;
       case 3:
@@ -111,7 +111,7 @@ class _ActivityDetailViewState extends ConsumerState<ActivityDetailView> {
   Color _platformColor(int platform) {
     switch (platform) {
       case 1:
-        return AppColors.sacBlue;
+        return AppColors.info;
       case 2:
         return AppColors.accent;
       default:

--- a/lib/features/activities/presentation/widgets/activity_hero_section.dart
+++ b/lib/features/activities/presentation/widgets/activity_hero_section.dart
@@ -195,7 +195,7 @@ class ActivityHeroSection extends StatelessWidget {
 
   Widget _buildVideoFallback(BuildContext context) {
     return Container(
-      color: AppColors.sacBlue.withValues(alpha: 0.12),
+      color: AppColors.info.withValues(alpha: 0.12),
       child: Column(
         mainAxisAlignment: MainAxisAlignment.center,
         children: [
@@ -203,20 +203,20 @@ class ActivityHeroSection extends StatelessWidget {
             width: 56,
             height: 56,
             decoration: BoxDecoration(
-              color: AppColors.sacBlue.withValues(alpha: 0.18),
+              color: AppColors.info.withValues(alpha: 0.18),
               shape: BoxShape.circle,
             ),
             child: HugeIcon(
               icon: HugeIcons.strokeRoundedComputerVideoCall,
               size: 28,
-              color: AppColors.sacBlue,
+              color: AppColors.info,
             ),
           ),
           const SizedBox(height: 10),
           Text(
             'activities.widgets.virtual_fallback'.tr(),
             style: Theme.of(context).textTheme.titleSmall?.copyWith(
-                  color: AppColors.sacBlue,
+                  color: AppColors.info,
                   fontWeight: FontWeight.w600,
                 ),
           ),
@@ -296,7 +296,7 @@ class _JoinMeetChip extends StatelessWidget {
       child: Container(
         padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 8),
         decoration: BoxDecoration(
-          color: AppColors.sacBlue,
+          color: AppColors.info,
           borderRadius: BorderRadius.circular(20),
           boxShadow: [
             BoxShadow(

--- a/lib/features/activities/presentation/widgets/activity_virtual_banner.dart
+++ b/lib/features/activities/presentation/widgets/activity_virtual_banner.dart
@@ -52,8 +52,8 @@ class ActivityVirtualBanner extends StatelessWidget {
           begin: Alignment.topLeft,
           end: Alignment.bottomRight,
           colors: [
-            AppColors.sacBlue,
-            AppColors.sacBlue.withValues(alpha: 0.6),
+            AppColors.info,
+            AppColors.info.withValues(alpha: 0.6),
           ],
         ),
       ),

--- a/lib/features/classes/presentation/sheets/requirement_status_history_sheet.dart
+++ b/lib/features/classes/presentation/sheets/requirement_status_history_sheet.dart
@@ -160,7 +160,7 @@ class RequirementStatusHistorySheet extends StatelessWidget {
           label: 'classes.status.sent'.tr(),
           description: 'classes.status_history.sent_desc'.tr(),
           icon: HugeIcons.strokeRoundedSent,
-          color: AppColors.sacBlue,
+          color: AppColors.info,
           author: requirement.submittedByName,
           timestamp: requirement.submittedAt,
         ),

--- a/lib/features/classes/presentation/widgets/requirement_status_badge.dart
+++ b/lib/features/classes/presentation/widgets/requirement_status_badge.dart
@@ -88,7 +88,7 @@ class RequirementStatusBadge extends StatelessWidget {
       case RequirementStatus.pendiente:
         return AppColors.accent.withValues(alpha: 0.4);
       case RequirementStatus.enviado:
-        return AppColors.sacBlue.withValues(alpha: 0.4);
+        return AppColors.info.withValues(alpha: 0.4);
       case RequirementStatus.validado:
         return AppColors.secondary.withValues(alpha: 0.4);
       case RequirementStatus.rechazado:

--- a/lib/features/evidence_folder/presentation/sheets/evidence_status_history_sheet.dart
+++ b/lib/features/evidence_folder/presentation/sheets/evidence_status_history_sheet.dart
@@ -166,7 +166,7 @@ class EvidenceStatusHistorySheet extends StatelessWidget {
           label: 'evidence_folder.status.submitted'.tr(),
           description: 'evidence_folder.status_history.submitted_desc'.tr(),
           icon: HugeIcons.strokeRoundedSent,
-          color: AppColors.sacBlue,
+          color: AppColors.info,
           author: section.submittedByName,
           timestamp: section.submittedAt,
         ),

--- a/lib/features/evidence_folder/presentation/views/evidence_folder_view.dart
+++ b/lib/features/evidence_folder/presentation/views/evidence_folder_view.dart
@@ -110,7 +110,7 @@ class _FolderBodyState extends ConsumerState<_FolderBody> {
           TextButton(
             onPressed: () => Navigator.pop(ctx, true),
             style: TextButton.styleFrom(
-              foregroundColor: AppColors.sacBlue,
+              foregroundColor: AppColors.info,
             ),
             child: Text('evidence_folder.send'.tr()),
           ),
@@ -471,7 +471,7 @@ class _ProgressSummaryRow extends StatelessWidget {
           _StatPill(
             count: submitted,
             label: 'evidence_folder.stats.submitted'.tr(),
-            color: AppColors.sacBlue,
+            color: AppColors.info,
           ),
           const SizedBox(width: 8),
           _StatPill(

--- a/lib/features/evidence_folder/presentation/views/evidence_section_detail_view.dart
+++ b/lib/features/evidence_folder/presentation/views/evidence_section_detail_view.dart
@@ -103,7 +103,7 @@ class _EvidenceSectionDetailViewState
           title: Text(
             'evidence_folder.section_title'.tr(),
             style: Theme.of(context).textTheme.titleLarge?.copyWith(
-                fontWeight: FontWeight.w700, color: AppColors.sacRed),
+                fontWeight: FontWeight.w700, color: AppColors.primary),
             overflow: TextOverflow.ellipsis,
           ),
           backgroundColor: c.background,
@@ -576,7 +576,7 @@ class _EvidenceStatusChip extends StatelessWidget {
       case EvidenceSectionStatus.pending:
         return AppColors.accent.withValues(alpha: 0.4);
       case EvidenceSectionStatus.submitted:
-        return AppColors.sacBlue.withValues(alpha: 0.4);
+        return AppColors.info.withValues(alpha: 0.4);
       case EvidenceSectionStatus.preapprovedLf:
         return AppColors.accent.withValues(alpha: 0.5);
       case EvidenceSectionStatus.validated:
@@ -846,8 +846,7 @@ class _ReviewerNoteCalloutState extends State<_ReviewerNoteCallout> {
     // AppColors.statusInfoBg* que ya existen para el estado "enviado".
     final bgColor =
         isDark ? AppColors.statusInfoBgDark : AppColors.statusInfoBgLight;
-    final borderColor =
-        AppColors.sacBlue.withValues(alpha: isDark ? 0.3 : 0.35);
+    final borderColor = AppColors.info.withValues(alpha: isDark ? 0.3 : 0.35);
     final noteColor =
         isDark ? AppColors.statusInfoTextDark : AppColors.statusInfoText;
     final labelColor = isDark

--- a/lib/features/evidence_folder/presentation/widgets/section_card.dart
+++ b/lib/features/evidence_folder/presentation/widgets/section_card.dart
@@ -272,11 +272,11 @@ class _SubmitSectionButton extends StatelessWidget {
           child: Ink(
             decoration: BoxDecoration(
               color: isSubmitting
-                  ? AppColors.sacBlue.withValues(alpha: 0.08)
-                  : AppColors.sacBlue.withValues(alpha: 0.12),
+                  ? AppColors.info.withValues(alpha: 0.08)
+                  : AppColors.info.withValues(alpha: 0.12),
               borderRadius: BorderRadius.circular(10),
               border: Border.all(
-                color: AppColors.sacBlue.withValues(alpha: 0.35),
+                color: AppColors.info.withValues(alpha: 0.35),
               ),
             ),
             child: Padding(
@@ -291,7 +291,7 @@ class _SubmitSectionButton extends StatelessWidget {
                       child: CircularProgressIndicator(
                         strokeWidth: 2,
                         valueColor: AlwaysStoppedAnimation<Color>(
-                          AppColors.sacBlue,
+                          AppColors.info,
                         ),
                       ),
                     ),
@@ -301,14 +301,14 @@ class _SubmitSectionButton extends StatelessWidget {
                       style: TextStyle(
                         fontSize: 13,
                         fontWeight: FontWeight.w600,
-                        color: AppColors.sacBlue,
+                        color: AppColors.info,
                       ),
                     ),
                   ] else ...[
                     HugeIcon(
                       icon: HugeIcons.strokeRoundedSent,
                       size: 15,
-                      color: AppColors.sacBlue,
+                      color: AppColors.info,
                     ),
                     const SizedBox(width: 6),
                     Text(
@@ -316,7 +316,7 @@ class _SubmitSectionButton extends StatelessWidget {
                       style: TextStyle(
                         fontSize: 13,
                         fontWeight: FontWeight.w600,
-                        color: AppColors.sacBlue,
+                        color: AppColors.info,
                       ),
                     ),
                   ],

--- a/lib/features/evidence_folder/presentation/widgets/section_status_badge.dart
+++ b/lib/features/evidence_folder/presentation/widgets/section_status_badge.dart
@@ -88,7 +88,7 @@ class SectionStatusBadge extends StatelessWidget {
       case EvidenceSectionStatus.pending:
         return AppColors.accent.withValues(alpha: 0.4);
       case EvidenceSectionStatus.submitted:
-        return AppColors.sacBlue.withValues(alpha: 0.4);
+        return AppColors.info.withValues(alpha: 0.4);
       case EvidenceSectionStatus.preapprovedLf:
         return AppColors.accent.withValues(alpha: 0.5);
       case EvidenceSectionStatus.validated:

--- a/lib/features/evidence_folder/presentation/widgets/status_timeline.dart
+++ b/lib/features/evidence_folder/presentation/widgets/status_timeline.dart
@@ -74,7 +74,7 @@ class StatusTimeline extends StatelessWidget {
             currentStatus == EvidenceSectionStatus.rejected ||
             currentStatus == EvidenceSectionStatus.preapprovedLf,
         isActive: currentStatus == EvidenceSectionStatus.submitted,
-        activeColor: AppColors.sacBlue,
+        activeColor: AppColors.info,
       ),
       if (_isRejected)
         _TimelineStep(

--- a/lib/features/home/presentation/widgets/resources_section.dart
+++ b/lib/features/home/presentation/widgets/resources_section.dart
@@ -85,7 +85,7 @@ const _mockCategories = <ResourceCategory>[
   ResourceCategory(
     name: 'Manuales',
     fileCount: 8,
-    color: AppColors.sacBlue,
+    color: AppColors.info,
   ),
   ResourceCategory(
     name: 'Imágenes',
@@ -423,7 +423,7 @@ class _FileCard extends StatelessWidget {
       case ResourceType.pdf:
         return AppColors.primary;
       case ResourceType.document:
-        return AppColors.sacBlue;
+        return AppColors.info;
       case ResourceType.image:
         return AppColors.secondary;
       case ResourceType.audio:

--- a/lib/features/honors/domain/entities/user_honor.dart
+++ b/lib/features/honors/domain/entities/user_honor.dart
@@ -75,16 +75,16 @@ class UserHonor extends Equatable {
   Color get statusColor {
     switch (displayStatus) {
       case 'validado':
-        return AppColors.sacGreen;
+        return AppColors.success;
       case 'enviado':
-        return AppColors.sacYellow;
+        return AppColors.accent;
       case 'en_progreso':
       case 'rechazado':
-        return AppColors.sacRed;
+        return AppColors.error;
       case 'inscrito':
-        return AppColors.sacBlue;
+        return AppColors.info;
       default:
-        return AppColors.sacGrey;
+        return AppColors.pendingColor;
     }
   }
 

--- a/lib/features/honors/domain/utils/honor_category_colors.dart
+++ b/lib/features/honors/domain/utils/honor_category_colors.dart
@@ -40,7 +40,7 @@ const Map<String, Color> kCategoryColorByName = {
 };
 
 /// Resolves the category [Color] using [categoryId] as primary key and
-/// [categoryName] as fallback. Returns [AppColors.sacBlue] if neither matches.
+/// [categoryName] as fallback. Returns [AppColors.info] if neither matches.
 Color getCategoryColor({int? categoryId, String? categoryName}) {
   if (categoryId != null) {
     final color = kCategoryColorById[categoryId];
@@ -50,5 +50,5 @@ Color getCategoryColor({int? categoryId, String? categoryName}) {
     final color = kCategoryColorByName[categoryName];
     if (color != null) return color;
   }
-  return AppColors.sacBlue;
+  return AppColors.info;
 }

--- a/lib/features/honors/presentation/views/honor_completion_view.dart
+++ b/lib/features/honors/presentation/views/honor_completion_view.dart
@@ -97,7 +97,7 @@ class _ErrorScaffold extends StatelessWidget {
     return Scaffold(
       backgroundColor: Colors.white,
       appBar: AppBar(
-        backgroundColor: AppColors.sacGreen,
+        backgroundColor: AppColors.success,
         foregroundColor: Colors.white,
         elevation: 0,
       ),
@@ -108,7 +108,7 @@ class _ErrorScaffold extends StatelessWidget {
             const Icon(
               Icons.error_outline_rounded,
               size: 48,
-              color: AppColors.sacGreen,
+              color: AppColors.success,
             ),
             const SizedBox(height: 16),
             Text(
@@ -123,7 +123,7 @@ class _ErrorScaffold extends StatelessWidget {
               onPressed: () => context.pop(),
               child: Text(
                 'honors.completion.back'.tr(),
-                style: const TextStyle(color: AppColors.sacBlue, fontSize: 14),
+                style: const TextStyle(color: AppColors.info, fontSize: 14),
               ),
             ),
           ],
@@ -156,12 +156,12 @@ class _CompletionBody extends StatelessWidget {
           SliverAppBar(
             expandedHeight: 210,
             pinned: true,
-            backgroundColor: AppColors.sacGreen,
+            backgroundColor: AppColors.success,
             foregroundColor: Colors.white,
             elevation: 0,
             flexibleSpace: FlexibleSpaceBar(
               background: Container(
-                color: AppColors.sacGreen,
+                color: AppColors.success,
                 child: SafeArea(
                   child: Column(
                     mainAxisAlignment: MainAxisAlignment.center,
@@ -225,7 +225,7 @@ class _CompletionBody extends StatelessWidget {
                     style: const TextStyle(
                       fontSize: 18,
                       fontWeight: FontWeight.w800,
-                      color: AppColors.sacBlack,
+                      color: AppColors.lightText,
                     ),
                     textAlign: TextAlign.center,
                   ),
@@ -252,7 +252,7 @@ class _CompletionBody extends StatelessWidget {
                         context.pop();
                       },
                       style: FilledButton.styleFrom(
-                        backgroundColor: AppColors.sacBlue,
+                        backgroundColor: AppColors.info,
                         foregroundColor: Colors.white,
                         padding: const EdgeInsets.symmetric(vertical: 15),
                         shape: RoundedRectangleBorder(
@@ -338,7 +338,7 @@ class _HonorBadge extends StatelessWidget {
       width: 88,
       height: 88,
       decoration: const BoxDecoration(
-        color: AppColors.sacYellow,
+        color: AppColors.accent,
         shape: BoxShape.circle,
       ),
       child: _imageUrl != null
@@ -387,13 +387,13 @@ class _PillsRow extends StatelessWidget {
         if (skillLevel != null)
           _StatusPill(
             label: _skillLevelLabel(skillLevel),
-            color: AppColors.sacGreen,
+            color: AppColors.success,
           ),
 
         // Badge obtained pill (yellow tint) — always shown on completion
         _StatusPill(
           label: 'honors.completion.badge_obtained'.tr(),
-          color: AppColors.sacYellow,
+          color: AppColors.accent,
         ),
       ],
     );
@@ -456,7 +456,7 @@ class _StatsCard extends StatelessWidget {
             _StatItem(
               value: '${userHonor.evidenceCount}',
               label: 'honors.completion.stat_evidences'.tr(),
-              color: AppColors.sacBlue,
+              color: AppColors.info,
             ),
 
             // Divider
@@ -470,7 +470,7 @@ class _StatsCard extends StatelessWidget {
             _StatItem(
               value: DateFormat('d MMM', 'es').format(enrollmentDate),
               label: 'honors.completion.stat_enrollment'.tr(),
-              color: AppColors.sacRed,
+              color: AppColors.error,
             ),
 
             // Divider
@@ -484,7 +484,7 @@ class _StatsCard extends StatelessWidget {
             _StatItem(
               value: duration,
               label: 'honors.completion.stat_duration'.tr(),
-              color: AppColors.sacGreen,
+              color: AppColors.success,
             ),
           ],
         ),

--- a/lib/features/honors/presentation/views/honor_detail_view.dart
+++ b/lib/features/honors/presentation/views/honor_detail_view.dart
@@ -108,7 +108,7 @@ class _LoadingScaffold extends StatelessWidget {
         children: [
           Container(
             height: _kHeroHeight,
-            color: AppColors.sacBlack.withValues(alpha: 0.85),
+            color: AppColors.lightText.withValues(alpha: 0.85),
             child: const SafeArea(
               child: Center(
                 child: CircularProgressIndicator(
@@ -137,7 +137,7 @@ class _ErrorScaffold extends StatelessWidget {
     return Scaffold(
       backgroundColor: context.sac.background,
       appBar: AppBar(
-        backgroundColor: AppColors.sacBlack,
+        backgroundColor: AppColors.lightText,
         foregroundColor: Colors.white,
         elevation: 0,
       ),
@@ -156,7 +156,7 @@ class _ErrorScaffold extends StatelessWidget {
               onPressed: onRetry,
               child: Text(
                 'honors.catalog.retry'.tr(),
-                style: const TextStyle(color: AppColors.sacBlue, fontSize: 14),
+                style: const TextStyle(color: AppColors.info, fontSize: 14),
               ),
             ),
           ],
@@ -555,14 +555,14 @@ class _BadgeImage extends StatelessWidget {
         errorWidget: (_, __, ___) => HugeIcon(
           icon: HugeIcons.strokeRoundedAward01,
           size: 36,
-          color: AppColors.sacBlack,
+          color: AppColors.lightText,
         ),
       );
     }
     return HugeIcon(
       icon: HugeIcons.strokeRoundedAward01,
       size: 36,
-      color: AppColors.sacBlack,
+      color: AppColors.lightText,
     );
   }
 }
@@ -601,11 +601,11 @@ class _StatusBadgePill extends StatelessWidget {
   Color _bgColor() {
     switch (status) {
       case 'validado':
-        return AppColors.sacGreen;
+        return AppColors.success;
       case 'enviado':
-        return AppColors.sacYellow;
+        return AppColors.accent;
       case 'rechazado':
-        return AppColors.sacRed;
+        return AppColors.error;
       default:
         return Colors.white.withValues(alpha: 0.25);
     }
@@ -1004,7 +1004,7 @@ class _DescriptionSectionState extends State<_DescriptionSection> {
                     ? 'honors.detail.see_less'.tr()
                     : 'honors.detail.see_more'.tr(),
                 style: TextStyle(
-                  color: AppColors.sacBlue,
+                  color: AppColors.info,
                   fontSize: 13,
                   fontWeight: FontWeight.w600,
                 ),
@@ -1456,10 +1456,10 @@ class _RequirementPreviewItem extends StatelessWidget {
             decoration: BoxDecoration(
               shape: BoxShape.circle,
               color: completed
-                  ? AppColors.sacGreen.withValues(alpha: 0.12)
+                  ? AppColors.success.withValues(alpha: 0.12)
                   : context.sac.surfaceVariant,
               border: Border.all(
-                color: completed ? AppColors.sacGreen : context.sac.border,
+                color: completed ? AppColors.success : context.sac.border,
                 width: 1.5,
               ),
             ),
@@ -1467,7 +1467,7 @@ class _RequirementPreviewItem extends StatelessWidget {
                 ? const Icon(
                     Icons.check_rounded,
                     size: 13,
-                    color: AppColors.sacGreen,
+                    color: AppColors.success,
                   )
                 : null,
           ),
@@ -1966,21 +1966,21 @@ class _EnrolledCtaButton extends StatelessWidget {
         width: double.infinity,
         height: 48,
         decoration: BoxDecoration(
-          color: AppColors.sacYellow.withValues(alpha: 0.15),
+          color: AppColors.accent.withValues(alpha: 0.15),
           borderRadius: BorderRadius.circular(14),
-          border: Border.all(color: AppColors.sacYellow, width: 1.5),
+          border: Border.all(color: AppColors.accent, width: 1.5),
         ),
         alignment: Alignment.center,
         child: Row(
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
             const Icon(Icons.hourglass_top_rounded,
-                size: 16, color: AppColors.sacYellow),
+                size: 16, color: AppColors.accent),
             const SizedBox(width: 8),
             Text(
               'honors.detail.under_review_cta'.tr(),
               style: const TextStyle(
-                color: AppColors.sacYellow,
+                color: AppColors.accent,
                 fontSize: 16,
                 fontWeight: FontWeight.w700,
               ),
@@ -1996,21 +1996,21 @@ class _EnrolledCtaButton extends StatelessWidget {
         width: double.infinity,
         height: 48,
         decoration: BoxDecoration(
-          color: AppColors.sacGreen.withValues(alpha: 0.12),
+          color: AppColors.success.withValues(alpha: 0.12),
           borderRadius: BorderRadius.circular(14),
-          border: Border.all(color: AppColors.sacGreen, width: 1.5),
+          border: Border.all(color: AppColors.success, width: 1.5),
         ),
         alignment: Alignment.center,
         child: Row(
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
             const Icon(Icons.check_circle_rounded,
-                size: 18, color: AppColors.sacGreen),
+                size: 18, color: AppColors.success),
             const SizedBox(width: 8),
             Text(
               'honors.detail.completed_cta'.tr(),
               style: const TextStyle(
-                color: AppColors.sacGreen,
+                color: AppColors.success,
                 fontSize: 15,
                 fontWeight: FontWeight.w700,
               ),

--- a/lib/features/honors/presentation/views/honor_evidence_view.dart
+++ b/lib/features/honors/presentation/views/honor_evidence_view.dart
@@ -75,7 +75,7 @@ class _HonorEvidenceViewState extends ConsumerState<HonorEvidenceView> {
     // Surface any hard error from userHonorsProvider
     if (userHonorsAsync.hasError) {
       return Scaffold(
-        appBar: AppBar(backgroundColor: AppColors.sacRed),
+        appBar: AppBar(backgroundColor: AppColors.error),
         body: Center(child: Text('honors.evidence.error_load'.tr())),
       );
     }
@@ -139,7 +139,7 @@ class _HonorEvidenceViewState extends ConsumerState<HonorEvidenceView> {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
           content: Text('honors.evidence.sent_review'.tr()),
-          backgroundColor: AppColors.sacGreen,
+          backgroundColor: AppColors.success,
         ),
       );
     }
@@ -160,7 +160,7 @@ class _HonorEvidenceViewState extends ConsumerState<HonorEvidenceView> {
               width: 40,
               height: 4,
               decoration: BoxDecoration(
-                color: AppColors.sacGrey,
+                color: AppColors.pendingColor,
                 borderRadius: BorderRadius.circular(2),
               ),
             ),
@@ -168,7 +168,7 @@ class _HonorEvidenceViewState extends ConsumerState<HonorEvidenceView> {
             ListTile(
               leading: const Icon(
                 Icons.camera_alt_rounded,
-                color: AppColors.sacBlue,
+                color: AppColors.info,
               ),
               title: Text('honors.evidence.pick_camera'.tr()),
               onTap: () {
@@ -179,7 +179,7 @@ class _HonorEvidenceViewState extends ConsumerState<HonorEvidenceView> {
             ListTile(
               leading: const Icon(
                 Icons.photo_library_rounded,
-                color: AppColors.sacGreen,
+                color: AppColors.success,
               ),
               title: Text('honors.evidence.pick_gallery'.tr()),
               onTap: () {
@@ -190,7 +190,7 @@ class _HonorEvidenceViewState extends ConsumerState<HonorEvidenceView> {
             ListTile(
               leading: const Icon(
                 Icons.picture_as_pdf_rounded,
-                color: AppColors.sacRed,
+                color: AppColors.error,
               ),
               title: Text('honors.evidence.pick_pdf'.tr()),
               onTap: () {
@@ -262,7 +262,7 @@ class _HonorEvidenceViewState extends ConsumerState<HonorEvidenceView> {
           SnackBar(
             content: Text('honors.evidence.file_size_error'
                 .tr(namedArgs: {'name': fileName})),
-            backgroundColor: AppColors.sacRed,
+            backgroundColor: AppColors.error,
           ),
         );
       }
@@ -275,7 +275,7 @@ class _HonorEvidenceViewState extends ConsumerState<HonorEvidenceView> {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
             content: Text('honors.evidence.no_session'.tr()),
-            backgroundColor: AppColors.sacRed,
+            backgroundColor: AppColors.error,
           ),
         );
       }
@@ -304,7 +304,7 @@ class _HonorEvidenceViewState extends ConsumerState<HonorEvidenceView> {
                 : 'honors.evidence.upload_error'
                     .tr(namedArgs: {'name': fileName}),
           ),
-          backgroundColor: success ? AppColors.sacGreen : AppColors.sacRed,
+          backgroundColor: success ? AppColors.success : AppColors.error,
         ),
       );
     } catch (e) {
@@ -313,7 +313,7 @@ class _HonorEvidenceViewState extends ConsumerState<HonorEvidenceView> {
           SnackBar(
             content: Text('honors.evidence.upload_error'
                 .tr(namedArgs: {'name': fileName})),
-            backgroundColor: AppColors.sacRed,
+            backgroundColor: AppColors.error,
           ),
         );
       }
@@ -343,7 +343,7 @@ class _HonorEvidenceViewState extends ConsumerState<HonorEvidenceView> {
             content: Text(success
                 ? 'honors.evidence.delete_success'.tr()
                 : 'honors.evidence.delete_error'.tr()),
-            backgroundColor: success ? AppColors.sacGreen : AppColors.sacRed,
+            backgroundColor: success ? AppColors.success : AppColors.error,
           ),
         );
       }
@@ -352,7 +352,7 @@ class _HonorEvidenceViewState extends ConsumerState<HonorEvidenceView> {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
             content: Text('honors.evidence.delete_error'.tr()),
-            backgroundColor: AppColors.sacRed,
+            backgroundColor: AppColors.error,
           ),
         );
       }
@@ -381,7 +381,7 @@ class _HonorEvidenceViewState extends ConsumerState<HonorEvidenceView> {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
             content: Text('honors.evidence.open_error'.tr()),
-            backgroundColor: AppColors.sacRed,
+            backgroundColor: AppColors.error,
           ),
         );
       }
@@ -661,11 +661,11 @@ class _StatusPill extends StatelessWidget {
   Color _bgColor() {
     switch (status) {
       case 'validado':
-        return AppColors.sacGreen;
+        return AppColors.success;
       case 'enviado':
-        return AppColors.sacYellow;
+        return AppColors.accent;
       case 'rechazado':
-        return AppColors.sacRed;
+        return AppColors.error;
       case 'en_progreso':
         return Colors.white.withValues(alpha: 0.30);
       default:
@@ -1134,7 +1134,7 @@ class _EvidenceThumbnail extends StatelessWidget {
                         onDelete();
                       },
                       style: TextButton.styleFrom(
-                        foregroundColor: AppColors.sacRed,
+                        foregroundColor: AppColors.error,
                       ),
                       child: Text('honors.evidence.delete_confirm'.tr()),
                     ),
@@ -1151,13 +1151,13 @@ class _EvidenceThumbnail extends StatelessWidget {
             // File content
             if (_isPdf)
               Container(
-                color: AppColors.sacRed.withAlpha(20),
+                color: AppColors.error.withAlpha(20),
                 child: const Column(
                   mainAxisAlignment: MainAxisAlignment.center,
                   children: [
                     Icon(
                       Icons.picture_as_pdf_rounded,
-                      color: AppColors.sacRed,
+                      color: AppColors.error,
                       size: 28,
                     ),
                     SizedBox(height: 4),
@@ -1166,7 +1166,7 @@ class _EvidenceThumbnail extends StatelessWidget {
                       style: TextStyle(
                         fontSize: 10,
                         fontWeight: FontWeight.w600,
-                        color: AppColors.sacRed,
+                        color: AppColors.error,
                       ),
                     ),
                   ],
@@ -1209,7 +1209,7 @@ class _EvidenceThumbnail extends StatelessWidget {
                   width: 18,
                   height: 18,
                   decoration: const BoxDecoration(
-                    color: AppColors.sacGreen,
+                    color: AppColors.success,
                     shape: BoxShape.circle,
                   ),
                   child: const Icon(
@@ -1259,10 +1259,10 @@ class _RejectionCard extends StatelessWidget {
     return Container(
       padding: const EdgeInsets.all(14),
       decoration: BoxDecoration(
-        color: AppColors.sacRed.withValues(alpha: 0.07),
+        color: AppColors.error.withValues(alpha: 0.07),
         borderRadius: BorderRadius.circular(14),
         border: Border.all(
-          color: AppColors.sacRed.withValues(alpha: 0.25),
+          color: AppColors.error.withValues(alpha: 0.25),
           width: 1,
         ),
       ),
@@ -1271,7 +1271,7 @@ class _RejectionCard extends StatelessWidget {
         children: [
           const Icon(
             Icons.warning_amber_rounded,
-            color: AppColors.sacRed,
+            color: AppColors.error,
             size: 22,
           ),
           const SizedBox(width: 12),
@@ -1284,7 +1284,7 @@ class _RejectionCard extends StatelessWidget {
                   style: const TextStyle(
                     fontSize: 13,
                     fontWeight: FontWeight.w700,
-                    color: AppColors.sacRed,
+                    color: AppColors.error,
                   ),
                 ),
                 const SizedBox(height: 4),
@@ -1295,7 +1295,7 @@ class _RejectionCard extends StatelessWidget {
                   style: const TextStyle(
                     fontSize: 12,
                     height: 1.5,
-                    color: AppColors.sacRed,
+                    color: AppColors.error,
                   ),
                 ),
                 const SizedBox(height: 6),
@@ -1303,7 +1303,7 @@ class _RejectionCard extends StatelessWidget {
                   'honors.evidence.rejection_hint'.tr(),
                   style: TextStyle(
                     fontSize: 11,
-                    color: AppColors.sacRed.withValues(alpha: 0.70),
+                    color: AppColors.error.withValues(alpha: 0.70),
                     fontWeight: FontWeight.w500,
                   ),
                 ),
@@ -1383,7 +1383,7 @@ class _BottomCtaBar extends ConsumerWidget {
         return _CtaButton(
           label: 'honors.evidence.cta_sent'.tr(),
           icon: Icons.hourglass_top_rounded,
-          color: AppColors.sacGrey,
+          color: AppColors.pendingColor,
           onPressed: null,
         );
 
@@ -1393,7 +1393,7 @@ class _BottomCtaBar extends ConsumerWidget {
           builder: (context) => _CtaButton(
             label: 'honors.evidence.cta_completed'.tr(),
             icon: Icons.emoji_events_rounded,
-            color: AppColors.sacGreen,
+            color: AppColors.success,
             onPressed: () {
               context.push(
                 RouteNames.honorCompletionPath(
@@ -1447,9 +1447,9 @@ class _CtaButton extends StatelessWidget {
       child: FilledButton(
         onPressed: isLoading ? null : onPressed,
         style: FilledButton.styleFrom(
-          backgroundColor: isDisabled ? AppColors.sacGrey : color,
+          backgroundColor: isDisabled ? AppColors.pendingColor : color,
           foregroundColor: Colors.white,
-          disabledBackgroundColor: AppColors.sacGrey,
+          disabledBackgroundColor: AppColors.pendingColor,
           disabledForegroundColor: Colors.white.withValues(alpha: 0.70),
           shape: RoundedRectangleBorder(
             borderRadius: BorderRadius.circular(14),

--- a/lib/features/honors/presentation/views/honor_requirements_view.dart
+++ b/lib/features/honors/presentation/views/honor_requirements_view.dart
@@ -836,7 +836,7 @@ class _ErrorBody extends StatelessWidget {
               child: Text(
                 'honors.requirements.retry'.tr(),
                 style: const TextStyle(
-                  color: AppColors.sacBlue,
+                  color: AppColors.info,
                   fontSize: 14,
                   fontWeight: FontWeight.w600,
                 ),

--- a/lib/features/honors/presentation/views/honors_catalog_view.dart
+++ b/lib/features/honors/presentation/views/honors_catalog_view.dart
@@ -192,7 +192,7 @@ class _HonorsCatalogViewState extends ConsumerState<HonorsCatalogView> {
                       style: TextStyle(
                           fontSize: 20,
                           fontWeight: FontWeight.w700,
-                          color: AppColors.sacRed),
+                          color: AppColors.error),
                     ),
                   ),
                   // Completed/total badge pill
@@ -298,7 +298,7 @@ class _HonorsCatalogViewState extends ConsumerState<HonorsCatalogView> {
               child: HonorCategoryChip(
                 label: 'honors.catalog.all_category'.tr(),
                 isSelected: selectedCategory == null,
-                activeColor: AppColors.sacRed,
+                activeColor: AppColors.error,
                 onTap: () {
                   ref.read(selectedCategoryProvider.notifier).state = null;
                 },
@@ -383,7 +383,7 @@ class _HonorsCatalogViewState extends ConsumerState<HonorsCatalogView> {
           HugeIcon(
             icon: HugeIcons.strokeRoundedAlert02,
             size: 56,
-            color: AppColors.sacRed,
+            color: AppColors.error,
           ),
           const SizedBox(height: 16),
           Text(

--- a/lib/features/honors/presentation/widgets/choice_group_header.dart
+++ b/lib/features/honors/presentation/widgets/choice_group_header.dart
@@ -32,7 +32,7 @@ class ChoiceGroupHeader extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final Color accentColor =
-        _isSatisfied ? AppColors.secondary : AppColors.sacYellow;
+        _isSatisfied ? AppColors.secondary : AppColors.accent;
     final Color bgColor =
         _isSatisfied ? AppColors.secondaryLight : AppColors.accentLight;
 

--- a/lib/features/honors/presentation/widgets/honor_card.dart
+++ b/lib/features/honors/presentation/widgets/honor_card.dart
@@ -227,7 +227,7 @@ class HonorCard extends StatelessWidget {
                   color: const Color(0xFFF0F4F5),
                   child: Icon(
                     Icons.emoji_events_outlined,
-                    color: _statusColor ?? AppColors.sacGrey,
+                    color: _statusColor ?? AppColors.pendingColor,
                     size: 24,
                   ),
                 ),
@@ -243,7 +243,7 @@ class HonorCard extends StatelessWidget {
             ),
             child: Icon(
               Icons.emoji_events_outlined,
-              color: _statusColor ?? AppColors.sacGrey,
+              color: _statusColor ?? AppColors.pendingColor,
               size: 24,
             ),
           );
@@ -265,7 +265,7 @@ class HonorCard extends StatelessWidget {
               width: 18,
               height: 18,
               decoration: BoxDecoration(
-                color: AppColors.sacGreen,
+                color: AppColors.success,
                 shape: BoxShape.circle,
                 border: Border.all(color: Colors.white, width: 1.5),
               ),
@@ -288,7 +288,7 @@ class HonorCard extends StatelessWidget {
         width: 28,
         height: 28,
         decoration: const BoxDecoration(
-          color: AppColors.sacYellow,
+          color: AppColors.accent,
           shape: BoxShape.circle,
         ),
         child: const Icon(
@@ -307,7 +307,7 @@ class HonorCard extends StatelessWidget {
     // Available: chevron
     return const Icon(
       Icons.chevron_right_rounded,
-      color: AppColors.sacGrey,
+      color: AppColors.pendingColor,
       size: 24,
     );
   }

--- a/lib/features/honors/presentation/widgets/honor_category_chip.dart
+++ b/lib/features/honors/presentation/widgets/honor_category_chip.dart
@@ -23,7 +23,7 @@ class HonorCategoryChip extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final chipColor = activeColor ?? AppColors.sacBlue;
+    final chipColor = activeColor ?? AppColors.info;
     return GestureDetector(
       onTap: onTap,
       child: AnimatedContainer(

--- a/lib/features/honors/presentation/widgets/requirement_tree_item.dart
+++ b/lib/features/honors/presentation/widgets/requirement_tree_item.dart
@@ -127,7 +127,7 @@ class _RequirementTreeItemState extends State<RequirementTreeItem> {
                     padding:
                         const EdgeInsets.symmetric(horizontal: 6, vertical: 1),
                     decoration: BoxDecoration(
-                      color: AppColors.sacBlack.withValues(alpha: 0.08),
+                      color: AppColors.lightText.withValues(alpha: 0.08),
                       borderRadius: BorderRadius.circular(5),
                     ),
                     child: Text(
@@ -146,7 +146,7 @@ class _RequirementTreeItemState extends State<RequirementTreeItem> {
                     padding:
                         const EdgeInsets.symmetric(horizontal: 6, vertical: 1),
                     decoration: BoxDecoration(
-                      color: AppColors.sacBlack.withValues(alpha: 0.08),
+                      color: AppColors.lightText.withValues(alpha: 0.08),
                       borderRadius: BorderRadius.circular(5),
                     ),
                     child: Text(

--- a/lib/features/investiture/presentation/widgets/investiture_status_badge.dart
+++ b/lib/features/investiture/presentation/widgets/investiture_status_badge.dart
@@ -97,7 +97,7 @@ class InvestitureStatusBadge extends StatelessWidget {
       case InvestitureStatus.coordinatorApproved:
       case InvestitureStatus.fieldApproved:
       case InvestitureStatus.approved:
-        return AppColors.sacBlue.withValues(alpha: 0.4);
+        return AppColors.info.withValues(alpha: 0.4);
       case InvestitureStatus.rejected:
         return AppColors.error.withValues(alpha: 0.4);
       case InvestitureStatus.investido:

--- a/lib/features/members/presentation/views/member_profile_view.dart
+++ b/lib/features/members/presentation/views/member_profile_view.dart
@@ -275,7 +275,7 @@ class _ClassesSection extends ConsumerWidget {
     return _MedicalCard(
       icon: HugeIcons.strokeRoundedSchool,
       title: 'members.profile_view.progressive_classes_title'.tr(),
-      iconColor: AppColors.sacBlue,
+      iconColor: AppColors.info,
       child: _ClassesSectionBody(userId: userId),
     );
   }
@@ -402,7 +402,7 @@ class _ClassItem extends StatelessWidget {
       case 'PENDIENTE':
         return AppColors.accent;
       default:
-        return AppColors.sacBlue;
+        return AppColors.info;
     }
   }
 

--- a/lib/features/profile/presentation/views/profile_view.dart
+++ b/lib/features/profile/presentation/views/profile_view.dart
@@ -543,11 +543,11 @@ class _ProfileScrollBody extends StatelessWidget {
                         width: 32,
                         height: 32,
                         child: Material(
-                          color: AppColors.sacBlue.withAlpha(20),
+                          color: AppColors.info.withAlpha(20),
                           shape: RoundedRectangleBorder(
                             borderRadius: BorderRadius.circular(8),
                             side: BorderSide(
-                              color: AppColors.sacBlue.withAlpha(40),
+                              color: AppColors.info.withAlpha(40),
                             ),
                           ),
                           child: InkWell(
@@ -561,7 +561,7 @@ class _ProfileScrollBody extends StatelessWidget {
                               child: const Center(
                                 child: HugeIcon(
                                   icon: HugeIcons.strokeRoundedAdd01,
-                                  color: AppColors.sacBlue,
+                                  color: AppColors.info,
                                   size: 18,
                                 ),
                               ),

--- a/lib/features/resources/presentation/widgets/resource_card.dart
+++ b/lib/features/resources/presentation/widgets/resource_card.dart
@@ -16,7 +16,7 @@ Color resourceTypeColor(String resourceType) {
     case 'video_link':
       return const Color(0xFFE53935);
     case 'text':
-      return AppColors.sacBlue;
+      return AppColors.info;
     case 'document':
     default:
       return AppColors.primary;


### PR DESCRIPTION
## Summary

Replaces all `AppColors.sac<X>` legacy hex constants with canonical semantic tokens (`AppColors.info` / `success` / `error` / `accent` / `pendingColor` / `lightText` / `secondary`).

**30 files · ~123/124 lines · 371/371 tests pass · flutter analyze clean**

## Mapping applied

| Legacy | New canonical | Hex impact |
|--------|---------------|------------|
| `sacBlue` (#2EA0DA) | `AppColors.info` | identical |
| `sacGreen` (#4FBF9F) | `AppColors.success` | identical |
| `sacGreenLight` (#43A78A) | `AppColors.secondary` (#4FBF9F) | minor delta |
| `sacRed` (#F06151 coral) | `AppColors.error` (#DC2626 true red) | semantic shift, matches destructive state usage |
| `sacYellow` (#FBBD5E) | `AppColors.accent` | identical |
| `sacGrey` (pinkish #E1B8B8) | `AppColors.pendingColor` (#9AA0AB) | neutral grey replaces legacy pinkish |
| `sacBlack` (#183651 navy) | `AppColors.lightText` (#0F172A slate-900) | semantic text replaces navy |

## Intentional exclusions (NOT touched)

- `login_view.dart` — 3 sacGreen/sacGreenLight/sacBlack are BY DESIGN (login scaffold/button/text identity)
- `app_colors.dart` — `sac*` constant declarations kept for this PR; a follow-up will delete the unused definitions
- `sac_colors.dart` — semantic tokens reference `AppColors.sac*` internally on purpose

## Test plan
- [x] `flutter test` — 371/371 pass
- [x] `flutter analyze` — clean
- [x] `dart format` — clean
- [ ] Manual visual smoke check (especially Honors flows — heaviest usage)

## Followups
- F-1: Delete unused `AppColors.sac*` constant declarations in `app_colors.dart` (after this PR merges + a release cycle of visual validation)
- F-2: Convert `AppColors.pendingColor` / `lightText` usages that allow non-const to `context.sac.textTertiary` / `context.sac.text` for dark-mode adaptivity