### PR TITLE
chore(secrets): externalize Google Maps API key via gitignored secrets files

### DIFF
--- a/android/.gitignore
+++ b/android/.gitignore
@@ -11,3 +11,4 @@ GeneratedPluginRegistrant.java
 key.properties
 **/*.keystore
 **/*.jks
+secrets.properties

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -23,6 +23,18 @@ if (keystorePropertiesFile.exists()) {
     keystorePropertiesFile.withReader("UTF-8") { reader -> keystoreProperties.load(reader) }
 }
 
+// ---------------------------------------------------------------------------
+// Secrets (Google Maps API key, etc.)
+// ---------------------------------------------------------------------------
+// Place android/secrets.properties (one level up from this file). See
+// android/secrets.properties.example. The file is gitignored.
+// ---------------------------------------------------------------------------
+def secretsPropertiesFile = rootProject.file("secrets.properties")
+def secretsProperties = new Properties()
+if (secretsPropertiesFile.exists()) {
+    secretsPropertiesFile.withReader("UTF-8") { reader -> secretsProperties.load(reader) }
+}
+
 android {
     namespace = "com.sacdia.app"
     compileSdk = flutter.compileSdkVersion
@@ -46,12 +58,14 @@ android {
         targetSdk = flutter.targetSdkVersion
         versionCode = flutter.versionCode
         versionName = flutter.versionName
-        // GOOGLE_MAPS_API_KEY must be set in android/gradle.properties or as a CI
-        // environment variable. Never hardcode the key here.
-        // Local dev: add `GOOGLE_MAPS_API_KEY=<key>` to android/gradle.properties (gitignored).
-        def mapsKey = project.findProperty("GOOGLE_MAPS_API_KEY") ?: ""
+        // GOOGLE_MAPS_API_KEY resolution order:
+        //   1. android/secrets.properties (gitignored, local dev) — see secrets.properties.example
+        //   2. Gradle -P / ~/.gradle/gradle.properties / CI env var
+        // Never hardcode the key here.
+        def mapsKey = secretsProperties.getProperty("GOOGLE_MAPS_API_KEY")
+            ?: project.findProperty("GOOGLE_MAPS_API_KEY") ?: ""
         if (mapsKey.isEmpty()) {
-            logger.warn("WARNING: GOOGLE_MAPS_API_KEY is not set. Google Maps will not render. Set it in android/gradle.properties or as a CI environment variable.")
+            logger.warn("WARNING: GOOGLE_MAPS_API_KEY is not set. Google Maps will not render. Set it in android/secrets.properties or as a CI environment variable.")
         }
         manifestPlaceholders += [GOOGLE_MAPS_API_KEY: mapsKey]
     }

--- a/android/secrets.properties.example
+++ b/android/secrets.properties.example
@@ -1,0 +1,4 @@
+# Copy this file to secrets.properties and fill in real values.
+# secrets.properties is gitignored — do not commit real keys.
+
+GOOGLE_MAPS_API_KEY=YOUR_ANDROID_GOOGLE_MAPS_API_KEY_HERE

--- a/ios/.gitignore
+++ b/ios/.gitignore
@@ -19,6 +19,7 @@ Flutter/App.framework
 Flutter/Flutter.framework
 Flutter/Flutter.podspec
 Flutter/Generated.xcconfig
+Flutter/Secrets.xcconfig
 Flutter/ephemeral/
 Flutter/app.flx
 Flutter/app.zip

--- a/ios/Flutter/Debug.xcconfig
+++ b/ios/Flutter/Debug.xcconfig
@@ -1,2 +1,3 @@
 #include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "Generated.xcconfig"
+#include? "Secrets.xcconfig"

--- a/ios/Flutter/Profile.xcconfig
+++ b/ios/Flutter/Profile.xcconfig
@@ -1,2 +1,3 @@
 #include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"
 #include "Generated.xcconfig"
+#include? "Secrets.xcconfig"

--- a/ios/Flutter/Release.xcconfig
+++ b/ios/Flutter/Release.xcconfig
@@ -1,2 +1,3 @@
 #include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "Generated.xcconfig"
+#include? "Secrets.xcconfig"

--- a/ios/Flutter/Secrets.xcconfig.example
+++ b/ios/Flutter/Secrets.xcconfig.example
@@ -1,0 +1,4 @@
+// Copy this file to Secrets.xcconfig and fill in real values.
+// Secrets.xcconfig is gitignored — do not commit real keys.
+
+GOOGLE_MAPS_API_KEY=YOUR_IOS_GOOGLE_MAPS_API_KEY_HERE

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -141,6 +141,8 @@ PODS:
     - TOCropViewController (~> 2.7.4)
   - image_picker_ios (0.0.1):
     - Flutter
+  - integration_test (0.0.1):
+    - Flutter
   - local_auth_darwin (0.0.1):
     - Flutter
     - FlutterMacOS
@@ -167,6 +169,8 @@ PODS:
   - SDWebImage (5.21.7):
     - SDWebImage/Core (= 5.21.7)
   - SDWebImage/Core (5.21.7)
+  - secure_application (0.0.1):
+    - Flutter
   - Sentry/HybridSDK (8.58.1)
   - sentry_flutter (9.19.0):
     - Flutter
@@ -201,6 +205,7 @@ DEPENDENCIES:
   - google_maps_flutter_ios (from `.symlinks/plugins/google_maps_flutter_ios/ios`)
   - image_cropper (from `.symlinks/plugins/image_cropper/ios`)
   - image_picker_ios (from `.symlinks/plugins/image_picker_ios/ios`)
+  - integration_test (from `.symlinks/plugins/integration_test/ios`)
   - local_auth_darwin (from `.symlinks/plugins/local_auth_darwin/darwin`)
   - mobile_scanner (from `.symlinks/plugins/mobile_scanner/darwin`)
   - package_info_plus (from `.symlinks/plugins/package_info_plus/ios`)
@@ -208,6 +213,7 @@ DEPENDENCIES:
   - permission_handler_apple (from `.symlinks/plugins/permission_handler_apple/ios`)
   - printing (from `.symlinks/plugins/printing/ios`)
   - screen_brightness_ios (from `.symlinks/plugins/screen_brightness_ios/ios`)
+  - secure_application (from `.symlinks/plugins/secure_application/ios`)
   - sentry_flutter (from `.symlinks/plugins/sentry_flutter/ios`)
   - share_plus (from `.symlinks/plugins/share_plus/ios`)
   - shared_preferences_foundation (from `.symlinks/plugins/shared_preferences_foundation/darwin`)
@@ -268,6 +274,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/image_cropper/ios"
   image_picker_ios:
     :path: ".symlinks/plugins/image_picker_ios/ios"
+  integration_test:
+    :path: ".symlinks/plugins/integration_test/ios"
   local_auth_darwin:
     :path: ".symlinks/plugins/local_auth_darwin/darwin"
   mobile_scanner:
@@ -282,6 +290,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/printing/ios"
   screen_brightness_ios:
     :path: ".symlinks/plugins/screen_brightness_ios/ios"
+  secure_application:
+    :path: ".symlinks/plugins/secure_application/ios"
   sentry_flutter:
     :path: ".symlinks/plugins/sentry_flutter/ios"
   share_plus:
@@ -323,6 +333,7 @@ SPEC CHECKSUMS:
   GoogleUtilities: 00c88b9a86066ef77f0da2fab05f65d7768ed8e1
   image_cropper: c4326ea50132b1e1564499e5d32a84f01fb03537
   image_picker_ios: e0ece4aa2a75771a7de3fa735d26d90817041326
+  integration_test: 4a889634ef21a45d28d50d622cf412dc6d9f586e
   local_auth_darwin: c3ee6cce0a8d56be34c8ccb66ba31f7f180aaebb
   mobile_scanner: 9157936403f5a0644ca3779a38ff8404c5434a93
   nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
@@ -333,6 +344,7 @@ SPEC CHECKSUMS:
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   screen_brightness_ios: 9953fd7da5bd480f1a93990daeec2eb42d4f3b52
   SDWebImage: e9fc87c1aab89a8ab1bbd74eba378c6f53be8abf
+  secure_application: 1b94e9be54ff82c3a2598e75e4ba559d5e14e2d3
   Sentry: 958d9619ceccf6abb8c4736003fa336dac1a80a7
   sentry_flutter: bdfd7a7b8931c4ecefa37fde9e44a15cd0af30b1
   share_plus: 50da8cb520a8f0f65671c6c6a99b3617ed10a58a


### PR DESCRIPTION
## Summary

- Move `GOOGLE_MAPS_API_KEY` lookup from in-repo properties to a gitignored `secrets.properties` (Android) / `Secrets.xcconfig` (iOS) pattern.
- Add `.example` templates documenting the expected shape on each platform.
- Bump `Podfile.lock` to include the `integration_test` pod added when the integration_test package was wired in `a1f404c`.

## Test plan
- [ ] `cp android/secrets.properties.example android/secrets.properties` + fill key → `flutter run` on Android shows maps
- [ ] `cp ios/Flutter/Secrets.xcconfig.example ios/Flutter/Secrets.xcconfig` + fill key → `flutter run` on iOS shows maps
- [ ] Without a secrets file the build still succeeds (just warns about missing key)