### PR TITLE
feat(profile): extend models + selection views with clinical metadata

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -909,6 +909,19 @@
         "load_error": "Error: {error}"
       }
     },
+    "allergies": {
+      "severity_label": "Severity"
+    },
+    "diseases": {
+      "since_year_label": "Since what year?",
+      "since_year_hint": "Year (e.g. 2018)",
+      "since_year_invalid": "Invalid year (1900–present)"
+    },
+    "medicines": {
+      "dose_label": "Dose",
+      "dose_hint": "e.g. 500mg every 8 hours",
+      "dose_too_long": "Maximum 255 characters"
+    },
     "photo": {
       "title": "Put a face to your adventure!",
       "subtitle": "Upload a photo so your club can recognize you",
@@ -2651,7 +2664,12 @@
       "blood_type_select_title": "Select your blood type",
       "blood_type_select_subtitle": "This shows on your digital credential and is useful in case of emergency.",
       "blood_type_updated": "Blood type updated to {value}",
-      "blood_type_update_failed": "Could not update blood type"
+      "blood_type_update_failed": "Could not update blood type",
+      "severity": {
+        "leve": "Mild",
+        "media": "Moderate",
+        "alta": "High"
+      }
     },
     "settings": {
       "change_password_dialog_title": "Change password",

--- a/assets/translations/es.json
+++ b/assets/translations/es.json
@@ -909,6 +909,19 @@
         "load_error": "Error: {error}"
       }
     },
+    "allergies": {
+      "severity_label": "Severidad"
+    },
+    "diseases": {
+      "since_year_label": "¿Desde qué año?",
+      "since_year_hint": "Año (ej. 2018)",
+      "since_year_invalid": "Año inválido (1900–presente)"
+    },
+    "medicines": {
+      "dose_label": "Dosis",
+      "dose_hint": "ej. 500mg cada 8 hs",
+      "dose_too_long": "Máximo 255 caracteres"
+    },
     "photo": {
       "title": "¡Ponle cara a tu aventura!",
       "subtitle": "Subí una foto para que te reconozcan en tu club",
@@ -2651,7 +2664,12 @@
       "blood_type_select_title": "Seleccioná tu tipo de sangre",
       "blood_type_select_subtitle": "Esta información aparece en tu credencial digital y es útil ante una emergencia.",
       "blood_type_updated": "Tipo de sangre actualizado a {value}",
-      "blood_type_update_failed": "No se pudo actualizar el tipo de sangre"
+      "blood_type_update_failed": "No se pudo actualizar el tipo de sangre",
+      "severity": {
+        "leve": "Leve",
+        "media": "Media",
+        "alta": "Alta"
+      }
     },
     "settings": {
       "change_password_dialog_title": "Cambiar contraseña",

--- a/assets/translations/fr.json
+++ b/assets/translations/fr.json
@@ -909,6 +909,19 @@
         "load_error": "Erreur : {error}"
       }
     },
+    "allergies": {
+      "severity_label": "Sévérité"
+    },
+    "diseases": {
+      "since_year_label": "Depuis quelle année ?",
+      "since_year_hint": "Année (ex. 2018)",
+      "since_year_invalid": "Année invalide (1900–présent)"
+    },
+    "medicines": {
+      "dose_label": "Dose",
+      "dose_hint": "ex. 500 mg toutes les 8 h",
+      "dose_too_long": "Maximum 255 caractères"
+    },
     "photo": {
       "title": "Donnez un visage à votre aventure !",
       "subtitle": "Ajoutez une photo pour que votre club vous reconnaisse",
@@ -2651,7 +2664,12 @@
       "blood_type_select_title": "Choisissez votre groupe sanguin",
       "blood_type_select_subtitle": "Cette information figure sur votre carte numérique et est utile en cas d'urgence.",
       "blood_type_updated": "Groupe sanguin mis à jour : {value}",
-      "blood_type_update_failed": "Impossible de mettre à jour le groupe sanguin"
+      "blood_type_update_failed": "Impossible de mettre à jour le groupe sanguin",
+      "severity": {
+        "leve": "Léger",
+        "media": "Moyen",
+        "alta": "Élevé"
+      }
     },
     "settings": {
       "change_password_dialog_title": "Changer le mot de passe",

--- a/assets/translations/pt-BR.json
+++ b/assets/translations/pt-BR.json
@@ -909,6 +909,19 @@
         "load_error": "Erro: {error}"
       }
     },
