### PR TITLE
chore(theme): delete legacy AppColors.sac* definitions

### DIFF
--- a/lib/core/theme/app_colors.dart
+++ b/lib/core/theme/app_colors.dart
@@ -204,17 +204,14 @@ class AppColors {
   static const Color statusInfoTextDark = Color(0xFF60A5FA);
 
   // ═══════════════════════════════════════════════════════════
-  // COLORES DE MARCA SACDIA (legacy, mantener para branding)
+  // COLORES DE LOGIN — usados exclusivamente en LoginView
   // ═══════════════════════════════════════════════════════════
 
-  static const Color sacRed = Color(0xFFF06151);
-  static const Color sacBlue = Color(0xFF2EA0DA);
-  static const Color sacYellow = Color(0xFFFBBD5E);
-  static const Color sacGreen = Color(0xFF4FBF9F);
-  static const Color sacBlack = Color(0xFF183651);
-  static const Color sacWhite = Color(0xFFE1E6E7);
-  static const Color sacGrey = Color.fromARGB(255, 225, 184, 184);
-  static const Color sacGreenLight = Color(0xFF43A78A);
+  /// Fondo scaffold de la pantalla de login (#4FBF9F)
+  static const Color loginScaffoldGreen = Color(0xFF4FBF9F);
+
+  /// Color del botón primario en la pantalla de login (#43A78A)
+  static const Color loginButtonGreen = Color(0xFF43A78A);
 
   // ═══════════════════════════════════════════════════════════
   // COLORES DE CLASES (tradición scout - NO cambiar)

--- a/lib/core/theme/sac_colors.dart
+++ b/lib/core/theme/sac_colors.dart
@@ -70,7 +70,7 @@ class SacColors {
   Color get warning => AppColors.accent; // #FBBD5E — same value both modes
   Color get onWarning => AppColors.accentDark; // dark text on yellow bg
 
-  Color get info => AppColors.sacBlue; // #2EA0DA — same value both modes
+  Color get info => AppColors.info; // #2EA0DA — same value both modes
   Color get onInfo => Colors.white;
 
   Color get error => AppColors.error; // #DC2626 — same value both modes

--- a/lib/features/auth/presentation/views/login_view.dart
+++ b/lib/features/auth/presentation/views/login_view.dart
@@ -109,7 +109,7 @@ class _LoginViewState extends ConsumerState<LoginView> {
     final logoBottomSpacing = Responsive.authLogoBottomSpacing(context);
 
     return Scaffold(
-      backgroundColor: AppColors.sacGreen,
+      backgroundColor: AppColors.loginScaffoldGreen,
       body: SafeArea(
         child: Center(
           child: SingleChildScrollView(
@@ -255,7 +255,7 @@ class _LoginViewState extends ConsumerState<LoginView> {
                       // Botón login
                       SacButton.primary(
                         text: 'auth.submit_idle'.tr(),
-                        backgroundColor: AppColors.sacGreenLight,
+                        backgroundColor: AppColors.loginButtonGreen,
                         isLoading: isLoading,
                         isEnabled: !_isCoolingDown,
                         onPressed: _signIn,
@@ -279,7 +279,7 @@ class _LoginViewState extends ConsumerState<LoginView> {
                       //             .textTheme
                       //             .bodySmall
                       //             ?.copyWith(
-                      //               color: AppColors.sacBlack,
+                      //               color: AppColors.lightText,
                       //             ),
                       //       ),
                       //     ),

--- a/test/core/theme/club_color_test.dart
+++ b/test/core/theme/club_color_test.dart
@@ -81,8 +81,8 @@ void main() {
       expect(ClubType.conquistadores.color, AppColors.primary);
     });
 
-    test('aventureros → AppColors.sacBlue', () {
-      expect(ClubType.aventureros.color, AppColors.sacBlue);
+    test('aventureros → AppColors.info', () {
+      expect(ClubType.aventureros.color, AppColors.info);
     });
 
     test('guiasMayores → AppColors.secondary', () {
@@ -93,7 +93,7 @@ void main() {
   group('clubColorFromName — convenience helper', () {
     test('known name returns the correct color', () {
       expect(clubColorFromName('Conquistadores'), AppColors.primary);
-      expect(clubColorFromName('Aventureros'), AppColors.sacBlue);
+      expect(clubColorFromName('Aventureros'), AppColors.info);
       expect(clubColorFromName('Guías Mayores'), AppColors.secondary);
     });
 
@@ -113,9 +113,9 @@ void main() {
         'Conquistadores': AppColors.primary,
         'conquistador': AppColors.primary,
         'CONQUISTADORES': AppColors.primary,
-        'Aventureros': AppColors.sacBlue,
-        'aventurero': AppColors.sacBlue,
-        'AVENTUREROS': AppColors.sacBlue,
+        'Aventureros': AppColors.info,
+        'aventurero': AppColors.info,
+        'AVENTUREROS': AppColors.info,
         'Guías Mayores': AppColors.secondary,
         'guia mayor': AppColors.secondary,
         'GUÍA': AppColors.secondary,


### PR DESCRIPTION
## Summary

- Deletes 7 unused `AppColors.sac*` constants (`sacRed`, `sacBlue`, `sacYellow`, `sacGreen`, `sacBlack`, `sacWhite`, `sacGrey`) that had no live consumers after PR #79 merged
- Renames 2 login-only constants to scope-clear names: `sacGreen → loginScaffoldGreen`, `sacGreenLight → loginButtonGreen`
- Updates `sac_colors.dart` `info` getter to reference `AppColors.info` directly (was `AppColors.sacBlue`, same hex `#2EA0DA`)
- Updates `club_color_test.dart` to use `AppColors.info` in place of the deleted `sacBlue`

**Approach chosen**: A (rename + delete)  
**Visual impact**: none — all hex values are identical

## Deleted constants

`sacRed` `sacBlue` `sacYellow` `sacGreen` `sacBlack` `sacWhite` `sacGrey`

## Renamed constants

| Old | New | Hex |
|-----|-----|-----|
| `sacGreen` | `loginScaffoldGreen` | `#4FBF9F` |
| `sacGreenLight` | `loginButtonGreen` | `#43A78A` |

## Test plan

- [ ] `flutter analyze lib/core/theme lib/features/auth` → no issues
- [ ] `flutter test` → 371/371 passing
- [ ] Login screen renders with identical green scaffold + button colors
- [ ] `context.sac.info` still resolves to `#2EA0DA`