### PR TITLE
feat(profile): redesign Información Médica screen with medico package

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -2669,6 +2669,29 @@
         "leve": "Mild",
         "media": "Moderate",
         "alta": "High"
+      },
+      "hero": {
+        "eyebrow": "BLOOD TYPE",
+        "completeness_title": "Profile complete",
+        "completeness_format": "{filled} of {total}",
+        "empty_blood": "—",
+        "rh_positive": "Rh positive",
+        "rh_negative": "Rh negative"
+      },
+      "appbar": {
+        "eyebrow": "PROFILE"
+      },
+      "contact": {
+        "call_aria": "Call",
+        "sms_aria": "Send SMS"
+      },
+      "sos": {
+        "button": "SOS",
+        "coming_soon": "Emergency mode · coming soon"
+      },
+      "empty": {
+        "add_contact_cta": "Add first one",
+        "no_blood": "No blood type registered · tap to complete"
       }
     },
     "settings": {

--- a/assets/translations/es.json
+++ b/assets/translations/es.json
@@ -2669,6 +2669,29 @@
         "leve": "Leve",
         "media": "Media",
         "alta": "Alta"
+      },
+      "hero": {
+        "eyebrow": "TIPO DE SANGRE",
+        "completeness_title": "Ficha completa",
+        "completeness_format": "{filled} de {total}",
+        "empty_blood": "—",
+        "rh_positive": "Rh positivo",
+        "rh_negative": "Rh negativo"
+      },
+      "appbar": {
+        "eyebrow": "PERFIL"
+      },
+      "contact": {
+        "call_aria": "Llamar",
+        "sms_aria": "Enviar mensaje"
+      },
+      "sos": {
+        "button": "SOS",
+        "coming_soon": "Modo emergencia · próximamente"
+      },
+      "empty": {
+        "add_contact_cta": "Agregar el primero",
+        "no_blood": "Sin tipo de sangre registrado · tocá para completar"
       }
     },
     "settings": {

--- a/assets/translations/fr.json
+++ b/assets/translations/fr.json
@@ -2669,6 +2669,29 @@
         "leve": "Léger",
         "media": "Moyen",
         "alta": "Élevé"
+      },
+      "hero": {
+        "eyebrow": "GROUPE SANGUIN",
+        "completeness_title": "Fiche complète",
+        "completeness_format": "{filled} sur {total}",
+        "empty_blood": "—",
+        "rh_positive": "Rh positif",
+        "rh_negative": "Rh négatif"
+      },
+      "appbar": {
+        "eyebrow": "PROFIL"
+      },
+      "contact": {
+        "call_aria": "Appeler",
+        "sms_aria": "Envoyer un SMS"
+      },
+      "sos": {
+        "button": "SOS",
+        "coming_soon": "Mode urgence · bientôt disponible"
+      },
+      "empty": {
+        "add_contact_cta": "Ajouter le premier",
+        "no_blood": "Aucun groupe sanguin enregistré · appuyez pour compléter"
       }
     },
     "settings": {

--- a/assets/translations/pt-BR.json
+++ b/assets/translations/pt-BR.json
@@ -2669,6 +2669,29 @@
         "leve": "Leve",
         "media": "Média",
         "alta": "Alta"
+      },
+      "hero": {
+        "eyebrow": "TIPO SANGUÍNEO",
+        "completeness_title": "Ficha completa",
+        "completeness_format": "{filled} de {total}",
+        "empty_blood": "—",
+        "rh_positive": "Rh positivo",
+        "rh_negative": "Rh negativo"
+      },
+      "appbar": {
+        "eyebrow": "PERFIL"
+      },
+      "contact": {
+        "call_aria": "Ligar",
+        "sms_aria": "Enviar mensagem"
+      },
+      "sos": {
+        "button": "SOS",
+        "coming_soon": "Modo emergência · em breve"
+      },
+      "empty": {
+        "add_contact_cta": "Adicionar o primeiro",
+        "no_blood": "Nenhum tipo sanguíneo registrado · toque para completar"
       }
     },
     "settings": {

--- a/lib/core/config/route_names.dart
+++ b/lib/core/config/route_names.dart
@@ -43,6 +43,9 @@ class RouteNames {
   // Información médica del usuario (detalle fuera del shell)
   static const String homeMedicalInfo = '/home/medical-info';
 
+  // SOS / Modo emergencia — sub-ruta de información médica
+  static const String medicalSos = '/profile/medical/sos';
+
   // Rutas de detalle fuera del shell
   static const String certificationDetail = '/certification/:certificationId';
   static const String certificationProgress =

--- a/lib/core/config/router.dart
+++ b/lib/core/config/router.dart
@@ -73,6 +73,7 @@ import '../../features/classes/presentation/views/roadmap_full_screen_view.dart'
 import '../../features/members/presentation/views/members_view.dart';
 import '../../features/profile/presentation/views/profile_view.dart';
 import '../../features/profile/presentation/views/medical_info_view.dart';
+import '../../features/profile/presentation/views/emergency_mode_view.dart';
 import '../animations/page_transitions.dart';
 import '../utils/responsive.dart';
 import '../../features/auth/domain/entities/authorization_snapshot.dart';
@@ -550,6 +551,13 @@ final routerProvider = Provider<GoRouter>((ref) {
         path: RouteNames.homeMedicalInfo,
         pageBuilder: (context, state) =>
             _sharedAxisBuild(context, state, const MedicalInfoView()),
+      ),
+
+      // SOS / Modo emergencia (fullscreen, deep-linkable)
+      GoRoute(
+        path: RouteNames.medicalSos,
+        pageBuilder: (context, state) =>
+            _slideUpBuild(context, state, const EmergencyModeView()),
       ),
 
       // Detalle de club

--- a/lib/features/profile/presentation/views/emergency_mode_view.dart
+++ b/lib/features/profile/presentation/views/emergency_mode_view.dart
@@ -1,0 +1,45 @@
+import 'package:easy_localization/easy_localization.dart';
+import 'package:flutter/material.dart';
+import '../widgets/medico/medico_tokens.dart';
+
+/// Pantalla placeholder del Modo Emergencia (SOS).
+///
+/// PR4 reemplazará este contenido con la implementación completa
+/// (WakeLock, orientación bloqueada, datos críticos en pantalla).
+class EmergencyModeView extends StatelessWidget {
+  const EmergencyModeView({super.key});
+
+  static const routeName = '/profile/medical/sos';
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: MedicoTokens.rose50,
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Text(
+              'profile.medical_info.sos.button'.tr(),
+              style: const TextStyle(
+                fontSize: 48,
+                fontWeight: FontWeight.w800,
+                color: MedicoTokens.rose500,
+                letterSpacing: -1.5,
+              ),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              'profile.medical_info.sos.coming_soon'.tr(),
+              style: const TextStyle(
+                fontSize: 16,
+                color: MedicoTokens.ink600,
+              ),
+              textAlign: TextAlign.center,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/profile/presentation/views/medical_info_view.dart
+++ b/lib/features/profile/presentation/views/medical_info_view.dart
@@ -28,18 +28,17 @@ import 'emergency_mode_view.dart';
 
 /// Mapea [AllergySeverity] a [SeverityTone] para renderizar chips.
 SeverityTone _severityTone(AllergySeverity severity) => switch (severity) {
-  AllergySeverity.alta => SeverityTone.rose,
-  AllergySeverity.media => SeverityTone.amber,
-  AllergySeverity.leve => SeverityTone.mint,
-};
+      AllergySeverity.alta => SeverityTone.rose,
+      AllergySeverity.media => SeverityTone.amber,
+      AllergySeverity.leve => SeverityTone.mint,
+    };
 
 class MedicalInfoView extends ConsumerWidget {
   const MedicalInfoView({super.key});
 
   // ── Helpers para url_launcher ──────────────────────────────────────────────
 
-  static String _cleanPhone(String p) =>
-      p.replaceAll(RegExp(r'[^0-9+]'), '');
+  static String _cleanPhone(String p) => p.replaceAll(RegExp(r'[^0-9+]'), '');
 
   static Future<void> _call(String phone) async {
     final uri = Uri.parse('tel:${_cleanPhone(phone)}');
@@ -143,7 +142,8 @@ class MedicalInfoView extends ConsumerWidget {
                   children: [
                     // ── Hero: tipo de sangre ────────────────────────────────
                     BloodHeroCard(
-                      bloodType: (blood == null || blood.isEmpty) ? null : blood,
+                      bloodType:
+                          (blood == null || blood.isEmpty) ? null : blood,
                       filled: filled,
                       total: total,
                       onEditar: () => _handleEditBlood(
@@ -173,13 +173,16 @@ class MedicalInfoView extends ConsumerWidget {
                         ),
                         error: (e, _) => _SectionError(
                           message: e.toString(),
-                          onRetry: () => ref.invalidate(emergencyContactsProvider),
+                          onRetry: () =>
+                              ref.invalidate(emergencyContactsProvider),
                         ),
                         data: (contactList) {
                           if (contactList.isEmpty) {
                             return EmptyHint(
                               label: 'profile.medical_info.none_contacts'.tr(),
-                              actionLabel: 'profile.medical_info.empty.add_contact_cta'.tr(),
+                              actionLabel:
+                                  'profile.medical_info.empty.add_contact_cta'
+                                      .tr(),
                               onAction: () => Navigator.of(context).push(
                                 MaterialPageRoute(
                                   builder: (_) => const EmergencyContactsView(),
@@ -229,10 +232,12 @@ class MedicalInfoView extends ConsumerWidget {
                           if (allergyList.isEmpty) {
                             return EmptyHint(
                               label: 'profile.medical_info.none_allergies'.tr(),
-                              actionLabel: 'profile.medical_info.action_edit'.tr(),
+                              actionLabel:
+                                  'profile.medical_info.action_edit'.tr(),
                               onAction: () => Navigator.of(context).push(
                                 MaterialPageRoute(
-                                  builder: (_) => const AllergiesSelectionView(),
+                                  builder: (_) =>
+                                      const AllergiesSelectionView(),
                                 ),
                               ),
                             );
@@ -276,7 +281,8 @@ class MedicalInfoView extends ConsumerWidget {
                           if (diseaseList.isEmpty) {
                             return EmptyHint(
                               label: 'profile.medical_info.none_diseases'.tr(),
-                              actionLabel: 'profile.medical_info.action_edit'.tr(),
+                              actionLabel:
+                                  'profile.medical_info.action_edit'.tr(),
                               onAction: () => Navigator.of(context).push(
                                 MaterialPageRoute(
                                   builder: (_) => const DiseasesSelectionView(),
@@ -285,16 +291,14 @@ class MedicalInfoView extends ConsumerWidget {
                             );
                           }
                           return MedicalChipRow(
-                            children: diseaseList
-                                .map((d) {
-                                  final year = d.sinceYear;
-                                  return MedicalChip(
-                                    label: d.name,
-                                    sub: year != null ? 'desde $year' : null,
-                                    tone: SeverityTone.amber,
-                                  );
-                                })
-                                .toList(),
+                            children: diseaseList.map((d) {
+                              final year = d.sinceYear;
+                              return MedicalChip(
+                                label: d.name,
+                                sub: year != null ? 'desde $year' : null,
+                                tone: SeverityTone.amber,
+                              );
+                            }).toList(),
                           );
                         },
                       ),
@@ -326,10 +330,12 @@ class MedicalInfoView extends ConsumerWidget {
                           if (medicineList.isEmpty) {
                             return EmptyHint(
                               label: 'profile.medical_info.none_medicines'.tr(),
-                              actionLabel: 'profile.medical_info.action_edit'.tr(),
+                              actionLabel:
+                                  'profile.medical_info.action_edit'.tr(),
                               onAction: () => Navigator.of(context).push(
                                 MaterialPageRoute(
-                                  builder: (_) => const MedicinesSelectionView(),
+                                  builder: (_) =>
+                                      const MedicinesSelectionView(),
                                 ),
                               ),
                             );
@@ -377,7 +383,8 @@ class MedicalInfoView extends ConsumerWidget {
                             data: (rep) {
                               if (rep == null) {
                                 return EmptyHint(
-                                  label: 'profile.medical_info.not_registered'.tr(),
+                                  label: 'profile.medical_info.not_registered'
+                                      .tr(),
                                 );
                               }
                               return Column(

--- a/lib/features/profile/presentation/views/medical_info_view.dart
+++ b/lib/features/profile/presentation/views/medical_info_view.dart
@@ -1,24 +1,61 @@
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
-import 'package:hugeicons/hugeicons.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:url_launcher/url_launcher.dart';
 import 'package:sacdia_app/core/theme/app_colors.dart';
-import 'package:sacdia_app/core/utils/icon_helper.dart';
-import 'package:sacdia_app/core/theme/sac_colors.dart';
 import 'package:sacdia_app/core/widgets/sac_loading.dart';
+import 'package:sacdia_app/core/widgets/secure_screen.dart';
+import 'package:sacdia_app/features/post_registration/data/models/allergy_model.dart';
 import 'package:sacdia_app/features/post_registration/presentation/providers/personal_info_providers.dart';
 import 'package:sacdia_app/features/post_registration/presentation/views/allergies_selection_view.dart';
 import 'package:sacdia_app/features/post_registration/presentation/views/diseases_selection_view.dart';
 import 'package:sacdia_app/features/post_registration/presentation/views/medicines_selection_view.dart';
 import 'package:sacdia_app/features/post_registration/presentation/views/emergency_contacts_view.dart';
 import 'package:sacdia_app/features/post_registration/presentation/views/legal_representative_view.dart';
-import 'package:sacdia_app/core/widgets/secure_screen.dart';
 import 'package:sacdia_app/features/profile/presentation/providers/profile_providers.dart';
 import 'package:sacdia_app/features/profile/presentation/widgets/blood_type_selector.dart';
 import 'package:sacdia_app/features/virtual_card/presentation/providers/virtual_card_providers.dart';
 
+import '../widgets/medico/medico_tokens.dart';
+import '../widgets/medico/blood_hero_card.dart';
+import '../widgets/medico/medico_section_card.dart';
+import '../widgets/medico/medical_chip.dart';
+import '../widgets/medico/contact_tile.dart';
+import '../widgets/medico/medicament_tile.dart';
+import '../widgets/medico/empty_hint.dart';
+import 'emergency_mode_view.dart';
+
+/// Mapea [AllergySeverity] a [SeverityTone] para renderizar chips.
+SeverityTone _severityTone(AllergySeverity severity) => switch (severity) {
+  AllergySeverity.alta => SeverityTone.rose,
+  AllergySeverity.media => SeverityTone.amber,
+  AllergySeverity.leve => SeverityTone.mint,
+};
+
 class MedicalInfoView extends ConsumerWidget {
   const MedicalInfoView({super.key});
+
+  // ── Helpers para url_launcher ──────────────────────────────────────────────
+
+  static String _cleanPhone(String p) =>
+      p.replaceAll(RegExp(r'[^0-9+]'), '');
+
+  static Future<void> _call(String phone) async {
+    final uri = Uri.parse('tel:${_cleanPhone(phone)}');
+    if (await canLaunchUrl(uri)) {
+      await launchUrl(uri, mode: LaunchMode.externalApplication);
+    }
+  }
+
+  static Future<void> _sms(String phone) async {
+    final uri = Uri.parse('sms:${_cleanPhone(phone)}');
+    if (await canLaunchUrl(uri)) {
+      await launchUrl(uri, mode: LaunchMode.externalApplication);
+    }
+  }
+
+  // ── Selector de tipo de sangre ─────────────────────────────────────────────
 
   Future<void> _handleEditBlood(
     BuildContext context,
@@ -37,8 +74,6 @@ class MedicalInfoView extends ConsumerWidget {
     });
 
     if (ok) {
-      // Refrescar la credencial digital para que muestre el nuevo tipo
-      // de sangre sin requerir pull-to-refresh manual.
       ref.invalidate(virtualCardFetcherProvider);
     }
 
@@ -58,6 +93,8 @@ class MedicalInfoView extends ConsumerWidget {
     );
   }
 
+  // ── Build ──────────────────────────────────────────────────────────────────
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final allergiesAsync = ref.watch(userAllergiesProvider);
@@ -68,492 +105,431 @@ class MedicalInfoView extends ConsumerWidget {
     final legalRequiredAsync = ref.watch(legalRepresentativeRequiredProvider);
     final profileAsync = ref.watch(profileNotifierProvider);
 
-    final c = context.sac;
+    // Extraer datos crudos para calcular la completitud
+    final blood = profileAsync.valueOrNull?.blood?.trim();
+    final allergies = allergiesAsync.valueOrNull ?? [];
+    final diseases = diseasesAsync.valueOrNull ?? [];
+    final medicines = medicinesAsync.valueOrNull ?? [];
+    final contacts = contactsAsync.valueOrNull ?? [];
+
+    // Calcular completitud: 5 secciones posibles
+    int filled = 0;
+    if (blood != null && blood.isNotEmpty) filled++;
+    if (allergies.isNotEmpty) filled++;
+    if (diseases.isNotEmpty) filled++;
+    if (medicines.isNotEmpty) filled++;
+    if (contacts.isNotEmpty) filled++;
+    const total = 5;
 
     return SecureScreen(
       child: Scaffold(
-        appBar: AppBar(title: Text('profile.medical_info.title'.tr())),
-        body: ListView(
-          padding: const EdgeInsets.all(16),
-          children: [
-            // Tipo de sangre — sección compacta antes de las alergias.
-            _MedicalSectionCard(
-              icon: HugeIcons.strokeRoundedBlood,
-              title: 'profile.medical_info.blood_type'.tr(),
-              iconColor: AppColors.error,
-              body: profileAsync.when(
-                loading: () => const Padding(
-                  padding: EdgeInsets.symmetric(vertical: 8),
-                  child: SacLoadingSmall(),
-                ),
-                error: (e, _) => _SectionError(
-                  message: e.toString(),
-                  onRetry: () =>
-                      ref.read(profileNotifierProvider.notifier).refresh(),
-                ),
-                data: (profile) {
-                  final blood = profile?.blood?.trim();
-                  if (blood == null || blood.isEmpty) {
-                    return Text(
-                      'profile.medical_info.blood_type_unset'.tr(),
-                      style: TextStyle(
-                        fontSize: 14,
-                        color: c.textTertiary,
-                        fontStyle: FontStyle.italic,
-                      ),
-                    );
-                  }
-                  return Container(
-                    padding: const EdgeInsets.symmetric(
-                      horizontal: 14,
-                      vertical: 6,
-                    ),
-                    decoration: BoxDecoration(
-                      color: AppColors.errorLight,
-                      borderRadius: BorderRadius.circular(999),
-                      border: Border.all(
-                        color: AppColors.error.withValues(alpha: 0.3),
+        backgroundColor: MedicoTokens.canvas,
+        body: SafeArea(
+          bottom: false,
+          child: Column(
+            children: [
+              _MedicoAppBar(
+                onBack: () => Navigator.of(context).maybePop(),
+                onSOS: () => context.push(EmergencyModeView.routeName),
+              ),
+              Expanded(
+                child: ListView(
+                  padding: EdgeInsets.fromLTRB(
+                    16,
+                    16,
+                    16,
+                    MediaQuery.of(context).padding.bottom + 24,
+                  ),
+                  children: [
+                    // ── Hero: tipo de sangre ────────────────────────────────
+                    BloodHeroCard(
+                      bloodType: (blood == null || blood.isEmpty) ? null : blood,
+                      filled: filled,
+                      total: total,
+                      onEditar: () => _handleEditBlood(
+                        context,
+                        ref,
+                        profileAsync.valueOrNull?.blood,
                       ),
                     ),
-                    child: Text(
-                      blood,
-                      style: TextStyle(
-                        fontSize: 16,
-                        fontWeight: FontWeight.w800,
-                        color: AppColors.errorDark,
-                        letterSpacing: 0.4,
+                    const SizedBox(height: 14),
+
+                    // ── Contactos de emergencia ─────────────────────────────
+                    MedicoSectionCard(
+                      icon: Icons.contact_phone_outlined,
+                      iconBg: MedicoTokens.coral100,
+                      iconFg: MedicoTokens.coral600,
+                      title: 'profile.medical_info.emergency_contacts'.tr(),
+                      actionLabel: 'profile.medical_info.action_manage'.tr(),
+                      onAction: () => Navigator.of(context).push(
+                        MaterialPageRoute(
+                          builder: (_) => const EmergencyContactsView(),
+                        ),
                       ),
-                    ),
-                  );
-                },
-              ),
-              actionLabel: 'profile.medical_info.action_edit'.tr(),
-              onAction: () => _handleEditBlood(
-                context,
-                ref,
-                profileAsync.valueOrNull?.blood,
-              ),
-            ),
-            const SizedBox(height: 12),
-            _MedicalSectionCard(
-              icon: HugeIcons.strokeRoundedFirstAidKit,
-              title: 'profile.medical_info.allergies'.tr(),
-              iconColor: AppColors.error,
-              body: allergiesAsync.when(
-                loading: () => const Padding(
-                  padding: EdgeInsets.symmetric(vertical: 8),
-                  child: SacLoadingSmall(),
-                ),
-                error: (e, _) => _SectionError(
-                  message: e.toString(),
-                  onRetry: () => ref.invalidate(userAllergiesProvider),
-                ),
-                data: (allergies) {
-                  if (allergies.isEmpty) {
-                    return Text(
-                      'profile.medical_info.none_allergies'.tr(),
-                      style: TextStyle(
-                        fontSize: 14,
-                        color: c.textTertiary,
-                        fontStyle: FontStyle.italic,
-                      ),
-                    );
-                  }
-                  return Wrap(
-                    spacing: 6,
-                    runSpacing: 6,
-                    children: allergies
-                        .map(
-                          (a) => Chip(
-                            label: Text(
-                              a.name,
-                              style: TextStyle(
-                                fontSize: 12,
-                                color: AppColors.errorDark,
-                                fontWeight: FontWeight.w500,
-                              ),
-                            ),
-                            backgroundColor: AppColors.errorLight,
-                            side: BorderSide(
-                              color: AppColors.error.withValues(alpha: 0.3),
-                            ),
-                            materialTapTargetSize:
-                                MaterialTapTargetSize.shrinkWrap,
-                            padding: const EdgeInsets.symmetric(horizontal: 4),
-                          ),
-                        )
-                        .toList(),
-                  );
-                },
-              ),
-              actionLabel: 'profile.medical_info.action_edit'.tr(),
-              onAction: () => Navigator.of(context).push(
-                MaterialPageRoute(
-                  builder: (_) => const AllergiesSelectionView(),
-                ),
-              ),
-            ),
-            const SizedBox(height: 12),
-            _MedicalSectionCard(
-              icon: HugeIcons.strokeRoundedHealth,
-              title: 'profile.medical_info.diseases'.tr(),
-              iconColor: AppColors.accent,
-              body: diseasesAsync.when(
-                loading: () => const Padding(
-                  padding: EdgeInsets.symmetric(vertical: 8),
-                  child: SacLoadingSmall(),
-                ),
-                error: (e, _) => _SectionError(
-                  message: e.toString(),
-                  onRetry: () => ref.invalidate(userDiseasesProvider),
-                ),
-                data: (diseases) {
-                  if (diseases.isEmpty) {
-                    return Text(
-                      'profile.medical_info.none_diseases'.tr(),
-                      style: TextStyle(
-                        fontSize: 14,
-                        color: c.textTertiary,
-                        fontStyle: FontStyle.italic,
-                      ),
-                    );
-                  }
-                  return Wrap(
-                    spacing: 6,
-                    runSpacing: 6,
-                    children: diseases
-                        .map(
-                          (d) => Chip(
-                            label: Text(
-                              d.name,
-                              style: TextStyle(
-                                fontSize: 12,
-                                color: AppColors.accentDark,
-                                fontWeight: FontWeight.w500,
-                              ),
-                            ),
-                            backgroundColor: AppColors.accentLight,
-                            side: BorderSide(
-                              color: AppColors.accent.withValues(alpha: 0.3),
-                            ),
-                            materialTapTargetSize:
-                                MaterialTapTargetSize.shrinkWrap,
-                            padding: const EdgeInsets.symmetric(horizontal: 4),
-                          ),
-                        )
-                        .toList(),
-                  );
-                },
-              ),
-              actionLabel: 'profile.medical_info.action_edit'.tr(),
-              onAction: () => Navigator.of(context).push(
-                MaterialPageRoute(
-                  builder: (_) => const DiseasesSelectionView(),
-                ),
-              ),
-            ),
-            const SizedBox(height: 12),
-            _MedicalSectionCard(
-              icon: HugeIcons.strokeRoundedMedicine01,
-              title: 'profile.medical_info.medicines'.tr(),
-              iconColor: AppColors.secondary,
-              body: medicinesAsync.when(
-                loading: () => const Padding(
-                  padding: EdgeInsets.symmetric(vertical: 8),
-                  child: SacLoadingSmall(),
-                ),
-                error: (e, _) => _SectionError(
-                  message: e.toString(),
-                  onRetry: () => ref.invalidate(userMedicinesProvider),
-                ),
-                data: (medicines) {
-                  if (medicines.isEmpty) {
-                    return Text(
-                      'profile.medical_info.none_medicines'.tr(),
-                      style: TextStyle(
-                        fontSize: 14,
-                        color: c.textTertiary,
-                        fontStyle: FontStyle.italic,
-                      ),
-                    );
-                  }
-                  return Wrap(
-                    spacing: 6,
-                    runSpacing: 6,
-                    children: medicines
-                        .map(
-                          (m) => Chip(
-                            label: Text(
-                              m.name,
-                              style: TextStyle(
-                                fontSize: 12,
-                                color: AppColors.secondaryDark,
-                                fontWeight: FontWeight.w500,
-                              ),
-                            ),
-                            backgroundColor: AppColors.secondaryLight,
-                            side: BorderSide(
-                              color: AppColors.secondary.withValues(alpha: 0.3),
-                            ),
-                            materialTapTargetSize:
-                                MaterialTapTargetSize.shrinkWrap,
-                            padding: const EdgeInsets.symmetric(horizontal: 4),
-                          ),
-                        )
-                        .toList(),
-                  );
-                },
-              ),
-              actionLabel: 'profile.medical_info.action_edit'.tr(),
-              onAction: () => Navigator.of(context).push(
-                MaterialPageRoute(
-                  builder: (_) => const MedicinesSelectionView(),
-                ),
-              ),
-            ),
-            const SizedBox(height: 12),
-            _MedicalSectionCard(
-              icon: HugeIcons.strokeRoundedContactBook,
-              title: 'profile.medical_info.emergency_contacts'.tr(),
-              iconColor: AppColors.primary,
-              body: contactsAsync.when(
-                loading: () => const Padding(
-                  padding: EdgeInsets.symmetric(vertical: 8),
-                  child: SacLoadingSmall(),
-                ),
-                error: (e, _) => _SectionError(
-                  message: e.toString(),
-                  onRetry: () => ref.invalidate(emergencyContactsProvider),
-                ),
-                data: (contacts) {
-                  if (contacts.isEmpty) {
-                    return Text(
-                      'profile.medical_info.none_contacts'.tr(),
-                      style: TextStyle(
-                        fontSize: 14,
-                        color: c.textTertiary,
-                        fontStyle: FontStyle.italic,
-                      ),
-                    );
-                  }
-                  return Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: contacts
-                        .map(
-                          (contact) => Padding(
-                            padding: const EdgeInsets.only(bottom: 8),
-                            child: Row(
-                              children: [
-                                Container(
-                                  width: 32,
-                                  height: 32,
-                                  decoration: BoxDecoration(
-                                    color: AppColors.primaryLight,
-                                    shape: BoxShape.circle,
-                                  ),
-                                  child: Center(
-                                    child: HugeIcon(
-                                      icon: HugeIcons.strokeRoundedUser,
-                                      color: AppColors.primaryDark,
-                                      size: 16,
-                                    ),
-                                  ),
+                      child: contactsAsync.when(
+                        loading: () => const Padding(
+                          padding: EdgeInsets.symmetric(vertical: 8),
+                          child: SacLoadingSmall(),
+                        ),
+                        error: (e, _) => _SectionError(
+                          message: e.toString(),
+                          onRetry: () => ref.invalidate(emergencyContactsProvider),
+                        ),
+                        data: (contactList) {
+                          if (contactList.isEmpty) {
+                            return EmptyHint(
+                              label: 'profile.medical_info.none_contacts'.tr(),
+                              actionLabel: 'profile.medical_info.empty.add_contact_cta'.tr(),
+                              onAction: () => Navigator.of(context).push(
+                                MaterialPageRoute(
+                                  builder: (_) => const EmergencyContactsView(),
                                 ),
-                                const SizedBox(width: 10),
-                                Expanded(
-                                  child: Column(
-                                    crossAxisAlignment:
-                                        CrossAxisAlignment.start,
-                                    children: [
-                                      Text(
-                                        contact.name,
-                                        style: TextStyle(
-                                          fontSize: 14,
-                                          fontWeight: FontWeight.w600,
-                                          color: c.text,
-                                        ),
-                                      ),
-                                      Text(
-                                        '${contact.relationshipTypeName ?? contact.relationshipTypeId} · ${contact.phone}',
-                                        style: TextStyle(
-                                          fontSize: 12,
-                                          color: c.textSecondary,
-                                        ),
-                                      ),
-                                    ],
-                                  ),
+                              ),
+                            );
+                          }
+                          return Column(
+                            children: [
+                              for (var i = 0; i < contactList.length; i++) ...[
+                                if (i > 0) const SizedBox(height: 10),
+                                ContactTile(
+                                  contact: contactList[i],
+                                  onCall: (phone) => _call(phone),
+                                  onSms: (phone) => _sms(phone),
                                 ),
                               ],
+                            ],
+                          );
+                        },
+                      ),
+                    ),
+                    const SizedBox(height: 14),
+
+                    // ── Alergias ────────────────────────────────────────────
+                    MedicoSectionCard(
+                      icon: Icons.medical_services_outlined,
+                      iconBg: MedicoTokens.rose50,
+                      iconFg: MedicoTokens.rose500,
+                      title: 'profile.medical_info.allergies'.tr(),
+                      actionLabel: 'profile.medical_info.action_edit'.tr(),
+                      onAction: () => Navigator.of(context).push(
+                        MaterialPageRoute(
+                          builder: (_) => const AllergiesSelectionView(),
+                        ),
+                      ),
+                      child: allergiesAsync.when(
+                        loading: () => const Padding(
+                          padding: EdgeInsets.symmetric(vertical: 8),
+                          child: SacLoadingSmall(),
+                        ),
+                        error: (e, _) => _SectionError(
+                          message: e.toString(),
+                          onRetry: () => ref.invalidate(userAllergiesProvider),
+                        ),
+                        data: (allergyList) {
+                          if (allergyList.isEmpty) {
+                            return EmptyHint(
+                              label: 'profile.medical_info.none_allergies'.tr(),
+                              actionLabel: 'profile.medical_info.action_edit'.tr(),
+                              onAction: () => Navigator.of(context).push(
+                                MaterialPageRoute(
+                                  builder: (_) => const AllergiesSelectionView(),
+                                ),
+                              ),
+                            );
+                          }
+                          return MedicalChipRow(
+                            children: allergyList
+                                .map((a) => MedicalChip(
+                                      label: a.name,
+                                      sub: a.severity.i18nKey.tr(),
+                                      tone: _severityTone(a.severity),
+                                    ))
+                                .toList(),
+                          );
+                        },
+                      ),
+                    ),
+                    const SizedBox(height: 14),
+
+                    // ── Enfermedades ────────────────────────────────────────
+                    MedicoSectionCard(
+                      icon: Icons.favorite_border,
+                      iconBg: MedicoTokens.amber50,
+                      iconFg: MedicoTokens.amber500,
+                      title: 'profile.medical_info.diseases'.tr(),
+                      actionLabel: 'profile.medical_info.action_edit'.tr(),
+                      onAction: () => Navigator.of(context).push(
+                        MaterialPageRoute(
+                          builder: (_) => const DiseasesSelectionView(),
+                        ),
+                      ),
+                      child: diseasesAsync.when(
+                        loading: () => const Padding(
+                          padding: EdgeInsets.symmetric(vertical: 8),
+                          child: SacLoadingSmall(),
+                        ),
+                        error: (e, _) => _SectionError(
+                          message: e.toString(),
+                          onRetry: () => ref.invalidate(userDiseasesProvider),
+                        ),
+                        data: (diseaseList) {
+                          if (diseaseList.isEmpty) {
+                            return EmptyHint(
+                              label: 'profile.medical_info.none_diseases'.tr(),
+                              actionLabel: 'profile.medical_info.action_edit'.tr(),
+                              onAction: () => Navigator.of(context).push(
+                                MaterialPageRoute(
+                                  builder: (_) => const DiseasesSelectionView(),
+                                ),
+                              ),
+                            );
+                          }
+                          return MedicalChipRow(
+                            children: diseaseList
+                                .map((d) {
+                                  final year = d.sinceYear;
+                                  return MedicalChip(
+                                    label: d.name,
+                                    sub: year != null ? 'desde $year' : null,
+                                    tone: SeverityTone.amber,
+                                  );
+                                })
+                                .toList(),
+                          );
+                        },
+                      ),
+                    ),
+                    const SizedBox(height: 14),
+
+                    // ── Medicamentos ────────────────────────────────────────
+                    MedicoSectionCard(
+                      icon: Icons.medication_outlined,
+                      iconBg: MedicoTokens.mint50,
+                      iconFg: MedicoTokens.mint500,
+                      title: 'profile.medical_info.medicines'.tr(),
+                      actionLabel: 'profile.medical_info.action_edit'.tr(),
+                      onAction: () => Navigator.of(context).push(
+                        MaterialPageRoute(
+                          builder: (_) => const MedicinesSelectionView(),
+                        ),
+                      ),
+                      child: medicinesAsync.when(
+                        loading: () => const Padding(
+                          padding: EdgeInsets.symmetric(vertical: 8),
+                          child: SacLoadingSmall(),
+                        ),
+                        error: (e, _) => _SectionError(
+                          message: e.toString(),
+                          onRetry: () => ref.invalidate(userMedicinesProvider),
+                        ),
+                        data: (medicineList) {
+                          if (medicineList.isEmpty) {
+                            return EmptyHint(
+                              label: 'profile.medical_info.none_medicines'.tr(),
+                              actionLabel: 'profile.medical_info.action_edit'.tr(),
+                              onAction: () => Navigator.of(context).push(
+                                MaterialPageRoute(
+                                  builder: (_) => const MedicinesSelectionView(),
+                                ),
+                              ),
+                            );
+                          }
+                          return Column(
+                            children: [
+                              for (var i = 0; i < medicineList.length; i++) ...[
+                                if (i > 0) const SizedBox(height: 8),
+                                MedicamentTile(medicine: medicineList[i]),
+                              ],
+                            ],
+                          );
+                        },
+                      ),
+                    ),
+                    const SizedBox(height: 14),
+
+                    // ── Representante Legal (condicional) ───────────────────
+                    legalRequiredAsync.when(
+                      loading: () => const SizedBox.shrink(),
+                      error: (_, __) => const SizedBox.shrink(),
+                      data: (isRequired) {
+                        if (!isRequired) return const SizedBox.shrink();
+                        return MedicoSectionCard(
+                          icon: Icons.shield_outlined,
+                          iconBg: MedicoTokens.lavender100,
+                          iconFg: MedicoTokens.lavender500,
+                          title: 'profile.medical_info.legal_rep'.tr(),
+                          actionLabel: 'profile.medical_info.action_edit'.tr(),
+                          onAction: () => Navigator.of(context).push(
+                            MaterialPageRoute(
+                              builder: (_) => const LegalRepresentativeView(),
                             ),
                           ),
-                        )
-                        .toList(),
-                  );
-                },
-              ),
-              actionLabel: 'profile.medical_info.action_manage'.tr(),
-              onAction: () => Navigator.of(context).push(
-                MaterialPageRoute(
-                  builder: (_) => const EmergencyContactsView(),
-                ),
-              ),
-            ),
-            const SizedBox(height: 12),
-            legalRequiredAsync.when(
-              loading: () => const SizedBox.shrink(),
-              error: (_, __) => const SizedBox.shrink(),
-              data: (isRequired) {
-                if (!isRequired) return const SizedBox.shrink();
-                return _MedicalSectionCard(
-                  icon: HugeIcons.strokeRoundedUserShield01,
-                  title: 'profile.medical_info.legal_rep'.tr(),
-                  iconColor: AppColors.secondary,
-                  body: legalRepAsync.when(
-                    loading: () => const Padding(
-                      padding: EdgeInsets.symmetric(vertical: 8),
-                      child: SacLoadingSmall(),
-                    ),
-                    error: (e, _) => _SectionError(
-                      message: e.toString(),
-                      onRetry: () =>
-                          ref.invalidate(legalRepresentativeProvider),
-                    ),
-                    data: (rep) {
-                      if (rep == null) {
-                        return Text(
-                          'profile.medical_info.not_registered'.tr(),
-                          style: TextStyle(
-                            fontSize: 14,
-                            color: c.textTertiary,
-                            fontStyle: FontStyle.italic,
+                          child: legalRepAsync.when(
+                            loading: () => const Padding(
+                              padding: EdgeInsets.symmetric(vertical: 8),
+                              child: SacLoadingSmall(),
+                            ),
+                            error: (e, _) => _SectionError(
+                              message: e.toString(),
+                              onRetry: () =>
+                                  ref.invalidate(legalRepresentativeProvider),
+                            ),
+                            data: (rep) {
+                              if (rep == null) {
+                                return EmptyHint(
+                                  label: 'profile.medical_info.not_registered'.tr(),
+                                );
+                              }
+                              return Column(
+                                crossAxisAlignment: CrossAxisAlignment.start,
+                                children: [
+                                  Text(
+                                    '${rep.name} ${rep.paternalSurname} ${rep.maternalSurname}',
+                                    style: const TextStyle(
+                                      fontSize: 14,
+                                      fontWeight: FontWeight.w600,
+                                      color: MedicoTokens.ink900,
+                                    ),
+                                  ),
+                                  const SizedBox(height: 2),
+                                  Text(
+                                    '${rep.type} · ${rep.phone}',
+                                    style: const TextStyle(
+                                      fontSize: 12,
+                                      color: MedicoTokens.ink500,
+                                    ),
+                                  ),
+                                ],
+                              );
+                            },
                           ),
                         );
-                      }
-                      return Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          Text(
-                            '${rep.name} ${rep.paternalSurname} ${rep.maternalSurname}',
-                            style: TextStyle(
-                              fontSize: 14,
-                              fontWeight: FontWeight.w600,
-                              color: c.text,
-                            ),
-                          ),
-                          const SizedBox(height: 2),
-                          Text(
-                            '${rep.type} · ${rep.phone}',
-                            style: TextStyle(
-                              fontSize: 12,
-                              color: c.textSecondary,
-                            ),
-                          ),
-                        ],
-                      );
-                    },
-                  ),
-                  actionLabel: 'profile.medical_info.action_edit'.tr(),
-                  onAction: () => Navigator.of(context).push(
-                    MaterialPageRoute(
-                      builder: (_) => const LegalRepresentativeView(),
+                      },
                     ),
-                  ),
-                );
-              },
-            ),
-            const SizedBox(height: 24),
-          ],
+                  ],
+                ),
+              ),
+            ],
+          ),
         ),
       ),
     );
   }
 }
 
-class _MedicalSectionCard extends StatelessWidget {
-  final HugeIconData icon;
-  final String title;
-  final Color iconColor;
-  final Widget body;
-  final String actionLabel;
-  final VoidCallback onAction;
+// ─────────── App bar ───────────────────────────────────────────────────────────
 
-  const _MedicalSectionCard({
-    required this.icon,
-    required this.title,
-    required this.iconColor,
-    required this.body,
-    required this.actionLabel,
-    required this.onAction,
-  });
+class _MedicoAppBar extends StatelessWidget {
+  final VoidCallback? onBack;
+  final VoidCallback? onSOS;
+
+  const _MedicoAppBar({this.onBack, this.onSOS});
 
   @override
   Widget build(BuildContext context) {
-    final c = context.sac;
-
     return Container(
-      decoration: BoxDecoration(
-        color: c.surface,
-        borderRadius: BorderRadius.circular(14),
-        border: Border.all(color: c.border, width: 1),
+      decoration: const BoxDecoration(
+        color: MedicoTokens.paper,
+        border: Border(bottom: BorderSide(color: MedicoTokens.ink150)),
       ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
+      padding: const EdgeInsets.fromLTRB(18, 8, 18, 14),
+      child: Row(
         children: [
-          Padding(
-            padding: const EdgeInsets.fromLTRB(14, 12, 8, 12),
-            child: Row(
+          _circleBtn(
+            color: MedicoTokens.ink100,
+            iconColor: MedicoTokens.ink800,
+            icon: Icons.chevron_left_rounded,
+            onTap: onBack,
+          ),
+          Expanded(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
               children: [
-                Container(
-                  width: 34,
-                  height: 34,
-                  decoration: BoxDecoration(
-                    color: iconColor.withValues(alpha: 0.12),
-                    borderRadius: BorderRadius.circular(8),
-                  ),
-                  child: Center(
-                    child: HugeIcon(icon: icon, color: iconColor, size: 18),
+                Text(
+                  'profile.medical_info.appbar.eyebrow'.tr(),
+                  style: const TextStyle(
+                    fontSize: 11,
+                    color: MedicoTokens.ink400,
+                    letterSpacing: 1.32,
+                    fontWeight: FontWeight.w600,
                   ),
                 ),
-                const SizedBox(width: 10),
-                Expanded(
-                  child: Text(
-                    title,
-                    style: TextStyle(
-                      fontSize: 15,
-                      fontWeight: FontWeight.w600,
-                      color: c.text,
-                    ),
-                  ),
-                ),
-                TextButton(
-                  onPressed: onAction,
-                  style: TextButton.styleFrom(
-                    foregroundColor: AppColors.primary,
-                    padding: const EdgeInsets.symmetric(
-                      horizontal: 12,
-                      vertical: 6,
-                    ),
-                    minimumSize: Size.zero,
-                    tapTargetSize: MaterialTapTargetSize.shrinkWrap,
-                  ),
-                  child: Text(
-                    actionLabel,
-                    style: const TextStyle(
-                      fontSize: 13,
-                      fontWeight: FontWeight.w600,
-                    ),
+                const SizedBox(height: 1),
+                Text(
+                  'profile.medical_info.title'.tr(),
+                  style: const TextStyle(
+                    fontSize: 17,
+                    fontWeight: FontWeight.w700,
+                    color: MedicoTokens.ink900,
+                    letterSpacing: -0.17,
                   ),
                 ),
               ],
             ),
           ),
-          Divider(height: 1, thickness: 1, color: c.borderLight),
-          Padding(padding: const EdgeInsets.all(14), child: body),
+          _sosBtn(onTap: onSOS),
         ],
       ),
     );
   }
+
+  Widget _circleBtn({
+    required Color color,
+    required Color iconColor,
+    required IconData icon,
+    VoidCallback? onTap,
+  }) {
+    return Material(
+      color: color,
+      borderRadius: BorderRadius.circular(12),
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(12),
+        child: SizedBox(
+          width: 38,
+          height: 38,
+          child: Icon(icon, color: iconColor, size: 22),
+        ),
+      ),
+    );
+  }
+
+  Widget _sosBtn({VoidCallback? onTap}) {
+    return Material(
+      color: MedicoTokens.rose50,
+      borderRadius: BorderRadius.circular(12),
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(12),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 11, vertical: 8),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              const Icon(
+                Icons.emergency_outlined,
+                color: MedicoTokens.rose500,
+                size: 16,
+              ),
+              const SizedBox(width: 6),
+              Text(
+                'profile.medical_info.sos.button'.tr(),
+                style: const TextStyle(
+                  color: MedicoTokens.rose500,
+                  fontSize: 12,
+                  fontWeight: FontWeight.w700,
+                  letterSpacing: 0.4,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
 }
+
+// ─────────── Error inline ──────────────────────────────────────────────────────
 
 class _SectionError extends StatelessWidget {
   final String message;
@@ -565,8 +541,8 @@ class _SectionError extends StatelessWidget {
   Widget build(BuildContext context) {
     return Row(
       children: [
-        HugeIcon(
-          icon: HugeIcons.strokeRoundedAlert02,
+        const Icon(
+          Icons.error_outline_rounded,
           size: 16,
           color: AppColors.error,
         ),
@@ -574,7 +550,7 @@ class _SectionError extends StatelessWidget {
         Expanded(
           child: Text(
             'profile.medical_info.load_error'.tr(),
-            style: TextStyle(fontSize: 13, color: AppColors.error),
+            style: const TextStyle(fontSize: 13, color: AppColors.error),
           ),
         ),
         TextButton(

--- a/lib/features/profile/presentation/widgets/medico/blood_hero_card.dart
+++ b/lib/features/profile/presentation/widgets/medico/blood_hero_card.dart
@@ -1,0 +1,215 @@
+import 'package:easy_localization/easy_localization.dart';
+import 'package:flutter/material.dart';
+import 'medico_tokens.dart';
+
+/// Tarjeta hero con tipo de sangre + barra de completitud.
+///
+/// Muestra el tipo de sangre en grande — dato más buscado en emergencia.
+/// Si está vacío muestra `—` y la barra actúa como invitación a completar.
+///
+/// Props:
+/// - [bloodType]: string como "O+", "AB-"; null cuando no está registrado.
+/// - [filled]: número de secciones completadas (0-5).
+/// - [total]: total de secciones (normalmente 5).
+/// - [onEditar]: callback al tocar la tarjeta (abre el selector de sangre).
+class BloodHeroCard extends StatelessWidget {
+  final String? bloodType;
+  final int filled;
+  final int total;
+  final VoidCallback? onEditar;
+
+  const BloodHeroCard({
+    super.key,
+    required this.filled,
+    required this.total,
+    this.bloodType,
+    this.onEditar,
+  });
+
+  /// Parsea el Rh del tipo de sangre: "+" → positivo, "-" → negativo.
+  String? _rhLabel() {
+    final blood = bloodType;
+    if (blood == null || blood.isEmpty || blood == '—') return null;
+    final isPositive = blood.endsWith('+');
+    return isPositive
+        ? 'profile.medical_info.hero.rh_positive'.tr()
+        : 'profile.medical_info.hero.rh_negative'.tr();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final pct = total > 0 ? (filled / total).clamp(0.0, 1.0) : 0.0;
+    final rhLabel = _rhLabel();
+
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(MedicoTokens.rHero),
+      child: GestureDetector(
+        onTap: onEditar,
+        child: Container(
+          padding: const EdgeInsets.fromLTRB(18, 18, 18, 16),
+          decoration: const BoxDecoration(
+            gradient: LinearGradient(
+              begin: Alignment.topLeft,
+              end: Alignment.bottomRight,
+              colors: [MedicoTokens.coral500, MedicoTokens.coral600],
+            ),
+            boxShadow: MedicoTokens.shadowHero,
+          ),
+          child: Stack(
+            clipBehavior: Clip.none,
+            children: [
+              // Blob decorativo
+              Positioned(
+                right: -40,
+                top: -40,
+                child: Container(
+                  width: 180,
+                  height: 180,
+                  decoration: const BoxDecoration(
+                    color: Color(0x14FFFFFF), // 8% white
+                    shape: BoxShape.circle,
+                  ),
+                ),
+              ),
+              Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Row(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Expanded(child: _identidad(rhLabel)),
+                      _gota(),
+                    ],
+                  ),
+                  const SizedBox(height: 16),
+                  _progreso(pct),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _identidad(String? rhLabel) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          'profile.medical_info.hero.eyebrow'.tr(),
+          style: const TextStyle(
+            fontSize: 11,
+            letterSpacing: 1.54, // ~0.14em
+            fontWeight: FontWeight.w700,
+            color: Color(0xD9FFFFFF),
+          ),
+        ),
+        const SizedBox(height: 4),
+        Row(
+          crossAxisAlignment: CrossAxisAlignment.end,
+          children: [
+            Text(
+              bloodType ?? 'profile.medical_info.hero.empty_blood'.tr(),
+              style: const TextStyle(
+                fontSize: 44,
+                fontWeight: FontWeight.w800,
+                color: Colors.white,
+                height: 1,
+                letterSpacing: -1.3,
+              ),
+            ),
+            if (rhLabel != null) ...[
+              const SizedBox(width: 8),
+              Padding(
+                padding: const EdgeInsets.only(bottom: 4),
+                child: Text(
+                  rhLabel,
+                  style: const TextStyle(
+                    fontSize: 13,
+                    color: Color(0xD9FFFFFF),
+                  ),
+                ),
+              ),
+            ],
+          ],
+        ),
+      ],
+    );
+  }
+
+  Widget _gota() {
+    return Container(
+      width: 56,
+      height: 56,
+      decoration: BoxDecoration(
+        color: const Color(0x2EFFFFFF), // 18% white
+        borderRadius: BorderRadius.circular(16),
+      ),
+      child: const Icon(
+        Icons.water_drop_outlined,
+        color: Colors.white,
+        size: 28,
+      ),
+    );
+  }
+
+  Widget _progreso(double pct) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Text(
+              'profile.medical_info.hero.completeness_title'.tr(),
+              style: const TextStyle(
+                fontSize: 12,
+                color: Color(0xD9FFFFFF),
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+            Text(
+              'profile.medical_info.hero.completeness_format'.tr(
+                namedArgs: {
+                  'filled': filled.toString(),
+                  'total': total.toString(),
+                },
+              ),
+              style: const TextStyle(
+                fontSize: 12,
+                color: Colors.white,
+                fontWeight: FontWeight.w700,
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: 6),
+        ClipRRect(
+          borderRadius: BorderRadius.circular(99),
+          child: Stack(
+            children: [
+              Container(height: 6, color: const Color(0x38FFFFFF)),
+              FractionallySizedBox(
+                widthFactor: pct,
+                child: Container(
+                  height: 6,
+                  decoration: BoxDecoration(
+                    color: Colors.white,
+                    borderRadius: BorderRadius.circular(99),
+                    boxShadow: const [
+                      BoxShadow(
+                        color: Color(0x99FFFFFF), // 60% white
+                        blurRadius: 12,
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/profile/presentation/widgets/medico/contact_tile.dart
+++ b/lib/features/profile/presentation/widgets/medico/contact_tile.dart
@@ -1,0 +1,132 @@
+import 'package:flutter/material.dart';
+import 'package:sacdia_app/features/post_registration/data/models/emergency_contact_model.dart';
+import 'medico_tokens.dart';
+
+/// Fila de contacto de emergencia con avatar de inicial y botones
+/// rápidos de llamar / SMS.
+///
+/// Los callbacks [onCall] y [onSms] reciben el teléfono limpio (solo
+/// dígitos y "+") para que el padre llame a `launchUrl(Uri.parse('tel:...'))`.
+class ContactTile extends StatelessWidget {
+  final EmergencyContactModel contact;
+  final ValueChanged<String>? onCall;
+  final ValueChanged<String>? onSms;
+
+  const ContactTile({
+    super.key,
+    required this.contact,
+    this.onCall,
+    this.onSms,
+  });
+
+  static String _cleanPhone(String p) =>
+      p.replaceAll(RegExp(r'[^0-9+]'), '');
+
+  String get _initial =>
+      contact.name.isNotEmpty ? contact.name[0].toUpperCase() : '?';
+
+  String get _cleanedPhone => _cleanPhone(contact.phone);
+
+  @override
+  Widget build(BuildContext context) {
+    final relation = contact.relationshipTypeName ?? '—';
+    final meta = '$relation · ${contact.phone}';
+
+    return Container(
+      padding: const EdgeInsets.fromLTRB(10, 10, 10, 10),
+      decoration: BoxDecoration(
+        color: MedicoTokens.ink50,
+        borderRadius: BorderRadius.circular(14),
+      ),
+      child: Row(
+        children: [
+          _avatar(),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text(
+                  contact.name,
+                  style: const TextStyle(
+                    fontSize: 14.5,
+                    fontWeight: FontWeight.w700,
+                    color: MedicoTokens.ink900,
+                  ),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
+                const SizedBox(height: 1),
+                Text(
+                  meta,
+                  style: const TextStyle(
+                    fontSize: 12.5,
+                    color: MedicoTokens.ink500,
+                  ),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(width: 8),
+          _quickButton(
+            icon: Icons.phone_outlined,
+            bg: MedicoTokens.mint50,
+            fg: MedicoTokens.mint500,
+            onTap: () => onCall?.call(_cleanedPhone),
+          ),
+          const SizedBox(width: 6),
+          _quickButton(
+            icon: Icons.chat_bubble_outline,
+            bg: MedicoTokens.ink100,
+            fg: MedicoTokens.ink600,
+            onTap: () => onSms?.call(_cleanedPhone),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _avatar() {
+    return Container(
+      width: 40,
+      height: 40,
+      decoration: BoxDecoration(
+        color: MedicoTokens.coral100,
+        borderRadius: BorderRadius.circular(12),
+      ),
+      alignment: Alignment.center,
+      child: Text(
+        _initial,
+        style: const TextStyle(
+          color: MedicoTokens.coral600,
+          fontSize: 15,
+          fontWeight: FontWeight.w700,
+        ),
+      ),
+    );
+  }
+
+  Widget _quickButton({
+    required IconData icon,
+    required Color bg,
+    required Color fg,
+    required VoidCallback onTap,
+  }) {
+    return Material(
+      color: bg,
+      borderRadius: BorderRadius.circular(MedicoTokens.rField),
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(MedicoTokens.rField),
+        child: SizedBox(
+          width: 36,
+          height: 36,
+          child: Icon(icon, color: fg, size: 16),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/profile/presentation/widgets/medico/contact_tile.dart
+++ b/lib/features/profile/presentation/widgets/medico/contact_tile.dart
@@ -19,8 +19,7 @@ class ContactTile extends StatelessWidget {
     this.onSms,
   });
 
-  static String _cleanPhone(String p) =>
-      p.replaceAll(RegExp(r'[^0-9+]'), '');
+  static String _cleanPhone(String p) => p.replaceAll(RegExp(r'[^0-9+]'), '');
 
   String get _initial =>
       contact.name.isNotEmpty ? contact.name[0].toUpperCase() : '?';

--- a/lib/features/profile/presentation/widgets/medico/empty_hint.dart
+++ b/lib/features/profile/presentation/widgets/medico/empty_hint.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/material.dart';
+import 'medico_tokens.dart';
+
+/// Widget de estado vacío para secciones sin datos.
+///
+/// Muestra un label en itálica y, opcionalmente, un CTA coral
+/// que dispara [onAction].
+class EmptyHint extends StatelessWidget {
+  final String label;
+  final String? actionLabel;
+  final VoidCallback? onAction;
+
+  const EmptyHint({
+    super.key,
+    required this.label,
+    this.actionLabel,
+    this.onAction,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: MedicoTokens.ink50,
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            label,
+            style: const TextStyle(
+              fontStyle: FontStyle.italic,
+              color: MedicoTokens.ink500,
+              fontSize: 13,
+            ),
+          ),
+          if (actionLabel != null) ...[
+            const SizedBox(height: 6),
+            GestureDetector(
+              onTap: onAction,
+              child: Text(
+                actionLabel!,
+                style: const TextStyle(
+                  color: MedicoTokens.coral500,
+                  fontSize: 13,
+                  fontWeight: FontWeight.w700,
+                ),
+              ),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/profile/presentation/widgets/medico/medical_chip.dart
+++ b/lib/features/profile/presentation/widgets/medico/medical_chip.dart
@@ -1,0 +1,77 @@
+import 'package:flutter/material.dart';
+import 'medico_tokens.dart';
+
+/// Chip con punto de color + etiqueta + sub-texto opcional.
+/// Usado para alergias, enfermedades y similares.
+class MedicalChip extends StatelessWidget {
+  final String label;
+
+  /// Sub-texto pequeño después del label (ej: severidad, "desde 2021").
+  final String? sub;
+
+  final SeverityTone tone;
+
+  const MedicalChip({
+    super.key,
+    required this.label,
+    required this.tone,
+    this.sub,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final t = MedicoTokens.toneFor(tone);
+    return Container(
+      padding: const EdgeInsets.fromLTRB(10, 7, 12, 7),
+      decoration: BoxDecoration(
+        color: t.bg,
+        borderRadius: BorderRadius.circular(MedicoTokens.rPill),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Container(
+            width: 6,
+            height: 6,
+            decoration: BoxDecoration(color: t.dot, shape: BoxShape.circle),
+          ),
+          const SizedBox(width: 7),
+          Text(
+            label,
+            style: TextStyle(
+              fontSize: 13,
+              fontWeight: FontWeight.w600,
+              color: t.fg,
+            ),
+          ),
+          if (sub != null) ...[
+            const SizedBox(width: 6),
+            Text(
+              '· $sub',
+              style: TextStyle(
+                fontSize: 11.5,
+                fontWeight: FontWeight.w500,
+                color: t.fg.withValues(alpha: 0.7),
+              ),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+/// Layout de chips estilo `Wrap` con espacios consistentes.
+class MedicalChipRow extends StatelessWidget {
+  final List<Widget> children;
+  const MedicalChipRow({super.key, required this.children});
+
+  @override
+  Widget build(BuildContext context) {
+    return Wrap(
+      spacing: 8,
+      runSpacing: 8,
+      children: children,
+    );
+  }
+}

--- a/lib/features/profile/presentation/widgets/medico/medicament_tile.dart
+++ b/lib/features/profile/presentation/widgets/medico/medicament_tile.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+import 'package:sacdia_app/features/post_registration/data/models/medicine_model.dart';
+import 'medico_tokens.dart';
+
+/// Fila para un medicamento — nombre destacado + dosis abajo (si tiene).
+/// Fondo mint suave para diferenciarlo visualmente del resto.
+class MedicamentTile extends StatelessWidget {
+  final MedicineModel medicine;
+
+  const MedicamentTile({super.key, required this.medicine});
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      color: MedicoTokens.mint50,
+      borderRadius: BorderRadius.circular(MedicoTokens.rChipSmall),
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(12, 10, 12, 10),
+        child: Row(
+          children: [
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text(
+                    medicine.name,
+                    style: const TextStyle(
+                      fontWeight: FontWeight.w700,
+                      color: MedicoTokens.mintInk,
+                      fontSize: 14,
+                    ),
+                  ),
+                  if (medicine.dose != null && medicine.dose!.isNotEmpty) ...[
+                    const SizedBox(height: 1),
+                    Text(
+                      medicine.dose!,
+                      style: const TextStyle(
+                        fontSize: 12,
+                        color: MedicoTokens.mintInkSoft,
+                      ),
+                    ),
+                  ],
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/profile/presentation/widgets/medico/medico_section_card.dart
+++ b/lib/features/profile/presentation/widgets/medico/medico_section_card.dart
@@ -1,0 +1,102 @@
+import 'package:flutter/material.dart';
+import 'medico_tokens.dart';
+
+/// Wrapper común para cada sección (Alergias, Enfermedades, etc.).
+///
+/// Header: icono coloreado + título + acción opcional ("Editar" / "Administrar").
+class MedicoSectionCard extends StatelessWidget {
+  /// Icono Material a mostrar dentro del badge coloreado.
+  final IconData icon;
+
+  /// Color de fondo del badge.
+  final Color iconBg;
+
+  /// Color del icono.
+  final Color iconFg;
+
+  /// Título de la sección.
+  final String title;
+
+  /// Texto de la acción a la derecha ("Editar", "Administrar", "+ Agregar"…).
+  final String? actionLabel;
+
+  final VoidCallback? onAction;
+
+  /// Contenido de la sección (chips, lista de contactos, etc.).
+  final Widget child;
+
+  const MedicoSectionCard({
+    super.key,
+    required this.icon,
+    required this.iconBg,
+    required this.iconFg,
+    required this.title,
+    required this.child,
+    this.actionLabel,
+    this.onAction,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.fromLTRB(16, 16, 12, 18),
+      decoration: BoxDecoration(
+        color: MedicoTokens.paper,
+        borderRadius: BorderRadius.circular(MedicoTokens.rCard),
+        border: Border.all(color: MedicoTokens.ink150),
+        boxShadow: MedicoTokens.shadowCard,
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          _header(),
+          const SizedBox(height: 14),
+          child,
+        ],
+      ),
+    );
+  }
+
+  Widget _header() {
+    return Row(
+      children: [
+        Container(
+          width: MedicoTokens.sectionIconBox,
+          height: MedicoTokens.sectionIconBox,
+          decoration: BoxDecoration(
+            color: iconBg,
+            borderRadius: BorderRadius.circular(MedicoTokens.sectionIconRadius),
+          ),
+          child: Icon(icon, color: iconFg, size: 20),
+        ),
+        const SizedBox(width: 12),
+        Expanded(
+          child: Text(
+            title,
+            style: const TextStyle(
+              fontSize: 16,
+              fontWeight: FontWeight.w700,
+              color: MedicoTokens.ink900,
+              letterSpacing: -0.16,
+            ),
+          ),
+        ),
+        if (actionLabel != null)
+          TextButton(
+            onPressed: onAction,
+            style: TextButton.styleFrom(
+              foregroundColor: MedicoTokens.coral500,
+              padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+              minimumSize: Size.zero,
+              tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+              textStyle: const TextStyle(
+                fontSize: 13,
+                fontWeight: FontWeight.w700,
+              ),
+            ),
+            child: Text(actionLabel!),
+          ),
+      ],
+    );
+  }
+}

--- a/lib/features/profile/presentation/widgets/medico/medico_tokens.dart
+++ b/lib/features/profile/presentation/widgets/medico/medico_tokens.dart
@@ -14,7 +14,7 @@ class MedicoTokens {
   MedicoTokens._();
 
   // ────────── BRAND / SEMÁNTICA ──────────
-  static const coral50  = Color(0xFFFFF1EE);
+  static const coral50 = Color(0xFFFFF1EE);
   static const coral100 = Color(0xFFFFE3DD);
   static const coral200 = Color(0xFFFFC9BE);
   static const coral300 = Color(0xFFFFA493);
@@ -22,13 +22,13 @@ class MedicoTokens {
   static const coral600 = Color(0xFFDD5A4B);
   static const coral700 = Color(0xFFB8453A);
 
-  static const mint50  = Color(0xFFE8F5EE);
+  static const mint50 = Color(0xFFE8F5EE);
   static const mint100 = Color(0xFFD7EFE2);
   static const mint500 = Color(0xFF4FB37C);
   static const mintInk = Color(0xFF2C7A52); // texto sobre mint50
   static const mintInkSoft = Color(0xFF5A8A6E);
 
-  static const amber50  = Color(0xFFFCF1DC);
+  static const amber50 = Color(0xFFFCF1DC);
   static const amber100 = Color(0xFFFBE7C2);
   static const amber500 = Color(0xFFC99036);
   static const amberInk = Color(0xFF8B6020);
@@ -36,7 +36,7 @@ class MedicoTokens {
   static const lavender100 = Color(0xFFDCD5EE);
   static const lavender500 = Color(0xFF6B59A8);
 
-  static const rose50  = Color(0xFFFDE9EE);
+  static const rose50 = Color(0xFFFDE9EE);
   static const rose500 = Color(0xFFD14B66);
   static const roseInk = Color(0xFF9B2D49);
 
@@ -51,18 +51,18 @@ class MedicoTokens {
   static const ink200 = Color(0xFFE3E5EA);
   static const ink150 = Color(0xFFECEEF2);
   static const ink100 = Color(0xFFF2F4F7);
-  static const ink50  = Color(0xFFF7F8FA);
-  static const paper  = Color(0xFFFFFFFF);
+  static const ink50 = Color(0xFFF7F8FA);
+  static const paper = Color(0xFFFFFFFF);
   static const canvas = Color(0xFFFAFAFB);
 
   // ────────── ESPACIADO (4pt) ──────────
-  static const s1  = 4.0;
-  static const s2  = 8.0;
-  static const s3  = 12.0;
-  static const s4  = 16.0;
-  static const s5  = 20.0;
-  static const s6  = 24.0;
-  static const s8  = 32.0;
+  static const s1 = 4.0;
+  static const s2 = 8.0;
+  static const s3 = 12.0;
+  static const s4 = 16.0;
+  static const s5 = 20.0;
+  static const s6 = 24.0;
+  static const s8 = 32.0;
 
   // ────────── RADIOS ──────────
   static const rField = 10.0;
@@ -112,4 +112,3 @@ class ChipTone {
   final Color dot;
   const ChipTone({required this.bg, required this.fg, required this.dot});
 }
-

--- a/lib/features/profile/presentation/widgets/medico/medico_tokens.dart
+++ b/lib/features/profile/presentation/widgets/medico/medico_tokens.dart
@@ -1,0 +1,115 @@
+import 'package:flutter/material.dart';
+
+/// Feature-scoped tokens for Información Médica (Variante A).
+///
+/// Coral and ink tokens duplicate `AppColors` values intentionally
+/// (feature-scoped per ADR-1). They are kept here so this screen's
+/// palette can evolve independently from the global theme. If the team
+/// later adopts the full palette app-wide, migrate `MedicoTokens.coralN`
+/// → `AppColors.coralN` mechanically.
+///
+/// Mint, amber, rose, and lavender scales are net-new and remain
+/// medical-screen-scoped.
+class MedicoTokens {
+  MedicoTokens._();
+
+  // ────────── BRAND / SEMÁNTICA ──────────
+  static const coral50  = Color(0xFFFFF1EE);
+  static const coral100 = Color(0xFFFFE3DD);
+  static const coral200 = Color(0xFFFFC9BE);
+  static const coral300 = Color(0xFFFFA493);
+  static const coral500 = Color(0xFFEF6B5C); // primario
+  static const coral600 = Color(0xFFDD5A4B);
+  static const coral700 = Color(0xFFB8453A);
+
+  static const mint50  = Color(0xFFE8F5EE);
+  static const mint100 = Color(0xFFD7EFE2);
+  static const mint500 = Color(0xFF4FB37C);
+  static const mintInk = Color(0xFF2C7A52); // texto sobre mint50
+  static const mintInkSoft = Color(0xFF5A8A6E);
+
+  static const amber50  = Color(0xFFFCF1DC);
+  static const amber100 = Color(0xFFFBE7C2);
+  static const amber500 = Color(0xFFC99036);
+  static const amberInk = Color(0xFF8B6020);
+
+  static const lavender100 = Color(0xFFDCD5EE);
+  static const lavender500 = Color(0xFF6B59A8);
+
+  static const rose50  = Color(0xFFFDE9EE);
+  static const rose500 = Color(0xFFD14B66);
+  static const roseInk = Color(0xFF9B2D49);
+
+  // ────────── NEUTRALES ──────────
+  static const ink900 = Color(0xFF131316);
+  static const ink800 = Color(0xFF20232A);
+  static const ink700 = Color(0xFF2C313B);
+  static const ink600 = Color(0xFF4B5260);
+  static const ink500 = Color(0xFF6B7280);
+  static const ink400 = Color(0xFF9AA0AB);
+  static const ink300 = Color(0xFFC7CBD2);
+  static const ink200 = Color(0xFFE3E5EA);
+  static const ink150 = Color(0xFFECEEF2);
+  static const ink100 = Color(0xFFF2F4F7);
+  static const ink50  = Color(0xFFF7F8FA);
+  static const paper  = Color(0xFFFFFFFF);
+  static const canvas = Color(0xFFFAFAFB);
+
+  // ────────── ESPACIADO (4pt) ──────────
+  static const s1  = 4.0;
+  static const s2  = 8.0;
+  static const s3  = 12.0;
+  static const s4  = 16.0;
+  static const s5  = 20.0;
+  static const s6  = 24.0;
+  static const s8  = 32.0;
+
+  // ────────── RADIOS ──────────
+  static const rField = 10.0;
+  static const rChipSmall = 12.0;
+  static const rCard = 18.0;
+  static const rHero = 22.0;
+  static const rPill = 999.0;
+
+  // ────────── ELEVACIÓN ──────────
+  static const shadowCard = [
+    BoxShadow(color: Color(0x0A111827), blurRadius: 2, offset: Offset(0, 1)),
+  ];
+  static const shadowHero = [
+    BoxShadow(
+      color: Color(0x66EF6B5C),
+      blurRadius: 28,
+      offset: Offset(0, 10),
+      spreadRadius: -10,
+    ),
+  ];
+
+  // ────────── ANCHOS DE ICONOS DE SECCIÓN ──────────
+  static const sectionIconBox = 38.0;
+  static const sectionIconRadius = 11.0;
+
+  // ────────── HELPERS ──────────
+  /// Tonos de chip por nivel de severidad.
+  static ChipTone toneFor(SeverityTone t) {
+    switch (t) {
+      case SeverityTone.rose:
+        return const ChipTone(bg: rose50, fg: roseInk, dot: rose500);
+      case SeverityTone.amber:
+        return const ChipTone(bg: amber50, fg: amberInk, dot: amber500);
+      case SeverityTone.mint:
+        return const ChipTone(bg: mint50, fg: mintInk, dot: mint500);
+      case SeverityTone.coral:
+        return const ChipTone(bg: coral50, fg: coral700, dot: coral500);
+    }
+  }
+}
+
+enum SeverityTone { rose, amber, mint, coral }
+
+class ChipTone {
+  final Color bg;
+  final Color fg;
+  final Color dot;
+  const ChipTone({required this.bg, required this.fg, required this.dot});
+}
+


### PR DESCRIPTION
## Summary
- New feature-scoped tokens in `widgets/medico/medico_tokens.dart` (ADR-1: coral/ink intentionally duplicate `AppColors`; mint/amber/rose/lavender are net-new)
- `BloodHeroCard`: blood type GIGANTE + completeness bar (`X de 5`) with coral gradient + decorative blob
- `MedicoSectionCard`: generic wrapper (colored icon badge + title + action)
- `MedicalChip`: pill with severity dot + sub-text
- `ContactTile`: avatar + name + relation/phone + tap-to-call (mint) / tap-to-SMS (ink) via `url_launcher`
- `MedicamentTile`: name + dose (mint-soft background)
- `EmptyHint`: empty state with optional coral CTA
- `EmergencyModeView`: placeholder fullscreen — full SOS UI in PR4
- `medical_info_view.dart` rewritten with custom AppBar (back · PERFIL eyebrow + title · SOS button); section order Hero → Contactos → Alergias → Enfermedades → Medicamentos → Legal Rep
- `flutter analyze`: 0 issues on touched files
- GoRouter: new `/profile/medical/sos` route
- i18n: 13 new keys × 4 locales

## Size exception
~990 LoC — tightly coupled atomic widgets + view rewrite + i18n. Split would create artificial PRs with no review value.

## Stacked on
PR #89 (feat/medical-info-redesign-data). Merge that one FIRST.

## Test plan
- [x] flutter analyze lib/features/profile/ → 0 issues
- [ ] open Información Médica → hero shows blood + correct X de 5
- [ ] tap blood hero → existing blood selector opens
- [ ] tap phone icon on contact → dialer opens
- [ ] tap SMS icon on contact → SMS composer opens
- [ ] tap SOS → emergency placeholder screen
- [ ] empty blood → hero shows —, completeness reflects empty
- [ ] allergy severity alta → chip rose tone

## Design source
/Users/abner/Downloads/Diseño App - Pantalla Información Médica/medico/ (Variant A, SPEC.md).

## Out of scope
- Dark mode (light-only intentional)
- SOS fullscreen final UI (PR4 — needs design pass with ui-ux-designer + ui-designer)