+    "allergies": {
+      "severity_label": "Gravidade"
+    },
+    "diseases": {
+      "since_year_label": "Desde qual ano?",
+      "since_year_hint": "Ano (ex. 2018)",
+      "since_year_invalid": "Ano inválido (1900–presente)"
+    },
+    "medicines": {
+      "dose_label": "Dose",
+      "dose_hint": "ex. 500mg a cada 8 h",
+      "dose_too_long": "Máximo 255 caracteres"
+    },
     "photo": {
       "title": "Dê um rosto à sua aventura!",
       "subtitle": "Envie uma foto para que te reconheçam no seu clube",
@@ -2651,7 +2664,12 @@
       "blood_type_select_title": "Selecione seu tipo sanguíneo",
       "blood_type_select_subtitle": "Esta informação aparece na sua credencial digital e é útil em caso de emergência.",
       "blood_type_updated": "Tipo sanguíneo atualizado para {value}",
-      "blood_type_update_failed": "Não foi possível atualizar o tipo sanguíneo"
+      "blood_type_update_failed": "Não foi possível atualizar o tipo sanguíneo",
+      "severity": {
+        "leve": "Leve",
+        "media": "Média",
+        "alta": "Alta"
+      }
     },
     "settings": {
       "change_password_dialog_title": "Alterar senha",

--- a/lib/features/post_registration/data/datasources/personal_info_remote_data_source.dart
+++ b/lib/features/post_registration/data/datasources/personal_info_remote_data_source.dart
@@ -9,6 +9,51 @@ import '../models/medicine_model.dart';
 import '../models/relationship_type_model.dart';
 import '../../../../core/utils/app_logger.dart';
 
+// ---------------------------------------------------------------------------
+// DTO de entrada para PUT — shape nueva del backend
+// ---------------------------------------------------------------------------
+
+/// Entrada de alergia para PUT /users/:id/allergies
+class AllergyEntry {
+  final int id;
+  final AllergySeverity severity;
+
+  const AllergyEntry({required this.id, required this.severity});
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'severity': severity.name,
+      };
+}
+
+/// Entrada de enfermedad para PUT /users/:id/diseases
+class DiseaseEntry {
+  final int id;
+  final int? sinceYear;
+
+  const DiseaseEntry({required this.id, this.sinceYear});
+
+  Map<String, dynamic> toJson() {
+    final map = <String, dynamic>{'id': id};
+    if (sinceYear != null) map['since_year'] = sinceYear;
+    return map;
+  }
+}
+
+/// Entrada de medicamento para PUT /users/:id/medicines
+class MedicineEntry {
+  final int id;
+  final String? dose;
+
+  const MedicineEntry({required this.id, this.dose});
+
+  Map<String, dynamic> toJson() {
+    final map = <String, dynamic>{'id': id};
+    if (dose != null) map['dose'] = dose;
+    return map;
+  }
+}
+
 /// Interface del data source remoto para información personal
 abstract class PersonalInfoRemoteDataSource {
   Future<void> updatePersonalInfo(
@@ -40,17 +85,23 @@ abstract class PersonalInfoRemoteDataSource {
   Future<List<AllergyModel>> getAllergiesCatalog({CancelToken? cancelToken});
   Future<List<AllergyModel>> getUserAllergies(String userId,
       {CancelToken? cancelToken});
-  Future<void> saveUserAllergies(String userId, List<int> allergyIds);
+
+  /// Guarda alergias con severidad. Shape nueva: `{ allergies: [{id, severity}] }`
+  Future<void> saveUserAllergies(String userId, List<AllergyEntry> entries);
   Future<void> deleteUserAllergy(String userId, int allergyId);
   Future<List<DiseaseModel>> getDiseasesCatalog({CancelToken? cancelToken});
   Future<List<DiseaseModel>> getUserDiseases(String userId,
       {CancelToken? cancelToken});
-  Future<void> saveUserDiseases(String userId, List<int> diseaseIds);
+
+  /// Guarda enfermedades con since_year. Shape nueva: `{ diseases: [{id, since_year?}] }`
+  Future<void> saveUserDiseases(String userId, List<DiseaseEntry> entries);
   Future<void> deleteUserDisease(String userId, int diseaseId);
   Future<List<MedicineModel>> getMedicinesCatalog({CancelToken? cancelToken});
   Future<List<MedicineModel>> getUserMedicines(String userId,
       {CancelToken? cancelToken});
-  Future<void> saveUserMedicines(String userId, List<int> medicineIds);
+
+  /// Guarda medicamentos con dosis. Shape nueva: `{ medicines: [{id, dose?}] }`
+  Future<void> saveUserMedicines(String userId, List<MedicineEntry> entries);
   Future<void> deleteUserMedicine(String userId, int medicineId);
   Future<void> completeStep2(String userId);
 }
@@ -344,11 +395,12 @@ class PersonalInfoRemoteDataSourceImpl implements PersonalInfoRemoteDataSource {
   }
 
   @override
-  Future<void> saveUserAllergies(String userId, List<int> allergyIds) async {
+  Future<void> saveUserAllergies(
+      String userId, List<AllergyEntry> entries) async {
     try {
       await dio.put(
         '$_baseUrl${ApiEndpoints.users}/$userId/allergies',
-        data: {'allergy_ids': allergyIds},
+        data: {'allergies': entries.map((e) => e.toJson()).toList()},
       );
     } on DioException catch (e) {
       throw Exception(
@@ -413,11 +465,12 @@ class PersonalInfoRemoteDataSourceImpl implements PersonalInfoRemoteDataSource {
   }
 
   @override
-  Future<void> saveUserDiseases(String userId, List<int> diseaseIds) async {
+  Future<void> saveUserDiseases(
+      String userId, List<DiseaseEntry> entries) async {
     try {
       await dio.put(
         '$_baseUrl${ApiEndpoints.users}/$userId/diseases',
-        data: {'disease_ids': diseaseIds},
+        data: {'diseases': entries.map((e) => e.toJson()).toList()},
       );
     } on DioException catch (e) {
       throw Exception(
@@ -482,11 +535,12 @@ class PersonalInfoRemoteDataSourceImpl implements PersonalInfoRemoteDataSource {
   }
 
   @override
-  Future<void> saveUserMedicines(String userId, List<int> medicineIds) async {
+  Future<void> saveUserMedicines(
+      String userId, List<MedicineEntry> entries) async {
     try {
       await dio.put(
         '$_baseUrl${ApiEndpoints.users}/$userId/medicines',
-        data: {'medicine_ids': medicineIds},
+        data: {'medicines': entries.map((e) => e.toJson()).toList()},
       );
     } on DioException catch (e) {
       throw Exception(

--- a/lib/features/post_registration/data/models/allergy_model.dart
+++ b/lib/features/post_registration/data/models/allergy_model.dart
@@ -1,18 +1,49 @@
 import 'package:equatable/equatable.dart';
 
+/// Nivel de severidad de una alergia
+enum AllergySeverity { leve, media, alta }
+
+/// Extension para parseo y display de [AllergySeverity]
+extension AllergySeverityX on AllergySeverity {
+  /// Parsea un String desde la API; desconocido/null → [AllergySeverity.leve]
+  static AllergySeverity parse(String? value) {
+    switch (value) {
+      case 'media':
+        return AllergySeverity.media;
+      case 'alta':
+        return AllergySeverity.alta;
+      default:
+        return AllergySeverity.leve;
+    }
+  }
+
+  /// Valor de visualización para la UI (coincide con el nombre del enum)
+  String get display => name;
+
+  /// i18n key bajo `profile.medical_info.severity.*`
+  String get i18nKey => 'profile.medical_info.severity.$name';
+}
+
 /// Modelo de alergia del catálogo
 class AllergyModel extends Equatable {
   final int id;
   final String name;
   final bool isSelected;
 
+  /// Severidad de la alergia para el usuario. Default: [AllergySeverity.leve].
+  final AllergySeverity severity;
+
   const AllergyModel({
     required this.id,
     required this.name,
     this.isSelected = false,
+    this.severity = AllergySeverity.leve,
   });
 
-  /// Crea una instancia desde JSON
+  /// Crea una instancia desde JSON.
+  ///
+  /// Tolera campos faltantes para compatibilidad con el catálogo
+  /// (que no incluye `severity`) y con respuestas antiguas del GET usuario.
   factory AllergyModel.fromJson(Map<String, dynamic> json) {
     // Tolerar diferentes nombres de campo para el ID
     final rawId = json['id'] ?? json['allergy_id'];
@@ -20,15 +51,17 @@ class AllergyModel extends Equatable {
       id: rawId is int ? rawId : (int.tryParse(rawId?.toString() ?? '') ?? 0),
       name: (json['name'] as String?) ?? '',
       isSelected: json['is_selected'] as bool? ?? false,
+      severity: AllergySeverityX.parse(json['severity'] as String?),
     );
   }
 
-  /// Convierte la instancia a JSON
+  /// Convierte la instancia a JSON (para serialización local)
   Map<String, dynamic> toJson() {
     return {
       'id': id,
       'name': name,
       'is_selected': isSelected,
+      'severity': severity.name,
     };
   }
 
@@ -37,14 +70,16 @@ class AllergyModel extends Equatable {
     int? id,
     String? name,
     bool? isSelected,
+    AllergySeverity? severity,
   }) {
     return AllergyModel(
       id: id ?? this.id,
       name: name ?? this.name,
       isSelected: isSelected ?? this.isSelected,
+      severity: severity ?? this.severity,
     );
   }
 
   @override
-  List<Object?> get props => [id, name, isSelected];
+  List<Object?> get props => [id, name, isSelected, severity];
 }

--- a/lib/features/post_registration/data/models/disease_model.dart
+++ b/lib/features/post_registration/data/models/disease_model.dart
@@ -6,13 +6,19 @@ class DiseaseModel extends Equatable {
   final String name;
   final bool isSelected;
 
+  /// Año desde el cual el usuario padece la enfermedad. Nullable — sin default.
+  final int? sinceYear;
+
   const DiseaseModel({
     required this.id,
     required this.name,
     this.isSelected = false,
+    this.sinceYear,
   });
 
-  /// Crea una instancia desde JSON
+  /// Crea una instancia desde JSON.
+  ///
+  /// Tolera `since_year` ausente (catálogo y respuestas antiguas).
   factory DiseaseModel.fromJson(Map<String, dynamic> json) {
     // Tolerar diferentes nombres de campo para el ID
     final rawId = json['id'] ?? json['disease_id'];
@@ -20,15 +26,17 @@ class DiseaseModel extends Equatable {
       id: rawId is int ? rawId : (int.tryParse(rawId?.toString() ?? '') ?? 0),
       name: (json['name'] as String?) ?? '',
       isSelected: json['is_selected'] as bool? ?? false,
+      sinceYear: (json['since_year'] as num?)?.toInt(),
     );
   }
 
-  /// Convierte la instancia a JSON
+  /// Convierte la instancia a JSON (para serialización local)
   Map<String, dynamic> toJson() {
     return {
       'id': id,
       'name': name,
       'is_selected': isSelected,
+      if (sinceYear != null) 'since_year': sinceYear,
     };
   }
 
@@ -37,14 +45,17 @@ class DiseaseModel extends Equatable {
     int? id,
     String? name,
     bool? isSelected,
+    int? sinceYear,
+    bool clearSinceYear = false,
   }) {
     return DiseaseModel(
       id: id ?? this.id,
       name: name ?? this.name,
       isSelected: isSelected ?? this.isSelected,
+      sinceYear: clearSinceYear ? null : (sinceYear ?? this.sinceYear),
     );
   }
 
   @override
-  List<Object?> get props => [id, name, isSelected];
+  List<Object?> get props => [id, name, isSelected, sinceYear];
 }

--- a/lib/features/post_registration/data/models/medicine_model.dart
+++ b/lib/features/post_registration/data/models/medicine_model.dart
@@ -6,13 +6,19 @@ class MedicineModel extends Equatable {
   final String name;
   final bool isSelected;
 
+  /// Dosis del medicamento (ej. "500mg cada 8 hs"). Nullable — sin default.
+  final String? dose;
+
   const MedicineModel({
     required this.id,
     required this.name,
     this.isSelected = false,
+    this.dose,
   });
 
-  /// Crea una instancia desde JSON
+  /// Crea una instancia desde JSON.
+  ///
+  /// Tolera `dose` ausente (catálogo y respuestas antiguas).
   factory MedicineModel.fromJson(Map<String, dynamic> json) {
     // Tolerar diferentes nombres de campo para el ID
     final rawId = json['id'] ?? json['medicine_id'];
@@ -20,15 +26,17 @@ class MedicineModel extends Equatable {
       id: rawId is int ? rawId : (int.tryParse(rawId?.toString() ?? '') ?? 0),
       name: (json['name'] as String?) ?? '',
       isSelected: json['is_selected'] as bool? ?? false,
+      dose: json['dose'] as String?,
     );
   }
 
-  /// Convierte la instancia a JSON
+  /// Convierte la instancia a JSON (para serialización local)
   Map<String, dynamic> toJson() {
     return {
       'id': id,
       'name': name,
       'is_selected': isSelected,
+      if (dose != null) 'dose': dose,
     };
   }
 
@@ -37,14 +45,17 @@ class MedicineModel extends Equatable {
     int? id,
     String? name,
     bool? isSelected,
+    String? dose,
+    bool clearDose = false,
   }) {
     return MedicineModel(
       id: id ?? this.id,
       name: name ?? this.name,
       isSelected: isSelected ?? this.isSelected,
+      dose: clearDose ? null : (dose ?? this.dose),
     );
   }
 
   @override
-  List<Object?> get props => [id, name, isSelected];
+  List<Object?> get props => [id, name, isSelected, dose];
 }

--- a/lib/features/post_registration/presentation/providers/personal_info_providers.dart
+++ b/lib/features/post_registration/presentation/providers/personal_info_providers.dart
@@ -13,6 +13,10 @@ import '../../../profile/presentation/widgets/blood_type_selector.dart';
 import '../../../../providers/dio_provider.dart';
 import '../../../../core/utils/app_logger.dart';
 
+// Re-export entry DTOs so views can import them from one place
+export '../../data/datasources/personal_info_remote_data_source.dart'
+    show AllergyEntry, DiseaseEntry, MedicineEntry;
+
 /// Provider del data source de información personal
 final personalInfoDataSourceProvider =
     Provider.autoDispose<PersonalInfoRemoteDataSource>((ref) {
@@ -139,8 +143,12 @@ class UserAllergiesNotifier
     });
   }
 
-  /// Guarda la lista completa de alergias seleccionadas en la API
-  Future<void> saveAll(List<int> allergyIds) async {
+  /// Guarda la lista completa de alergias con severidad en la API.
+  ///
+  /// Cada [AllergyEntry] contiene `id` + `severity`. La severity es
+  /// requerida (NOT NULL) en el backend; el default [AllergySeverity.leve]
+  /// se aplica cuando el usuario no la elige explícitamente en la vista.
+  Future<void> saveAll(List<AllergyEntry> entries) async {
     state = const AsyncValue.loading();
 
     state = await AsyncValue.guard(() async {
@@ -150,7 +158,7 @@ class UserAllergiesNotifier
       if (userId == null) throw Exception(tr('errors.user_not_authenticated'));
 
       final dataSource = ref.read(personalInfoDataSourceProvider);
-      await dataSource.saveUserAllergies(userId, allergyIds);
+      await dataSource.saveUserAllergies(userId, entries);
 
       return await dataSource.getUserAllergies(userId);
     });
@@ -219,8 +227,11 @@ class UserDiseasesNotifier
     });
   }
 
-  /// Guarda la lista completa de enfermedades seleccionadas en la API
-  Future<void> saveAll(List<int> diseaseIds) async {
+  /// Guarda la lista completa de enfermedades con since_year en la API.
+  ///
+  /// Cada [DiseaseEntry] contiene `id` + `sinceYear` opcional.
+  /// `sinceYear == null` se serializa omitiendo el campo (backend acepta null).
+  Future<void> saveAll(List<DiseaseEntry> entries) async {
     state = const AsyncValue.loading();
 
     state = await AsyncValue.guard(() async {
@@ -230,7 +241,7 @@ class UserDiseasesNotifier
       if (userId == null) throw Exception(tr('errors.user_not_authenticated'));
 
       final dataSource = ref.read(personalInfoDataSourceProvider);
-      await dataSource.saveUserDiseases(userId, diseaseIds);
+      await dataSource.saveUserDiseases(userId, entries);
 
       return await dataSource.getUserDiseases(userId);
     });
@@ -312,8 +323,11 @@ class UserMedicinesNotifier
     });
   }
 
-  /// Guarda la lista completa de medicamentos seleccionados en la API
-  Future<void> saveAll(List<int> medicineIds) async {
+  /// Guarda la lista completa de medicamentos con dosis en la API.
+  ///
+  /// Cada [MedicineEntry] contiene `id` + `dose` opcional.
+  /// `dose == null` se serializa omitiendo el campo (backend acepta null).
+  Future<void> saveAll(List<MedicineEntry> entries) async {
     state = const AsyncValue.loading();
 
     state = await AsyncValue.guard(() async {
@@ -323,7 +337,7 @@ class UserMedicinesNotifier
       if (userId == null) throw Exception(tr('errors.user_not_authenticated'));
 
       final dataSource = ref.read(personalInfoDataSourceProvider);
-      await dataSource.saveUserMedicines(userId, medicineIds);
+      await dataSource.saveUserMedicines(userId, entries);
 
       return await dataSource.getUserMedicines(userId);
     });
@@ -585,17 +599,28 @@ class SavePersonalInfoNotifier extends AutoDisposeAsyncNotifier<void> {
 
       final selectedAllergies = ref.read(selectedAllergiesProvider);
       if (selectedAllergies.isNotEmpty) {
-        await dataSource.saveUserAllergies(userId, selectedAllergies);
+        // Post-registration flow: no severity UI yet — default to leve
+        final allergyEntries = selectedAllergies
+            .map((id) =>
+                AllergyEntry(id: id, severity: AllergySeverity.leve))
+            .toList();
+        await dataSource.saveUserAllergies(userId, allergyEntries);
       }
 
       final selectedDiseases = ref.read(selectedDiseasesProvider);
       if (selectedDiseases.isNotEmpty) {
-        await dataSource.saveUserDiseases(userId, selectedDiseases);
+        // Post-registration flow: no since_year UI yet — omit the field
+        final diseaseEntries =
+            selectedDiseases.map((id) => DiseaseEntry(id: id)).toList();
+        await dataSource.saveUserDiseases(userId, diseaseEntries);
       }
 
       final selectedMedicines = ref.read(selectedMedicinesProvider);
       if (selectedMedicines.isNotEmpty) {
-        await dataSource.saveUserMedicines(userId, selectedMedicines);
+        // Post-registration flow: no dose UI yet — omit the field
+        final medicineEntries =
+            selectedMedicines.map((id) => MedicineEntry(id: id)).toList();
+        await dataSource.saveUserMedicines(userId, medicineEntries);
       }
 
       await dataSource.completeStep2(userId);

--- a/lib/features/post_registration/presentation/providers/personal_info_providers.dart
+++ b/lib/features/post_registration/presentation/providers/personal_info_providers.dart
@@ -601,8 +601,7 @@ class SavePersonalInfoNotifier extends AutoDisposeAsyncNotifier<void> {
       if (selectedAllergies.isNotEmpty) {
         // Post-registration flow: no severity UI yet — default to leve
         final allergyEntries = selectedAllergies
-            .map((id) =>
-                AllergyEntry(id: id, severity: AllergySeverity.leve))
+            .map((id) => AllergyEntry(id: id, severity: AllergySeverity.leve))
             .toList();
         await dataSource.saveUserAllergies(userId, allergyEntries);
       }

--- a/lib/features/post_registration/presentation/views/allergies_selection_view.dart
+++ b/lib/features/post_registration/presentation/views/allergies_selection_view.dart
@@ -480,8 +480,7 @@ class _AllergiesListWithSeverityState
                   itemBuilder: (context, index) {
                     final item = filteredItems[index];
                     final isNoneOption = item.id == _noneOptionId;
-                    final isSelected =
-                        item.isSelected && !isNoneOption;
+                    final isSelected = item.isSelected && !isNoneOption;
 
                     return Column(
                       crossAxisAlignment: CrossAxisAlignment.start,

--- a/lib/features/post_registration/presentation/views/allergies_selection_view.dart
+++ b/lib/features/post_registration/presentation/views/allergies_selection_view.dart
@@ -12,6 +12,7 @@ import '../widgets/searchable_selection_list.dart';
 
 /// Vista para seleccionar y gestionar alergias del usuario.
 /// Pre-carga las alergias existentes del usuario al inicializarse.
+/// Cada alergia seleccionada muestra un selector inline de severidad.
 class AllergiesSelectionView extends ConsumerStatefulWidget {
   const AllergiesSelectionView({super.key});
 
@@ -22,14 +23,30 @@ class AllergiesSelectionView extends ConsumerStatefulWidget {
 
 class _AllergiesSelectionViewState
     extends ConsumerState<AllergiesSelectionView> {
+  /// Mapa local id → severidad para las alergias seleccionadas en esta sesión.
+  /// Se inicializa con los datos del servidor al cargar.
+  final Map<int, AllergySeverity> _severityMap = {};
+  bool _severitySeeded = false;
+
   @override
   void initState() {
     super.initState();
-    // Pre-cargar alergias del usuario al entrar a la vista.
     Future.microtask(() {
       ref.read(userAllergiesProvider.notifier).refresh();
     });
   }
+
+  /// Sincroniza _severityMap con los datos del servidor (solo 1ª vez).
+  void _seedSeverity(List<AllergyModel> serverAllergies) {
+    if (_severitySeeded) return;
+    _severitySeeded = true;
+    for (final a in serverAllergies) {
+      _severityMap[a.id] = a.severity;
+    }
+  }
+
+  AllergySeverity _severityFor(int id) =>
+      _severityMap[id] ?? AllergySeverity.leve;
 
   Future<void> _showDeleteConfirmation(
     BuildContext context,
@@ -48,6 +65,9 @@ class _AllergiesSelectionViewState
     if (confirmed == true && context.mounted) {
       try {
         await ref.read(userAllergiesProvider.notifier).deleteAllergy(allergyId);
+        setState(() {
+          _severityMap.remove(allergyId);
+        });
         if (context.mounted) {
           ScaffoldMessenger.of(context).showSnackBar(
             SnackBar(
@@ -83,17 +103,14 @@ class _AllergiesSelectionViewState
 
   @override
   Widget build(BuildContext context) {
-    // Seed selection state the first time user allergies load from the API.
-    // The guard `prev?.value == null` ensures this only fires once on
-    // the loading→data transition, not on every rebuild. Because
-    // userAllergiesProvider is .autoDispose, it resets when the screen is
-    // left, so re-entering the screen will re-seed correctly.
+    // Seed selection state + severity the first time user allergies load.
     ref.listen<AsyncValue<List<AllergyModel>>>(
       userAllergiesProvider,
       (prev, next) {
         if (prev?.value == null && next.value != null) {
           ref.read(selectedAllergiesProvider.notifier).state =
               next.value!.map((a) => a.id).toList();
+          _seedSeverity(next.value!);
         }
       },
     );
@@ -108,13 +125,23 @@ class _AllergiesSelectionViewState
         actions: [
           IconButton(
             icon: HugeIcon(icon: HugeIcons.strokeRoundedRefresh, size: 24),
-            onPressed: () => ref.read(userAllergiesProvider.notifier).refresh(),
+            onPressed: () {
+              setState(() => _severitySeeded = false);
+              ref.read(userAllergiesProvider.notifier).refresh();
+            },
             tooltip: 'post_registration.health.allergies.refresh_tooltip'.tr(),
           ),
           TextButton.icon(
             onPressed: () async {
               final ids = ref.read(selectedAllergiesProvider);
-              await ref.read(userAllergiesProvider.notifier).saveAll(ids);
+              // Build entries with severity; default leve if not set
+              final entries = ids
+                  .map((id) => AllergyEntry(
+                        id: id,
+                        severity: _severityFor(id),
+                      ))
+                  .toList();
+              await ref.read(userAllergiesProvider.notifier).saveAll(entries);
               if (context.mounted) Navigator.of(context).pop();
             },
             icon: const HugeIcon(
@@ -156,7 +183,6 @@ class _AllergiesSelectionViewState
                   ))
               .toList();
 
-          // Alergias actualmente guardadas en la API
           final savedAllergies = userAllergiesAsync.valueOrNull ?? [];
 
           return Column(
@@ -242,13 +268,19 @@ class _AllergiesSelectionViewState
                 const Divider(height: 1),
               ],
 
-              // Lista de selección
+              // Lista de selección con editor inline de severidad
               Expanded(
-                child: SearchableSelectionList(
+                child: _AllergiesListWithSeverity(
                   items: items,
                   selectedIds: selectedIds,
+                  severityMap: _severityMap,
                   onSelectionChanged: (ids) {
                     ref.read(selectedAllergiesProvider.notifier).state = ids;
+                  },
+                  onSeverityChanged: (id, severity) {
+                    setState(() {
+                      _severityMap[id] = severity;
+                    });
                   },
                   searchHint:
                       'post_registration.health.allergies.search_hint'.tr(),
@@ -260,6 +292,327 @@ class _AllergiesSelectionViewState
             ],
           );
         },
+      ),
+    );
+  }
+}
+
+/// Lista con búsqueda + selector inline de severidad para alergias seleccionadas.
+class _AllergiesListWithSeverity extends StatefulWidget {
+  final List<SelectableItem> items;
+  final List<int> selectedIds;
+  final Map<int, AllergySeverity> severityMap;
+  final Function(List<int>) onSelectionChanged;
+  final Function(int, AllergySeverity) onSeverityChanged;
+  final String? searchHint;
+  final bool hasNoneOption;
+  final String noneOptionLabel;
+
+  const _AllergiesListWithSeverity({
+    required this.items,
+    required this.selectedIds,
+    required this.severityMap,
+    required this.onSelectionChanged,
+    required this.onSeverityChanged,
+    this.searchHint,
+    this.hasNoneOption = true,
+    this.noneOptionLabel = 'Ninguna',
+  });
+
+  @override
+  State<_AllergiesListWithSeverity> createState() =>
+      _AllergiesListWithSeverityState();
+}
+
+class _AllergiesListWithSeverityState
+    extends State<_AllergiesListWithSeverity> {
+  final TextEditingController _searchController = TextEditingController();
+  String _searchQuery = '';
+  late List<SelectableItem> _items;
+
+  static const int _noneOptionId = -1;
+
+  @override
+  void initState() {
+    super.initState();
+    _initializeItems();
+  }
+
+  void _initializeItems() {
+    _items = widget.items.map((item) {
+      return SelectableItem(
+        id: item.id,
+        name: item.name,
+        isSelected: widget.selectedIds.contains(item.id),
+      );
+    }).toList();
+
+    if (widget.hasNoneOption) {
+      _items.insert(
+        0,
+        SelectableItem(
+          id: _noneOptionId,
+          name: widget.noneOptionLabel,
+          isSelected: widget.selectedIds.isEmpty,
+        ),
+      );
+    }
+  }
+
+  @override
+  void didUpdateWidget(_AllergiesListWithSeverity oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.selectedIds != widget.selectedIds ||
+        oldWidget.items != widget.items) {
+      _initializeItems();
+    }
+  }
+
+  @override
+  void dispose() {
+    _searchController.dispose();
+    super.dispose();
+  }
+
+  List<SelectableItem> get _filteredItems {
+    if (_searchQuery.isEmpty) return _items;
+    return _items
+        .where((item) =>
+            item.name.toLowerCase().contains(_searchQuery.toLowerCase()))
+        .toList();
+  }
+
+  void _handleItemToggle(SelectableItem item) {
+    setState(() {
+      if (item.id == _noneOptionId) {
+        for (var i in _items) {
+          i.isSelected = i.id == _noneOptionId;
+        }
+      } else {
+        item.isSelected = !item.isSelected;
+        final noneItem = _items.firstWhere(
+          (i) => i.id == _noneOptionId,
+          orElse: () => item,
+        );
+        if (noneItem.id == _noneOptionId) noneItem.isSelected = false;
+      }
+
+      final selectedIds = _items
+          .where((i) => i.isSelected && i.id != _noneOptionId)
+          .map((i) => i.id)
+          .toList();
+
+      widget.onSelectionChanged(selectedIds);
+    });
+  }
+
+  String _getSelectionCountText() {
+    final count =
+        _items.where((i) => i.isSelected && i.id != _noneOptionId).length;
+    if (count == 0) return tr('common.none_selected');
+    if (count == 1) return tr('common.items_selected_one');
+    return tr('common.items_selected_other', namedArgs: {'count': '$count'});
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final filteredItems = _filteredItems;
+
+    return Column(
+      children: [
+        Padding(
+          padding: const EdgeInsets.all(16),
+          child: TextField(
+            controller: _searchController,
+            decoration: InputDecoration(
+              hintText: widget.searchHint ?? tr('common.search'),
+              prefixIcon:
+                  HugeIcon(icon: HugeIcons.strokeRoundedSearch01, size: 22),
+              suffixIcon: _searchQuery.isNotEmpty
+                  ? IconButton(
+                      icon: HugeIcon(
+                          icon: HugeIcons.strokeRoundedCancel01, size: 22),
+                      onPressed: () {
+                        setState(() {
+                          _searchController.clear();
+                          _searchQuery = '';
+                        });
+                      },
+                    )
+                  : null,
+              border: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(12),
+              ),
+              filled: true,
+              fillColor: context.sac.surfaceVariant,
+            ),
+            onChanged: (value) {
+              setState(() {
+                _searchQuery = value;
+              });
+            },
+          ),
+        ),
+        Expanded(
+          child: filteredItems.isEmpty
+              ? Center(
+                  child: Column(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      HugeIcon(
+                        icon: HugeIcons.strokeRoundedSearchMinus,
+                        size: 64,
+                        color: context.sac.textTertiary,
+                      ),
+                      const SizedBox(height: 16),
+                      Text(
+                        tr('common.no_results'),
+                        style: TextStyle(
+                          fontSize: 16,
+                          color: context.sac.textSecondary,
+                        ),
+                      ),
+                    ],
+                  ),
+                )
+              : ListView.builder(
+                  itemCount: filteredItems.length,
+                  itemBuilder: (context, index) {
+                    final item = filteredItems[index];
+                    final isNoneOption = item.id == _noneOptionId;
+                    final isSelected =
+                        item.isSelected && !isNoneOption;
+
+                    return Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        ListTile(
+                          title: Text(
+                            item.name,
+                            style: TextStyle(
+                              fontWeight: isNoneOption
+                                  ? FontWeight.bold
+                                  : FontWeight.normal,
+                            ),
+                          ),
+                          leading: Checkbox(
+                            value: item.isSelected,
+                            onChanged: (_) => _handleItemToggle(item),
+                          ),
+                          onTap: () => _handleItemToggle(item),
+                        ),
+                        // Inline severity editor cuando está seleccionada
+                        if (isSelected)
+                          _SeverityInlineEditor(
+                            selectedSeverity: widget.severityMap[item.id] ??
+                                AllergySeverity.leve,
+                            onChanged: (severity) =>
+                                widget.onSeverityChanged(item.id, severity),
+                          ),
+                      ],
+                    );
+                  },
+                ),
+        ),
+        Container(
+          padding: const EdgeInsets.all(16),
+          decoration: BoxDecoration(
+            color: context.sac.surfaceVariant,
+            border: Border(top: BorderSide(color: context.sac.border)),
+          ),
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Text(
+                _getSelectionCountText(),
+                style: TextStyle(
+                  fontSize: 14,
+                  color: context.sac.textSecondary,
+                  fontWeight: FontWeight.w500,
+                ),
+              ),
+              if (_items.any((i) => i.isSelected && i.id != _noneOptionId))
+                TextButton.icon(
+                  icon:
+                      HugeIcon(icon: HugeIcons.strokeRoundedCancel02, size: 20),
+                  label: Text(tr('common.clear')),
+                  onPressed: () {
+                    setState(() {
+                      for (var item in _items) {
+                        item.isSelected = item.id == _noneOptionId;
+                      }
+                      widget.onSelectionChanged([]);
+                    });
+                  },
+                ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+/// Editor inline de severidad con 3 opciones (SegmentedButton).
+class _SeverityInlineEditor extends StatelessWidget {
+  final AllergySeverity selectedSeverity;
+  final ValueChanged<AllergySeverity> onChanged;
+
+  const _SeverityInlineEditor({
+    required this.selectedSeverity,
+    required this.onChanged,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(left: 56, right: 16, bottom: 8),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'post_registration.allergies.severity_label'.tr(),
+            style: TextStyle(
+              fontSize: 12,
+              color: context.sac.textSecondary,
+              fontWeight: FontWeight.w500,
+            ),
+          ),
+          const SizedBox(height: 6),
+          SegmentedButton<AllergySeverity>(
+            segments: [
+              ButtonSegment(
+                value: AllergySeverity.leve,
+                label: Text(
+                  'profile.medical_info.severity.leve'.tr(),
+                  style: const TextStyle(fontSize: 12),
+                ),
+              ),
+              ButtonSegment(
+                value: AllergySeverity.media,
+                label: Text(
+                  'profile.medical_info.severity.media'.tr(),
+                  style: const TextStyle(fontSize: 12),
+                ),
+              ),
+              ButtonSegment(
+                value: AllergySeverity.alta,
+                label: Text(
+                  'profile.medical_info.severity.alta'.tr(),
+                  style: const TextStyle(fontSize: 12),
+                ),
+              ),
+            ],
+            selected: {selectedSeverity},
+            onSelectionChanged: (selection) {
+              if (selection.isNotEmpty) onChanged(selection.first);
+            },
+            style: ButtonStyle(
+              tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+              visualDensity: VisualDensity.compact,
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/lib/features/post_registration/presentation/views/diseases_selection_view.dart
+++ b/lib/features/post_registration/presentation/views/diseases_selection_view.dart
@@ -586,8 +586,7 @@ class _SinceYearInlineEditorState extends State<_SinceYearInlineEditor> {
 
     if (year == null || year < 1900 || year > currentYear) {
       setState(() {
-        _errorText =
-            'post_registration.diseases.since_year_invalid'.tr();
+        _errorText = 'post_registration.diseases.since_year_invalid'.tr();
       });
       widget.onChanged(null);
     } else {

--- a/lib/features/post_registration/presentation/views/diseases_selection_view.dart
+++ b/lib/features/post_registration/presentation/views/diseases_selection_view.dart
@@ -1,5 +1,6 @@
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:hugeicons/hugeicons.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:sacdia_app/core/widgets/sac_dialog.dart';
@@ -12,6 +13,7 @@ import '../widgets/searchable_selection_list.dart';
 
 /// Vista para seleccionar y gestionar enfermedades del usuario.
 /// Pre-carga las enfermedades existentes del usuario al inicializarse.
+/// Cada enfermedad seleccionada muestra un input inline para el año de inicio.
 class DiseasesSelectionView extends ConsumerStatefulWidget {
   const DiseasesSelectionView({super.key});
 
@@ -21,13 +23,24 @@ class DiseasesSelectionView extends ConsumerStatefulWidget {
 }
 
 class _DiseasesSelectionViewState extends ConsumerState<DiseasesSelectionView> {
+  /// Mapa local id → since_year para las enfermedades seleccionadas.
+  final Map<int, int?> _sinceYearMap = {};
+  bool _sinceYearSeeded = false;
+
   @override
   void initState() {
     super.initState();
-    // Pre-cargar enfermedades del usuario al entrar a la vista.
     Future.microtask(() {
       ref.read(userDiseasesProvider.notifier).refresh();
     });
+  }
+
+  void _seedSinceYear(List<DiseaseModel> serverDiseases) {
+    if (_sinceYearSeeded) return;
+    _sinceYearSeeded = true;
+    for (final d in serverDiseases) {
+      if (d.sinceYear != null) _sinceYearMap[d.id] = d.sinceYear;
+    }
   }
 
   Future<void> _showDeleteConfirmation(
@@ -47,6 +60,9 @@ class _DiseasesSelectionViewState extends ConsumerState<DiseasesSelectionView> {
     if (confirmed == true && context.mounted) {
       try {
         await ref.read(userDiseasesProvider.notifier).deleteDisease(diseaseId);
+        setState(() {
+          _sinceYearMap.remove(diseaseId);
+        });
         if (context.mounted) {
           ScaffoldMessenger.of(context).showSnackBar(
             SnackBar(
@@ -82,17 +98,13 @@ class _DiseasesSelectionViewState extends ConsumerState<DiseasesSelectionView> {
 
   @override
   Widget build(BuildContext context) {
-    // Seed selection state the first time user diseases load from the API.
-    // The guard `prev?.value == null` ensures this only fires once on
-    // the loading→data transition, not on every rebuild. Because
-    // userDiseasesProvider is .autoDispose, it resets when the screen is
-    // left, so re-entering the screen will re-seed correctly.
     ref.listen<AsyncValue<List<DiseaseModel>>>(
       userDiseasesProvider,
       (prev, next) {
         if (prev?.value == null && next.value != null) {
           ref.read(selectedDiseasesProvider.notifier).state =
               next.value!.map((d) => d.id).toList();
+          _seedSinceYear(next.value!);
         }
       },
     );
@@ -107,13 +119,22 @@ class _DiseasesSelectionViewState extends ConsumerState<DiseasesSelectionView> {
         actions: [
           IconButton(
             icon: HugeIcon(icon: HugeIcons.strokeRoundedRefresh, size: 24),
-            onPressed: () => ref.read(userDiseasesProvider.notifier).refresh(),
+            onPressed: () {
+              setState(() => _sinceYearSeeded = false);
+              ref.read(userDiseasesProvider.notifier).refresh();
+            },
             tooltip: 'post_registration.health.diseases.refresh_tooltip'.tr(),
           ),
           TextButton.icon(
             onPressed: () async {
               final ids = ref.read(selectedDiseasesProvider);
-              await ref.read(userDiseasesProvider.notifier).saveAll(ids);
+              final entries = ids
+                  .map((id) => DiseaseEntry(
+                        id: id,
+                        sinceYear: _sinceYearMap[id],
+                      ))
+                  .toList();
+              await ref.read(userDiseasesProvider.notifier).saveAll(entries);
               if (context.mounted) Navigator.of(context).pop();
             },
             icon: const HugeIcon(
@@ -155,7 +176,6 @@ class _DiseasesSelectionViewState extends ConsumerState<DiseasesSelectionView> {
                   ))
               .toList();
 
-          // Enfermedades actualmente guardadas en la API
           final savedDiseases = userDiseasesAsync.valueOrNull ?? [];
 
           return Column(
@@ -241,13 +261,19 @@ class _DiseasesSelectionViewState extends ConsumerState<DiseasesSelectionView> {
                 const Divider(height: 1),
               ],
 
-              // Lista de selección
+              // Lista de selección con editor inline de año
               Expanded(
-                child: SearchableSelectionList(
+                child: _DiseasesListWithYear(
                   items: items,
                   selectedIds: selectedIds,
+                  sinceYearMap: _sinceYearMap,
                   onSelectionChanged: (ids) {
                     ref.read(selectedDiseasesProvider.notifier).state = ids;
+                  },
+                  onSinceYearChanged: (id, year) {
+                    setState(() {
+                      _sinceYearMap[id] = year;
+                    });
                   },
                   searchHint:
                       'post_registration.health.diseases.search_hint'.tr(),
@@ -259,6 +285,343 @@ class _DiseasesSelectionViewState extends ConsumerState<DiseasesSelectionView> {
             ],
           );
         },
+      ),
+    );
+  }
+}
+
+/// Lista con búsqueda + input inline de año para enfermedades seleccionadas.
+class _DiseasesListWithYear extends StatefulWidget {
+  final List<SelectableItem> items;
+  final List<int> selectedIds;
+  final Map<int, int?> sinceYearMap;
+  final Function(List<int>) onSelectionChanged;
+  final Function(int, int?) onSinceYearChanged;
+  final String? searchHint;
+  final bool hasNoneOption;
+  final String noneOptionLabel;
+
+  const _DiseasesListWithYear({
+    required this.items,
+    required this.selectedIds,
+    required this.sinceYearMap,
+    required this.onSelectionChanged,
+    required this.onSinceYearChanged,
+    this.searchHint,
+    this.hasNoneOption = true,
+    this.noneOptionLabel = 'Ninguna',
+  });
+
+  @override
+  State<_DiseasesListWithYear> createState() => _DiseasesListWithYearState();
+}
+
+class _DiseasesListWithYearState extends State<_DiseasesListWithYear> {
+  final TextEditingController _searchController = TextEditingController();
+  String _searchQuery = '';
+  late List<SelectableItem> _items;
+
+  /// Mapa de controllers de TextField para cada item seleccionado
+  final Map<int, TextEditingController> _yearControllers = {};
+
+  static const int _noneOptionId = -1;
+
+  @override
+  void initState() {
+    super.initState();
+    _initializeItems();
+  }
+
+  void _initializeItems() {
+    _items = widget.items.map((item) {
+      return SelectableItem(
+        id: item.id,
+        name: item.name,
+        isSelected: widget.selectedIds.contains(item.id),
+      );
+    }).toList();
+
+    if (widget.hasNoneOption) {
+      _items.insert(
+        0,
+        SelectableItem(
+          id: _noneOptionId,
+          name: widget.noneOptionLabel,
+          isSelected: widget.selectedIds.isEmpty,
+        ),
+      );
+    }
+  }
+
+  @override
+  void didUpdateWidget(_DiseasesListWithYear oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.selectedIds != widget.selectedIds ||
+        oldWidget.items != widget.items) {
+      _initializeItems();
+    }
+  }
+
+  TextEditingController _controllerFor(int id) {
+    return _yearControllers.putIfAbsent(id, () {
+      final existing = widget.sinceYearMap[id];
+      return TextEditingController(
+          text: existing != null ? existing.toString() : '');
+    });
+  }
+
+  @override
+  void dispose() {
+    _searchController.dispose();
+    for (final c in _yearControllers.values) {
+      c.dispose();
+    }
+    super.dispose();
+  }
+
+  List<SelectableItem> get _filteredItems {
+    if (_searchQuery.isEmpty) return _items;
+    return _items
+        .where((item) =>
+            item.name.toLowerCase().contains(_searchQuery.toLowerCase()))
+        .toList();
+  }
+
+  void _handleItemToggle(SelectableItem item) {
+    setState(() {
+      if (item.id == _noneOptionId) {
+        for (var i in _items) {
+          i.isSelected = i.id == _noneOptionId;
+        }
+      } else {
+        item.isSelected = !item.isSelected;
+        final noneItem = _items.firstWhere(
+          (i) => i.id == _noneOptionId,
+          orElse: () => item,
+        );
+        if (noneItem.id == _noneOptionId) noneItem.isSelected = false;
+      }
+
+      final selectedIds = _items
+          .where((i) => i.isSelected && i.id != _noneOptionId)
+          .map((i) => i.id)
+          .toList();
+
+      widget.onSelectionChanged(selectedIds);
+    });
+  }
+
+  String _getSelectionCountText() {
+    final count =
+        _items.where((i) => i.isSelected && i.id != _noneOptionId).length;
+    if (count == 0) return tr('common.none_selected');
+    if (count == 1) return tr('common.items_selected_one');
+    return tr('common.items_selected_other', namedArgs: {'count': '$count'});
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final filteredItems = _filteredItems;
+
+    return Column(
+      children: [
+        Padding(
+          padding: const EdgeInsets.all(16),
+          child: TextField(
+            controller: _searchController,
+            decoration: InputDecoration(
+              hintText: widget.searchHint ?? tr('common.search'),
+              prefixIcon:
+                  HugeIcon(icon: HugeIcons.strokeRoundedSearch01, size: 22),
+              suffixIcon: _searchQuery.isNotEmpty
+                  ? IconButton(
+                      icon: HugeIcon(
+                          icon: HugeIcons.strokeRoundedCancel01, size: 22),
+                      onPressed: () {
+                        setState(() {
+                          _searchController.clear();
+                          _searchQuery = '';
+                        });
+                      },
+                    )
+                  : null,
+              border: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(12),
+              ),
+              filled: true,
+              fillColor: context.sac.surfaceVariant,
+            ),
+            onChanged: (value) {
+              setState(() {
+                _searchQuery = value;
+              });
+            },
+          ),
+        ),
+        Expanded(
+          child: filteredItems.isEmpty
+              ? Center(
+                  child: Column(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      HugeIcon(
+                        icon: HugeIcons.strokeRoundedSearchMinus,
+                        size: 64,
+                        color: context.sac.textTertiary,
+                      ),
+                      const SizedBox(height: 16),
+                      Text(
+                        tr('common.no_results'),
+                        style: TextStyle(
+                          fontSize: 16,
+                          color: context.sac.textSecondary,
+                        ),
+                      ),
+                    ],
+                  ),
+                )
+              : ListView.builder(
+                  itemCount: filteredItems.length,
+                  itemBuilder: (context, index) {
+                    final item = filteredItems[index];
+                    final isNoneOption = item.id == _noneOptionId;
+                    final isSelected = item.isSelected && !isNoneOption;
+
+                    return Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        ListTile(
+                          title: Text(
+                            item.name,
+                            style: TextStyle(
+                              fontWeight: isNoneOption
+                                  ? FontWeight.bold
+                                  : FontWeight.normal,
+                            ),
+                          ),
+                          leading: Checkbox(
+                            value: item.isSelected,
+                            onChanged: (_) => _handleItemToggle(item),
+                          ),
+                          onTap: () => _handleItemToggle(item),
+                        ),
+                        // Inline year input cuando está seleccionada
+                        if (isSelected)
+                          _SinceYearInlineEditor(
+                            controller: _controllerFor(item.id),
+                            onChanged: (year) =>
+                                widget.onSinceYearChanged(item.id, year),
+                          ),
+                      ],
+                    );
+                  },
+                ),
+        ),
+        Container(
+          padding: const EdgeInsets.all(16),
+          decoration: BoxDecoration(
+            color: context.sac.surfaceVariant,
+            border: Border(top: BorderSide(color: context.sac.border)),
+          ),
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Text(
+                _getSelectionCountText(),
+                style: TextStyle(
+                  fontSize: 14,
+                  color: context.sac.textSecondary,
+                  fontWeight: FontWeight.w500,
+                ),
+              ),
+              if (_items.any((i) => i.isSelected && i.id != _noneOptionId))
+                TextButton.icon(
+                  icon:
+                      HugeIcon(icon: HugeIcons.strokeRoundedCancel02, size: 20),
+                  label: Text(tr('common.clear')),
+                  onPressed: () {
+                    setState(() {
+                      for (var item in _items) {
+                        item.isSelected = item.id == _noneOptionId;
+                      }
+                      widget.onSelectionChanged([]);
+                    });
+                  },
+                ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+/// Editor inline de año (TextField numérico de 4 dígitos, validado 1900–año actual).
+class _SinceYearInlineEditor extends StatefulWidget {
+  final TextEditingController controller;
+  final ValueChanged<int?> onChanged;
+
+  const _SinceYearInlineEditor({
+    required this.controller,
+    required this.onChanged,
+  });
+
+  @override
+  State<_SinceYearInlineEditor> createState() => _SinceYearInlineEditorState();
+}
+
+class _SinceYearInlineEditorState extends State<_SinceYearInlineEditor> {
+  String? _errorText;
+
+  void _validate(String value) {
+    final trimmed = value.trim();
+    if (trimmed.isEmpty) {
+      setState(() => _errorText = null);
+      widget.onChanged(null);
+      return;
+    }
+
+    final year = int.tryParse(trimmed);
+    final currentYear = DateTime.now().year;
+
+    if (year == null || year < 1900 || year > currentYear) {
+      setState(() {
+        _errorText =
+            'post_registration.diseases.since_year_invalid'.tr();
+      });
+      widget.onChanged(null);
+    } else {
+      setState(() => _errorText = null);
+      widget.onChanged(year);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(left: 56, right: 16, bottom: 8),
+      child: TextField(
+        controller: widget.controller,
+        decoration: InputDecoration(
+          labelText: 'post_registration.diseases.since_year_label'.tr(),
+          hintText: 'post_registration.diseases.since_year_hint'.tr(),
+          errorText: _errorText,
+          isDense: true,
+          border: OutlineInputBorder(
+            borderRadius: BorderRadius.circular(8),
+          ),
+          suffixText: 'common.optional'.tr(),
+          suffixStyle: TextStyle(
+            fontSize: 11,
+            color: context.sac.textTertiary,
+          ),
+        ),
+        keyboardType: TextInputType.number,
+        inputFormatters: [
+          FilteringTextInputFormatter.digitsOnly,
+          LengthLimitingTextInputFormatter(4),
+        ],
+        onChanged: _validate,
       ),
     );
   }

--- a/lib/features/post_registration/presentation/views/medicines_selection_view.dart
+++ b/lib/features/post_registration/presentation/views/medicines_selection_view.dart
@@ -12,6 +12,7 @@ import '../widgets/searchable_selection_list.dart';
 
 /// Vista para seleccionar y gestionar medicamentos del usuario.
 /// Pre-carga los medicamentos existentes del usuario al inicializarse.
+/// Cada medicamento seleccionado muestra un input inline para la dosis.
 class MedicinesSelectionView extends ConsumerStatefulWidget {
   const MedicinesSelectionView({super.key});
 
@@ -22,13 +23,24 @@ class MedicinesSelectionView extends ConsumerStatefulWidget {
 
 class _MedicinesSelectionViewState
     extends ConsumerState<MedicinesSelectionView> {
+  /// Mapa local id → dosis para los medicamentos seleccionados.
+  final Map<int, String?> _doseMap = {};
+  bool _doseSeeded = false;
+
   @override
   void initState() {
     super.initState();
-    // Pre-cargar medicamentos del usuario al entrar a la vista.
     Future.microtask(() {
       ref.read(userMedicinesProvider.notifier).refresh();
     });
+  }
+
+  void _seedDose(List<MedicineModel> serverMedicines) {
+    if (_doseSeeded) return;
+    _doseSeeded = true;
+    for (final m in serverMedicines) {
+      if (m.dose != null) _doseMap[m.id] = m.dose;
+    }
   }
 
   Future<void> _showDeleteConfirmation(
@@ -50,6 +62,9 @@ class _MedicinesSelectionViewState
         await ref
             .read(userMedicinesProvider.notifier)
             .deleteMedicine(medicineId);
+        setState(() {
+          _doseMap.remove(medicineId);
+        });
         if (context.mounted) {
           ScaffoldMessenger.of(context).showSnackBar(
             SnackBar(
@@ -85,17 +100,13 @@ class _MedicinesSelectionViewState
 
   @override
   Widget build(BuildContext context) {
-    // Seed selection state the first time user medicines load from the API.
-    // The guard `prev?.value == null` ensures this only fires once on
-    // the loading→data transition, not on every rebuild. Because
-    // userMedicinesProvider is .autoDispose, it resets when the screen is
-    // left, so re-entering the screen will re-seed correctly.
     ref.listen<AsyncValue<List<MedicineModel>>>(
       userMedicinesProvider,
       (prev, next) {
         if (prev?.value == null && next.value != null) {
           ref.read(selectedMedicinesProvider.notifier).state =
               next.value!.map((m) => m.id).toList();
+          _seedDose(next.value!);
         }
       },
     );
@@ -110,13 +121,22 @@ class _MedicinesSelectionViewState
         actions: [
           IconButton(
             icon: HugeIcon(icon: HugeIcons.strokeRoundedRefresh, size: 24),
-            onPressed: () => ref.read(userMedicinesProvider.notifier).refresh(),
+            onPressed: () {
+              setState(() => _doseSeeded = false);
+              ref.read(userMedicinesProvider.notifier).refresh();
+            },
             tooltip: 'post_registration.health.medicines.refresh_tooltip'.tr(),
           ),
           TextButton.icon(
             onPressed: () async {
               final ids = ref.read(selectedMedicinesProvider);
-              await ref.read(userMedicinesProvider.notifier).saveAll(ids);
+              final entries = ids
+                  .map((id) => MedicineEntry(
+                        id: id,
+                        dose: _doseMap[id],
+                      ))
+                  .toList();
+              await ref.read(userMedicinesProvider.notifier).saveAll(entries);
               if (context.mounted) Navigator.of(context).pop();
             },
             icon: const HugeIcon(
@@ -158,7 +178,6 @@ class _MedicinesSelectionViewState
                   ))
               .toList();
 
-          // Medicamentos actualmente guardados en la API
           final savedMedicines = userMedicinesAsync.valueOrNull ?? [];
 
           return Column(
@@ -244,13 +263,19 @@ class _MedicinesSelectionViewState
                 const Divider(height: 1),
               ],
 
-              // Lista de selección
+              // Lista de selección con editor inline de dosis
               Expanded(
-                child: SearchableSelectionList(
+                child: _MedicinesListWithDose(
                   items: items,
                   selectedIds: selectedIds,
+                  doseMap: _doseMap,
                   onSelectionChanged: (ids) {
                     ref.read(selectedMedicinesProvider.notifier).state = ids;
+                  },
+                  onDoseChanged: (id, dose) {
+                    setState(() {
+                      _doseMap[id] = dose;
+                    });
                   },
                   searchHint:
                       'post_registration.health.medicines.search_hint'.tr(),
@@ -262,6 +287,338 @@ class _MedicinesSelectionViewState
             ],
           );
         },
+      ),
+    );
+  }
+}
+
+/// Lista con búsqueda + input inline de dosis para medicamentos seleccionados.
+class _MedicinesListWithDose extends StatefulWidget {
+  final List<SelectableItem> items;
+  final List<int> selectedIds;
+  final Map<int, String?> doseMap;
+  final Function(List<int>) onSelectionChanged;
+  final Function(int, String?) onDoseChanged;
+  final String? searchHint;
+  final bool hasNoneOption;
+  final String noneOptionLabel;
+
+  const _MedicinesListWithDose({
+    required this.items,
+    required this.selectedIds,
+    required this.doseMap,
+    required this.onSelectionChanged,
+    required this.onDoseChanged,
+    this.searchHint,
+    this.hasNoneOption = true,
+    this.noneOptionLabel = 'Ninguno',
+  });
+
+  @override
+  State<_MedicinesListWithDose> createState() => _MedicinesListWithDoseState();
+}
+
+class _MedicinesListWithDoseState extends State<_MedicinesListWithDose> {
+  final TextEditingController _searchController = TextEditingController();
+  String _searchQuery = '';
+  late List<SelectableItem> _items;
+  final Map<int, TextEditingController> _doseControllers = {};
+
+  static const int _noneOptionId = -1;
+
+  @override
+  void initState() {
+    super.initState();
+    _initializeItems();
+  }
+
+  void _initializeItems() {
+    _items = widget.items.map((item) {
+      return SelectableItem(
+        id: item.id,
+        name: item.name,
+        isSelected: widget.selectedIds.contains(item.id),
+      );
+    }).toList();
+
+    if (widget.hasNoneOption) {
+      _items.insert(
+        0,
+        SelectableItem(
+          id: _noneOptionId,
+          name: widget.noneOptionLabel,
+          isSelected: widget.selectedIds.isEmpty,
+        ),
+      );
+    }
+  }
+
+  @override
+  void didUpdateWidget(_MedicinesListWithDose oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.selectedIds != widget.selectedIds ||
+        oldWidget.items != widget.items) {
+      _initializeItems();
+    }
+  }
+
+  TextEditingController _controllerFor(int id) {
+    return _doseControllers.putIfAbsent(id, () {
+      final existing = widget.doseMap[id];
+      return TextEditingController(text: existing ?? '');
+    });
+  }
+
+  @override
+  void dispose() {
+    _searchController.dispose();
+    for (final c in _doseControllers.values) {
+      c.dispose();
+    }
+    super.dispose();
+  }
+
+  List<SelectableItem> get _filteredItems {
+    if (_searchQuery.isEmpty) return _items;
+    return _items
+        .where((item) =>
+            item.name.toLowerCase().contains(_searchQuery.toLowerCase()))
+        .toList();
+  }
+
+  void _handleItemToggle(SelectableItem item) {
+    setState(() {
+      if (item.id == _noneOptionId) {
+        for (var i in _items) {
+          i.isSelected = i.id == _noneOptionId;
+        }
+      } else {
+        item.isSelected = !item.isSelected;
+        final noneItem = _items.firstWhere(
+          (i) => i.id == _noneOptionId,
+          orElse: () => item,
+        );
+        if (noneItem.id == _noneOptionId) noneItem.isSelected = false;
+      }
+
+      final selectedIds = _items
+          .where((i) => i.isSelected && i.id != _noneOptionId)
+          .map((i) => i.id)
+          .toList();
+
+      widget.onSelectionChanged(selectedIds);
+    });
+  }
+
+  String _getSelectionCountText() {
+    final count =
+        _items.where((i) => i.isSelected && i.id != _noneOptionId).length;
+    if (count == 0) return tr('common.none_selected');
+    if (count == 1) return tr('common.items_selected_one');
+    return tr('common.items_selected_other', namedArgs: {'count': '$count'});
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final filteredItems = _filteredItems;
+
+    return Column(
+      children: [
+        Padding(
+          padding: const EdgeInsets.all(16),
+          child: TextField(
+            controller: _searchController,
+            decoration: InputDecoration(
+              hintText: widget.searchHint ?? tr('common.search'),
+              prefixIcon:
+                  HugeIcon(icon: HugeIcons.strokeRoundedSearch01, size: 22),
+              suffixIcon: _searchQuery.isNotEmpty
+                  ? IconButton(
+                      icon: HugeIcon(
+                          icon: HugeIcons.strokeRoundedCancel01, size: 22),
+                      onPressed: () {
+                        setState(() {
+                          _searchController.clear();
+                          _searchQuery = '';
+                        });
+                      },
+                    )
+                  : null,
+              border: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(12),
+              ),
+              filled: true,
+              fillColor: context.sac.surfaceVariant,
+            ),
+            onChanged: (value) {
+              setState(() {
+                _searchQuery = value;
+              });
+            },
+          ),
+        ),
+        Expanded(
+          child: filteredItems.isEmpty
+              ? Center(
+                  child: Column(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      HugeIcon(
+                        icon: HugeIcons.strokeRoundedSearchMinus,
+                        size: 64,
+                        color: context.sac.textTertiary,
+                      ),
+                      const SizedBox(height: 16),
+                      Text(
+                        tr('common.no_results'),
+                        style: TextStyle(
+                          fontSize: 16,
+                          color: context.sac.textSecondary,
+                        ),
+                      ),
+                    ],
+                  ),
+                )
+              : ListView.builder(
+                  itemCount: filteredItems.length,
+                  itemBuilder: (context, index) {
+                    final item = filteredItems[index];
+                    final isNoneOption = item.id == _noneOptionId;
+                    final isSelected = item.isSelected && !isNoneOption;
+
+                    return Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        ListTile(
+                          title: Text(
+                            item.name,
+                            style: TextStyle(
+                              fontWeight: isNoneOption
+                                  ? FontWeight.bold
+                                  : FontWeight.normal,
+                            ),
+                          ),
+                          leading: Checkbox(
+                            value: item.isSelected,
+                            onChanged: (_) => _handleItemToggle(item),
+                          ),
+                          onTap: () => _handleItemToggle(item),
+                        ),
+                        // Inline dose input cuando está seleccionado
+                        if (isSelected)
+                          _DoseInlineEditor(
+                            controller: _controllerFor(item.id),
+                            onChanged: (dose) =>
+                                widget.onDoseChanged(item.id, dose),
+                          ),
+                      ],
+                    );
+                  },
+                ),
+        ),
+        Container(
+          padding: const EdgeInsets.all(16),
+          decoration: BoxDecoration(
+            color: context.sac.surfaceVariant,
+            border: Border(top: BorderSide(color: context.sac.border)),
+          ),
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Text(
+                _getSelectionCountText(),
+                style: TextStyle(
+                  fontSize: 14,
+                  color: context.sac.textSecondary,
+                  fontWeight: FontWeight.w500,
+                ),
+              ),
+              if (_items.any((i) => i.isSelected && i.id != _noneOptionId))
+                TextButton.icon(
+                  icon:
+                      HugeIcon(icon: HugeIcons.strokeRoundedCancel02, size: 20),
+                  label: Text(tr('common.clear')),
+                  onPressed: () {
+                    setState(() {
+                      for (var item in _items) {
+                        item.isSelected = item.id == _noneOptionId;
+                      }
+                      widget.onSelectionChanged([]);
+                    });
+                  },
+                ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+/// Editor inline de dosis (TextField libre, max 255 chars, opcional).
+class _DoseInlineEditor extends StatefulWidget {
+  final TextEditingController controller;
+  final ValueChanged<String?> onChanged;
+
+  const _DoseInlineEditor({
+    required this.controller,
+    required this.onChanged,
+  });
+
+  @override
+  State<_DoseInlineEditor> createState() => _DoseInlineEditorState();
+}
+
+class _DoseInlineEditorState extends State<_DoseInlineEditor> {
+  String? _errorText;
+
+  void _validate(String value) {
+    final trimmed = value.trim();
+    if (trimmed.isEmpty) {
+      setState(() => _errorText = null);
+      widget.onChanged(null);
+      return;
+    }
+
+    if (trimmed.length > 255) {
+      setState(() {
+        _errorText = 'post_registration.medicines.dose_too_long'.tr();
+      });
+      // Still notify with truncated value to avoid silent data loss
+      widget.onChanged(null);
+    } else {
+      setState(() => _errorText = null);
+      widget.onChanged(trimmed);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(left: 56, right: 16, bottom: 8),
+      child: TextField(
+        controller: widget.controller,
+        decoration: InputDecoration(
+          labelText: 'post_registration.medicines.dose_label'.tr(),
+          hintText: 'post_registration.medicines.dose_hint'.tr(),
+          errorText: _errorText,
+          isDense: true,
+          border: OutlineInputBorder(
+            borderRadius: BorderRadius.circular(8),
+          ),
+          suffixText: 'common.optional'.tr(),
+          suffixStyle: TextStyle(
+            fontSize: 11,
+            color: context.sac.textTertiary,
+          ),
+        ),
+        maxLength: 255,
+        buildCounter: (context,
+                {required currentLength,
+                required isFocused,
+                required maxLength}) =>
+            null, // hide the counter
+        onChanged: _validate,
       ),
     );
   }


### PR DESCRIPTION
## Summary
- `AllergyModel` gains `severity` (enum `leve|media|alta`) + `AllergySeverityX` extension for parsing/display
- `DiseaseModel` gains nullable `sinceYear` (int)
- `MedicineModel` gains nullable `dose` (string)
- Datasource PUT body switches to object shape: `{allergies:[{id, severity}]}`, etc.
- Providers re-export entry DTOs and propagate clinical fields
- Selection views gain inline editor per selected item:
  - Allergies: `SegmentedButton<AllergySeverity>` (default `leve`)
  - Diseases: numeric `TextField` (1900 ↔ current year, optional)
  - Medicines: free-text `TextField` (max 255, optional)
- i18n: 10 new keys × 4 locales (`es` `en` `fr` `pt-BR`)

## Pairs with
Backend PR: https://github.com/abn-r/sacdia-backend/pulls (feat/medical-info-redesign)

## Test plan
- [x] `flutter analyze` clean on touched files
- [ ] Reviewer: post-registration flow — select an allergy, change severity, save, reload, verify chip shows new severity
- [ ] Reviewer: edit a disease year, save, reload, verify persisted
- [ ] Reviewer: edit a medicine dose, save, reload, verify persisted
- [ ] Reviewer: try with backend NOT updated → expect 400

## UI changes
None in this PR. `medical_info_view.dart` is unchanged. UI redesign is the stacked follow-up PR `feat/medical-info-redesign-ui`.