### PR TITLE
feat(materiales): módulo pedidos para director

### DIFF
--- a/lib/core/config/route_names.dart
+++ b/lib/core/config/route_names.dart
@@ -183,6 +183,10 @@ class RouteNames {
   static const String materialesHistorial = '/home/materiales/historial';
   static const String materialesOrdenDetailRoute =
       '/home/materiales/orden/:folio';
+  static const String materialesOrdenPagoRoute =
+      '/home/materiales/orden/:folio/pago';
+  static const String materialesOrdenComprobanteRoute =
+      '/home/materiales/orden/:folio/comprobante';
 
   // Helpers para materiales
   static String materialesProductDetailPath(String id) =>
@@ -190,6 +194,12 @@ class RouteNames {
 
   static String materialesOrdenDetail(String folioOrId) =>
       '/home/materiales/orden/$folioOrId';
+
+  static String materialesOrdenPago(String folioOrId) =>
+      '/home/materiales/orden/$folioOrId/pago';
+
+  static String materialesOrdenComprobante(String folioOrId) =>
+      '/home/materiales/orden/$folioOrId/comprobante';
 
   // Rankings
   static const String homeMyRanking = '/home/my-ranking';

--- a/lib/core/config/route_names.dart
+++ b/lib/core/config/route_names.dart
@@ -175,6 +175,15 @@ class RouteNames {
   static String camporeeEnrollClubPath(int camporeeId) =>
       '/camporee/$camporeeId/enroll-club';
 
+  // Materiales (pedidos)
+  static const String homeMateriales = '/home/materiales';
+  static const String materialesProductDetail = '/home/materiales/producto/:id';
+  static const String materialesCarrito = '/home/materiales/carrito';
+
+  // Helpers para materiales
+  static String materialesProductDetailPath(String id) =>
+      '/home/materiales/producto/$id';
+
   // Rankings
   static const String homeMyRanking = '/home/my-ranking';
   static const String sectionRanking = '/section-ranking/:sectionId';

--- a/lib/core/config/route_names.dart
+++ b/lib/core/config/route_names.dart
@@ -179,10 +179,17 @@ class RouteNames {
   static const String homeMateriales = '/home/materiales';
   static const String materialesProductDetail = '/home/materiales/producto/:id';
   static const String materialesCarrito = '/home/materiales/carrito';
+  static const String materialesResumen = '/home/materiales/resumen';
+  static const String materialesHistorial = '/home/materiales/historial';
+  static const String materialesOrdenDetailRoute =
+      '/home/materiales/orden/:folio';
 
   // Helpers para materiales
   static String materialesProductDetailPath(String id) =>
       '/home/materiales/producto/$id';
+
+  static String materialesOrdenDetail(String folioOrId) =>
+      '/home/materiales/orden/$folioOrId';
 
   // Rankings
   static const String homeMyRanking = '/home/my-ranking';

--- a/lib/core/config/router.dart
+++ b/lib/core/config/router.dart
@@ -55,10 +55,12 @@ import 'package:sacdia_app/features/support/presentation/views/contact_view.dart
 import 'package:sacdia_app/features/support/presentation/views/report_problem_view.dart';
 import 'package:sacdia_app/features/materiales/presentation/screens/carrito_screen.dart';
 import 'package:sacdia_app/features/materiales/presentation/screens/catalogo_screen.dart';
+import 'package:sacdia_app/features/materiales/presentation/screens/datos_pago_screen.dart';
 import 'package:sacdia_app/features/materiales/presentation/screens/detalle_producto_screen.dart';
 import 'package:sacdia_app/features/materiales/presentation/screens/historial_screen.dart';
 import 'package:sacdia_app/features/materiales/presentation/screens/orden_review_screen.dart';
 import 'package:sacdia_app/features/materiales/presentation/screens/resumen_screen.dart';
+import 'package:sacdia_app/features/materiales/presentation/screens/subir_comprobante_screen.dart';
 import 'package:sacdia_app/features/rankings/presentation/screens/member_breakdown_screen.dart';
 import 'package:sacdia_app/features/rankings/presentation/screens/my_ranking_screen.dart';
 import 'package:sacdia_app/features/rankings/presentation/screens/section_ranking_screen.dart';
@@ -1125,6 +1127,32 @@ final routerProvider = Provider<GoRouter>((ref) {
             context,
             state,
             OrdenReviewScreen(folioOrId: folioOrId),
+          );
+        },
+      ),
+
+      // Materiales — datos bancarios para pago (push, fuera del shell)
+      GoRoute(
+        path: RouteNames.materialesOrdenPagoRoute,
+        pageBuilder: (context, state) {
+          final folioOrId = state.pathParameters['folio']!;
+          return _sharedAxisBuild(
+            context,
+            state,
+            DatosPagoScreen(folioOrId: folioOrId),
+          );
+        },
+      ),
+
+      // Materiales — subir comprobante de pago (push, fuera del shell)
+      GoRoute(
+        path: RouteNames.materialesOrdenComprobanteRoute,
+        pageBuilder: (context, state) {
+          final folioOrId = state.pathParameters['folio']!;
+          return _sharedAxisBuild(
+            context,
+            state,
+            SubirComprobanteScreen(folioOrId: folioOrId),
           );
         },
       ),

--- a/lib/core/config/router.dart
+++ b/lib/core/config/router.dart
@@ -53,6 +53,9 @@ import 'package:sacdia_app/features/support/presentation/views/support_view.dart
 import 'package:sacdia_app/features/support/presentation/views/faq_view.dart';
 import 'package:sacdia_app/features/support/presentation/views/contact_view.dart';
 import 'package:sacdia_app/features/support/presentation/views/report_problem_view.dart';
+import 'package:sacdia_app/features/materiales/presentation/screens/carrito_screen.dart';
+import 'package:sacdia_app/features/materiales/presentation/screens/catalogo_screen.dart';
+import 'package:sacdia_app/features/materiales/presentation/screens/detalle_producto_screen.dart';
 import 'package:sacdia_app/features/rankings/presentation/screens/member_breakdown_screen.dart';
 import 'package:sacdia_app/features/rankings/presentation/screens/my_ranking_screen.dart';
 import 'package:sacdia_app/features/rankings/presentation/screens/section_ranking_screen.dart';
@@ -538,6 +541,20 @@ final routerProvider = Provider<GoRouter>((ref) {
                   context,
                   state,
                   const MyRankingScreen(),
+                ),
+              ),
+            ],
+          ),
+
+          // ── Branch 18: Materiales / Pedidos (quick-access, no nav bar) ────
+          StatefulShellBranch(
+            routes: [
+              GoRoute(
+                path: RouteNames.homeMateriales,
+                pageBuilder: (context, state) => _fadeThroughBuild(
+                  context,
+                  state,
+                  const CatalogoScreen(),
                 ),
               ),
             ],
@@ -1060,6 +1077,26 @@ final routerProvider = Provider<GoRouter>((ref) {
         path: ReportProblemView.routeName,
         pageBuilder: (context, state) =>
             _sharedAxisBuild(context, state, const ReportProblemView()),
+      ),
+
+      // Materiales — detalle de producto (push, fuera del shell)
+      GoRoute(
+        path: RouteNames.materialesProductDetail,
+        pageBuilder: (context, state) {
+          final productId = state.pathParameters['id']!;
+          return _sharedAxisBuild(
+            context,
+            state,
+            DetalleProductoScreen(productId: productId),
+          );
+        },
+      ),
+
+      // Materiales — carrito (push, fuera del shell)
+      GoRoute(
+        path: RouteNames.materialesCarrito,
+        pageBuilder: (context, state) =>
+            _sharedAxisBuild(context, state, const CarritoScreen()),
       ),
 
       // OAuth callback deep link — io.sacdia.app://auth/callback?session_token=...&provider=...

--- a/lib/core/config/router.dart
+++ b/lib/core/config/router.dart
@@ -56,6 +56,9 @@ import 'package:sacdia_app/features/support/presentation/views/report_problem_vi
 import 'package:sacdia_app/features/materiales/presentation/screens/carrito_screen.dart';
 import 'package:sacdia_app/features/materiales/presentation/screens/catalogo_screen.dart';
 import 'package:sacdia_app/features/materiales/presentation/screens/detalle_producto_screen.dart';
+import 'package:sacdia_app/features/materiales/presentation/screens/historial_screen.dart';
+import 'package:sacdia_app/features/materiales/presentation/screens/orden_review_screen.dart';
+import 'package:sacdia_app/features/materiales/presentation/screens/resumen_screen.dart';
 import 'package:sacdia_app/features/rankings/presentation/screens/member_breakdown_screen.dart';
 import 'package:sacdia_app/features/rankings/presentation/screens/my_ranking_screen.dart';
 import 'package:sacdia_app/features/rankings/presentation/screens/section_ranking_screen.dart';
@@ -1097,6 +1100,33 @@ final routerProvider = Provider<GoRouter>((ref) {
         path: RouteNames.materialesCarrito,
         pageBuilder: (context, state) =>
             _sharedAxisBuild(context, state, const CarritoScreen()),
+      ),
+
+      // Materiales — resumen y confirmación de pedido (push, fuera del shell)
+      GoRoute(
+        path: RouteNames.materialesResumen,
+        pageBuilder: (context, state) =>
+            _sharedAxisBuild(context, state, const ResumenScreen()),
+      ),
+
+      // Materiales — historial de pedidos (push, fuera del shell)
+      GoRoute(
+        path: RouteNames.materialesHistorial,
+        pageBuilder: (context, state) =>
+            _sharedAxisBuild(context, state, const HistorialScreen()),
+      ),
+
+      // Materiales — detalle de orden por folio o ID (push, fuera del shell)
+      GoRoute(
+        path: RouteNames.materialesOrdenDetailRoute,
+        pageBuilder: (context, state) {
+          final folioOrId = state.pathParameters['folio']!;
+          return _sharedAxisBuild(
+            context,
+            state,
+            OrdenReviewScreen(folioOrId: folioOrId),
+          );
+        },
       ),
 
       // OAuth callback deep link — io.sacdia.app://auth/callback?session_token=...&provider=...

--- a/lib/core/constants/api_endpoints.dart
+++ b/lib/core/constants/api_endpoints.dart
@@ -104,4 +104,7 @@ class ApiEndpoints {
   // ── Rankings ─────────────────────────────────────────────────────────────
   static const String memberRankings = '/member-rankings';
   static const String sectionRankings = '/section-rankings';
+
+  // ── Materiales ────────────────────────────────────────────────────────────
+  static const String materiales = '/materiales';
 }

--- a/lib/features/dashboard/presentation/widgets/quick_access_grid.dart
+++ b/lib/features/dashboard/presentation/widgets/quick_access_grid.dart
@@ -122,6 +122,14 @@ final List<_QuickAccessItemConfig> _quickAccessItemsConfig = [
     route: RouteNames.homeInventory,
     requiredPermissions: {'inventory:read'},
   ),
+  // Pedidos de materiales — materiales:create es el permiso de directores
+  _QuickAccessItemConfig(
+    labelKey: 'dashboard.quick_access.materiales',
+    icon: HugeIcons.strokeRoundedShoppingCart01,
+    color: AppColors.info,
+    route: RouteNames.homeMateriales,
+    requiredPermissions: {'materiales:create'},
+  ),
   // Club-wide shared resources — folders:read is granted to every club role.
   _QuickAccessItemConfig(
     labelKey: 'dashboard.quick_access.resources',

--- a/lib/features/materiales/data/data.dart
+++ b/lib/features/materiales/data/data.dart
@@ -1,0 +1,12 @@
+// Data barrel — datasources, models, repositories
+export 'datasources/materiales_remote_data_source.dart';
+export 'models/comprobante_model.dart';
+export 'models/material_category_model.dart';
+export 'models/material_config_model.dart';
+export 'models/material_item_model.dart';
+export 'models/material_programa_model.dart';
+export 'models/material_variant_model.dart';
+export 'models/material_variant_option_model.dart';
+export 'models/orden_line_model.dart';
+export 'models/orden_model.dart';
+export 'repositories/materiales_repository_impl.dart';

--- a/lib/features/materiales/data/datasources/materiales_remote_data_source.dart
+++ b/lib/features/materiales/data/datasources/materiales_remote_data_source.dart
@@ -1,0 +1,555 @@
+import 'dart:io';
+
+import 'package:dio/dio.dart';
+import 'package:easy_localization/easy_localization.dart';
+
+import '../../../../core/constants/api_endpoints.dart';
+import '../../../../core/errors/exceptions.dart';
+import '../../../../core/utils/app_logger.dart';
+import '../../domain/entities/material_entrega.dart';
+import '../models/comprobante_model.dart';
+import '../models/material_category_model.dart';
+import '../models/material_config_model.dart';
+import '../models/material_item_model.dart';
+import '../models/material_programa_model.dart';
+import '../models/orden_model.dart';
+
+/// Interfaz para la fuente de datos remota del módulo de materiales.
+abstract class MaterialesRemoteDataSource {
+  // ── Catálogo ─────────────────────────────────────────────────────────────
+  Future<List<MaterialItemModel>> browseCatalog({
+    String? cat,
+    int? programaId,
+    String? q,
+    int page = 1,
+    int pageSize = 20,
+  });
+
+  Future<MaterialItemModel> getProductDetail(String id);
+  Future<List<MaterialCategoryModel>> listCategorias();
+  Future<List<MaterialProgramaModel>> listProgramas();
+
+  // ── Órdenes ───────────────────────────────────────────────────────────────
+  Future<OrdenModel> createOrder({
+    required int clubSectionId,
+    required List<({String productId, String? variantOptionId, int qty})> lines,
+    required MaterialEntrega entrega,
+    String? notas,
+  });
+
+  Future<List<OrdenModel>> listOrdenes({
+    String? estado,
+    int page = 1,
+    int pageSize = 20,
+  });
+
+  Future<List<OrdenModel>> getOrderHistory({
+    int page = 1,
+    int pageSize = 20,
+  });
+
+  Future<OrdenModel> getOrderByFolio(String folioOrId);
+  Future<OrdenModel> cancelOrder(String folioOrId, String reason);
+
+  // ── Comprobantes ──────────────────────────────────────────────────────────
+  Future<List<ComprobanteModel>> listComprobantes(String folioOrId);
+
+  Future<ComprobanteModel> uploadComprobante({
+    required String folioOrId,
+    required File file,
+    required int montoCentavos,
+    required String refBancariaDeclarada,
+    required DateTime fechaPago,
+    void Function(double)? onProgress,
+  });
+
+  // ── Configuración ─────────────────────────────────────────────────────────
+  Future<MaterialConfigModel> getConfig();
+}
+
+/// Implementación de la fuente de datos remota del módulo de materiales.
+///
+/// Consume los endpoints bajo `/api/v1/materiales/*` del backend SACDIA.
+/// Auth token es inyectado automáticamente por [AuthInterceptor].
+class MaterialesRemoteDataSourceImpl implements MaterialesRemoteDataSource {
+  final Dio _dio;
+  final String _baseUrl;
+
+  static const _tag = 'MaterialesDS';
+
+  MaterialesRemoteDataSourceImpl({
+    required Dio dio,
+    required String baseUrl,
+  })  : _dio = dio,
+        _baseUrl = baseUrl;
+
+  // ── Catálogo ──────────────────────────────────────────────────────────────
+
+  @override
+  Future<List<MaterialItemModel>> browseCatalog({
+    String? cat,
+    int? programaId,
+    String? q,
+    int page = 1,
+    int pageSize = 20,
+  }) async {
+    try {
+      final queryParams = <String, dynamic>{
+        'page': page,
+        'pageSize': pageSize,
+        if (cat != null) 'cat': cat,
+        if (programaId != null) 'programa': programaId,
+        if (q != null && q.isNotEmpty) 'q': q,
+      };
+
+      final response = await _dio.get(
+        '$_baseUrl${ApiEndpoints.materiales}/catalogo',
+        queryParameters: queryParams,
+      );
+
+      if (response.statusCode == 200 || response.statusCode == 201) {
+        final body = response.data as Map<String, dynamic>;
+        final rawData = _extractData(body) as List<dynamic>;
+        return rawData
+            .map((item) =>
+                MaterialItemModel.fromJson(item as Map<String, dynamic>))
+            .toList();
+      }
+
+      throw ServerException(
+        message: tr('materiales.errors.browse_catalog'),
+        code: response.statusCode,
+      );
+    } catch (e) {
+      AppLogger.e('Error en browseCatalog', tag: _tag, error: e);
+      _rethrow(e);
+    }
+  }
+
+  @override
+  Future<MaterialItemModel> getProductDetail(String id) async {
+    try {
+      final response = await _dio.get(
+        '$_baseUrl${ApiEndpoints.materiales}/catalogo/$id',
+      );
+
+      if (response.statusCode == 200 || response.statusCode == 201) {
+        final body = response.data as Map<String, dynamic>;
+        final json = body.containsKey('data')
+            ? body['data'] as Map<String, dynamic>
+            : body;
+        return MaterialItemModel.fromJson(json);
+      }
+
+      throw ServerException(
+        message: tr('materiales.errors.get_product'),
+        code: response.statusCode,
+      );
+    } catch (e) {
+      AppLogger.e('Error en getProductDetail', tag: _tag, error: e);
+      _rethrow(e);
+    }
+  }
+
+  @override
+  Future<List<MaterialCategoryModel>> listCategorias() async {
+    try {
+      final response = await _dio.get(
+        '$_baseUrl${ApiEndpoints.materiales}/catalogo/categorias',
+      );
+
+      if (response.statusCode == 200 || response.statusCode == 201) {
+        final body = response.data as Map<String, dynamic>;
+        final rawData = _extractData(body) as List<dynamic>;
+        return rawData
+            .map((item) =>
+                MaterialCategoryModel.fromJson(item as Map<String, dynamic>))
+            .toList();
+      }
+
+      throw ServerException(
+        message: tr('materiales.errors.list_categorias'),
+        code: response.statusCode,
+      );
+    } catch (e) {
+      AppLogger.e('Error en listCategorias', tag: _tag, error: e);
+      _rethrow(e);
+    }
+  }
+
+  @override
+  Future<List<MaterialProgramaModel>> listProgramas() async {
+    try {
+      final response = await _dio.get(
+        '$_baseUrl${ApiEndpoints.materiales}/catalogo/programas',
+      );
+
+      if (response.statusCode == 200 || response.statusCode == 201) {
+        final body = response.data as Map<String, dynamic>;
+        final rawData = _extractData(body) as List<dynamic>;
+        return rawData
+            .map((item) =>
+                MaterialProgramaModel.fromJson(item as Map<String, dynamic>))
+            .toList();
+      }
+
+      throw ServerException(
+        message: tr('materiales.errors.list_programas'),
+        code: response.statusCode,
+      );
+    } catch (e) {
+      AppLogger.e('Error en listProgramas', tag: _tag, error: e);
+      _rethrow(e);
+    }
+  }
+
+  // ── Órdenes ───────────────────────────────────────────────────────────────
+
+  @override
+  Future<OrdenModel> createOrder({
+    required int clubSectionId,
+    required List<({String productId, String? variantOptionId, int qty})> lines,
+    required MaterialEntrega entrega,
+    String? notas,
+  }) async {
+    try {
+      final body = <String, dynamic>{
+        'club_section_id': clubSectionId,
+        'lines': lines
+            .map((l) => {
+                  'product_id': l.productId,
+                  if (l.variantOptionId != null)
+                    'variant_option_id': l.variantOptionId,
+                  'qty': l.qty,
+                })
+            .toList(),
+        'entrega': entrega.toApiString(),
+        if (notas != null && notas.isNotEmpty) 'notas': notas,
+      };
+
+      final response = await _dio.post(
+        '$_baseUrl${ApiEndpoints.materiales}/ordenes',
+        data: body,
+      );
+
+      if (response.statusCode == 200 || response.statusCode == 201) {
+        final responseBody = response.data as Map<String, dynamic>;
+        final json = responseBody.containsKey('data')
+            ? responseBody['data'] as Map<String, dynamic>
+            : responseBody;
+        return OrdenModel.fromJson(json);
+      }
+
+      throw ServerException(
+        message: tr('materiales.errors.create_order'),
+        code: response.statusCode,
+      );
+    } catch (e) {
+      AppLogger.e('Error en createOrder', tag: _tag, error: e);
+      _rethrow(e);
+    }
+  }
+
+  @override
+  Future<List<OrdenModel>> listOrdenes({
+    String? estado,
+    int page = 1,
+    int pageSize = 20,
+  }) async {
+    try {
+      final queryParams = <String, dynamic>{
+        'page': page,
+        'pageSize': pageSize,
+        if (estado != null) 'estado': estado,
+      };
+
+      final response = await _dio.get(
+        '$_baseUrl${ApiEndpoints.materiales}/ordenes',
+        queryParameters: queryParams,
+      );
+
+      if (response.statusCode == 200 || response.statusCode == 201) {
+        final body = response.data as Map<String, dynamic>;
+        final rawData = _extractData(body) as List<dynamic>;
+        return rawData
+            .map((item) =>
+                OrdenModel.fromJson(item as Map<String, dynamic>))
+            .toList();
+      }
+
+      throw ServerException(
+        message: tr('materiales.errors.list_ordenes'),
+        code: response.statusCode,
+      );
+    } catch (e) {
+      AppLogger.e('Error en listOrdenes', tag: _tag, error: e);
+      _rethrow(e);
+    }
+  }
+
+  @override
+  Future<List<OrdenModel>> getOrderHistory({
+    int page = 1,
+    int pageSize = 20,
+  }) async {
+    try {
+      final queryParams = <String, dynamic>{
+        'page': page,
+        'pageSize': pageSize,
+      };
+
+      final response = await _dio.get(
+        '$_baseUrl${ApiEndpoints.materiales}/ordenes/historial',
+        queryParameters: queryParams,
+      );
+
+      if (response.statusCode == 200 || response.statusCode == 201) {
+        final body = response.data as Map<String, dynamic>;
+        final rawData = _extractData(body) as List<dynamic>;
+        return rawData
+            .map((item) =>
+                OrdenModel.fromJson(item as Map<String, dynamic>))
+            .toList();
+      }
+
+      throw ServerException(
+        message: tr('materiales.errors.get_history'),
+        code: response.statusCode,
+      );
+    } catch (e) {
+      AppLogger.e('Error en getOrderHistory', tag: _tag, error: e);
+      _rethrow(e);
+    }
+  }
+
+  @override
+  Future<OrdenModel> getOrderByFolio(String folioOrId) async {
+    try {
+      final response = await _dio.get(
+        '$_baseUrl${ApiEndpoints.materiales}/ordenes/$folioOrId',
+      );
+
+      if (response.statusCode == 200 || response.statusCode == 201) {
+        final body = response.data as Map<String, dynamic>;
+        final json = body.containsKey('data')
+            ? body['data'] as Map<String, dynamic>
+            : body;
+        return OrdenModel.fromJson(json);
+      }
+
+      throw ServerException(
+        message: tr('materiales.errors.get_orden'),
+        code: response.statusCode,
+      );
+    } catch (e) {
+      AppLogger.e('Error en getOrderByFolio', tag: _tag, error: e);
+      _rethrow(e);
+    }
+  }
+
+  @override
+  Future<OrdenModel> cancelOrder(String folioOrId, String reason) async {
+    try {
+      final response = await _dio.post(
+        '$_baseUrl${ApiEndpoints.materiales}/ordenes/$folioOrId/cancelar',
+        data: {'cancel_reason': reason},
+      );
+
+      if (response.statusCode == 200 || response.statusCode == 201) {
+        final body = response.data as Map<String, dynamic>;
+        final json = body.containsKey('data')
+            ? body['data'] as Map<String, dynamic>
+            : body;
+        return OrdenModel.fromJson(json);
+      }
+
+      throw ServerException(
+        message: tr('materiales.errors.cancel_order'),
+        code: response.statusCode,
+      );
+    } catch (e) {
+      AppLogger.e('Error en cancelOrder', tag: _tag, error: e);
+      _rethrow(e);
+    }
+  }
+
+  // ── Comprobantes ──────────────────────────────────────────────────────────
+
+  @override
+  Future<List<ComprobanteModel>> listComprobantes(String folioOrId) async {
+    try {
+      final response = await _dio.get(
+        '$_baseUrl${ApiEndpoints.materiales}/comprobantes/$folioOrId',
+      );
+
+      if (response.statusCode == 200 || response.statusCode == 201) {
+        final body = response.data as Map<String, dynamic>;
+        final rawData = _extractData(body) as List<dynamic>;
+        return rawData
+            .map((item) =>
+                ComprobanteModel.fromJson(item as Map<String, dynamic>))
+            .toList();
+      }
+
+      throw ServerException(
+        message: tr('materiales.errors.list_comprobantes'),
+        code: response.statusCode,
+      );
+    } catch (e) {
+      AppLogger.e('Error en listComprobantes', tag: _tag, error: e);
+      _rethrow(e);
+    }
+  }
+
+  @override
+  Future<ComprobanteModel> uploadComprobante({
+    required String folioOrId,
+    required File file,
+    required int montoCentavos,
+    required String refBancariaDeclarada,
+    required DateTime fechaPago,
+    void Function(double)? onProgress,
+  }) async {
+    try {
+      // Derive MIME from extension — NEVER trust the original filename for
+      // content type. The backend also validates MIME server-side.
+      final ext = file.path.split('.').last.toLowerCase();
+      final mime = _mimeFromExt(ext);
+
+      final formFields = <String, dynamic>{
+        'file': await MultipartFile.fromFile(
+          file.path,
+          filename: file.path.split('/').last,
+          contentType: DioMediaType.parse(mime),
+        ),
+        'monto_centavos': montoCentavos.toString(),
+        'ref_bancaria_declarada': refBancariaDeclarada,
+        // Backend expects ISO date string (date only, e.g. "2026-05-13")
+        'fecha_pago': fechaPago.toIso8601String().split('T').first,
+      };
+
+      final formData = FormData.fromMap(formFields);
+
+      final response = await _dio.post(
+        '$_baseUrl${ApiEndpoints.materiales}/comprobantes/$folioOrId',
+        data: formData,
+        options: Options(
+          headers: {'Content-Type': 'multipart/form-data'},
+          sendTimeout: const Duration(minutes: 2),
+          receiveTimeout: const Duration(minutes: 2),
+        ),
+        onSendProgress: (sent, total) {
+          if (total > 0) {
+            final fraction = sent / total;
+            onProgress?.call(fraction);
+            AppLogger.d(
+              'Comprobante upload: ${(fraction * 100).toStringAsFixed(1)}%',
+              tag: _tag,
+            );
+          }
+        },
+      );
+
+      if (response.statusCode == 200 || response.statusCode == 201) {
+        final body = response.data as Map<String, dynamic>;
+        final json = body.containsKey('data')
+            ? body['data'] as Map<String, dynamic>
+            : body;
+        return ComprobanteModel.fromJson(json);
+      }
+
+      throw ServerException(
+        message: tr('materiales.errors.upload_comprobante'),
+        code: response.statusCode,
+      );
+    } catch (e) {
+      AppLogger.e('Error en uploadComprobante', tag: _tag, error: e);
+      _rethrow(e);
+    }
+  }
+
+  // ── Configuración ─────────────────────────────────────────────────────────
+
+  @override
+  Future<MaterialConfigModel> getConfig() async {
+    try {
+      final response = await _dio.get(
+        '$_baseUrl${ApiEndpoints.materiales}/configuracion',
+      );
+
+      if (response.statusCode == 200 || response.statusCode == 201) {
+        final body = response.data as Map<String, dynamic>;
+        final json = body.containsKey('data')
+            ? body['data'] as Map<String, dynamic>
+            : body;
+        return MaterialConfigModel.fromJson(json);
+      }
+
+      throw ServerException(
+        message: tr('materiales.errors.get_config'),
+        code: response.statusCode,
+      );
+    } catch (e) {
+      AppLogger.e('Error en getConfig', tag: _tag, error: e);
+      _rethrow(e);
+    }
+  }
+
+  // ── Helpers ───────────────────────────────────────────────────────────────
+
+  /// Extrae el array/objeto de datos del envelope `{ data: [...] }` o devuelve
+  /// el body completo si no hay envelope.
+  dynamic _extractData(Map<String, dynamic> body) {
+    if (body.containsKey('data') && body['data'] != null) {
+      return body['data'];
+    }
+    return body;
+  }
+
+  /// Mapea extensión de archivo a MIME type.
+  /// PDF y JPG son los más comunes para comprobantes.
+  String _mimeFromExt(String ext) {
+    switch (ext) {
+      case 'pdf':
+        return 'application/pdf';
+      case 'jpg':
+      case 'jpeg':
+        return 'image/jpeg';
+      case 'png':
+        return 'image/png';
+      default:
+        return 'application/octet-stream';
+    }
+  }
+
+  /// Convierte excepciones a tipos conocidos.
+  ///
+  /// Respeta el patrón establecido en [EvidenceFolderRemoteDataSourceImpl].
+  Never _rethrow(Object e) {
+    if (e is DioException) {
+      final statusCode = e.response?.statusCode;
+      final msg = _extractDioMessage(e);
+      if (statusCode == 404) {
+        throw NotFoundException(message: msg, code: statusCode);
+      }
+      throw ServerException(message: msg, code: statusCode);
+    }
+    if (e is ServerException || e is AuthException || e is NotFoundException) {
+      throw e;
+    }
+    throw ServerException(message: e.toString());
+  }
+
+  String _extractDioMessage(DioException e) {
+    try {
+      final data = e.response?.data;
+      if (data is Map) {
+        return (data['message'] ?? e.message ?? tr('common.error_network'))
+            .toString();
+      }
+    } catch (ex) {
+      AppLogger.w('Error al parsear respuesta de error', tag: _tag, error: ex);
+    }
+    return e.message ?? tr('common.error_network');
+  }
+}

--- a/lib/features/materiales/data/datasources/materiales_remote_data_source.dart
+++ b/lib/features/materiales/data/datasources/materiales_remote_data_source.dart
@@ -272,8 +272,7 @@ class MaterialesRemoteDataSourceImpl implements MaterialesRemoteDataSource {
         final body = response.data as Map<String, dynamic>;
         final rawData = _extractData(body) as List<dynamic>;
         return rawData
-            .map((item) =>
-                OrdenModel.fromJson(item as Map<String, dynamic>))
+            .map((item) => OrdenModel.fromJson(item as Map<String, dynamic>))
             .toList();
       }
 
@@ -307,8 +306,7 @@ class MaterialesRemoteDataSourceImpl implements MaterialesRemoteDataSource {
         final body = response.data as Map<String, dynamic>;
         final rawData = _extractData(body) as List<dynamic>;
         return rawData
-            .map((item) =>
-                OrdenModel.fromJson(item as Map<String, dynamic>))
+            .map((item) => OrdenModel.fromJson(item as Map<String, dynamic>))
             .toList();
       }
 

--- a/lib/features/materiales/data/models/comprobante_model.dart
+++ b/lib/features/materiales/data/models/comprobante_model.dart
@@ -1,0 +1,110 @@
+import '../../domain/entities/comprobante.dart';
+import '../../domain/entities/material_comprobante_status.dart';
+
+/// Modelo de datos para [Comprobante].
+///
+/// Mapea la respuesta JSON de GET /materiales/comprobantes/:folio.
+class ComprobanteModel extends Comprobante {
+  const ComprobanteModel({
+    required super.id,
+    required super.orderId,
+    required super.r2Key,
+    required super.fileName,
+    required super.mimeType,
+    required super.sizeBytes,
+    required super.montoCentavos,
+    super.refBancariaDeclarada,
+    super.fechaPago,
+    required super.status,
+    super.signedUrl,
+    required super.uploadedBy,
+    super.validatedBy,
+    super.rejectReason,
+    required super.createdAt,
+    super.validatedAt,
+  });
+
+  factory ComprobanteModel.fromJson(Map<String, dynamic> json) {
+    DateTime? fechaPago;
+    final rawFecha = json['fecha_pago'] ?? json['fechaPago'];
+    if (rawFecha != null) {
+      fechaPago = DateTime.tryParse(rawFecha.toString());
+    }
+
+    DateTime? validatedAt;
+    final rawValidated = json['validated_at'] ?? json['validatedAt'];
+    if (rawValidated != null) {
+      validatedAt = DateTime.tryParse(rawValidated.toString());
+    }
+
+    return ComprobanteModel(
+      id: (json['id'] ?? '').toString(),
+      orderId: (json['order_id'] ?? json['orderId'] ?? '').toString(),
+      r2Key: (json['r2_key'] ?? json['r2Key'] ?? '').toString(),
+      fileName: (json['file_name'] ?? json['fileName'] ?? '').toString(),
+      mimeType: (json['mime_type'] ?? json['mimeType'] ?? '').toString(),
+      sizeBytes: (json['size_bytes'] ?? json['sizeBytes'] ?? 0) as int,
+      montoCentavos:
+          (json['monto_centavos'] ?? json['montoCentavos'] ?? 0) as int,
+      refBancariaDeclarada:
+          (json['ref_bancaria_declarada'] ?? json['refBancariaDeclarada'])
+              ?.toString(),
+      fechaPago: fechaPago,
+      status: MaterialComprobanteStatusX.fromString(
+        (json['status'] ?? 'pendiente').toString(),
+      ),
+      signedUrl:
+          (json['signed_url'] ?? json['signedUrl'])?.toString(),
+      uploadedBy: (json['uploaded_by'] ?? json['uploadedBy'] ?? '').toString(),
+      validatedBy:
+          (json['validated_by'] ?? json['validatedBy'])?.toString(),
+      rejectReason:
+          (json['reject_reason'] ?? json['rejectReason'])?.toString(),
+      createdAt: DateTime.tryParse(
+              (json['created_at'] ?? json['createdAt'] ?? '').toString()) ??
+          DateTime.now(),
+      validatedAt: validatedAt,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'order_id': orderId,
+      'r2_key': r2Key,
+      'file_name': fileName,
+      'mime_type': mimeType,
+      'size_bytes': sizeBytes,
+      'monto_centavos': montoCentavos,
+      if (refBancariaDeclarada != null)
+        'ref_bancaria_declarada': refBancariaDeclarada,
+      if (fechaPago != null) 'fecha_pago': fechaPago!.toIso8601String(),
+      'status': status.toApiString(),
+      if (signedUrl != null) 'signed_url': signedUrl,
+      'uploaded_by': uploadedBy,
+      if (validatedBy != null) 'validated_by': validatedBy,
+      if (rejectReason != null) 'reject_reason': rejectReason,
+      'created_at': createdAt.toIso8601String(),
+      if (validatedAt != null) 'validated_at': validatedAt!.toIso8601String(),
+    };
+  }
+
+  Comprobante toEntity() => Comprobante(
+        id: id,
+        orderId: orderId,
+        r2Key: r2Key,
+        fileName: fileName,
+        mimeType: mimeType,
+        sizeBytes: sizeBytes,
+        montoCentavos: montoCentavos,
+        refBancariaDeclarada: refBancariaDeclarada,
+        fechaPago: fechaPago,
+        status: status,
+        signedUrl: signedUrl,
+        uploadedBy: uploadedBy,
+        validatedBy: validatedBy,
+        rejectReason: rejectReason,
+        createdAt: createdAt,
+        validatedAt: validatedAt,
+      );
+}

--- a/lib/features/materiales/data/models/comprobante_model.dart
+++ b/lib/features/materiales/data/models/comprobante_model.dart
@@ -53,13 +53,10 @@ class ComprobanteModel extends Comprobante {
       status: MaterialComprobanteStatusX.fromString(
         (json['status'] ?? 'pendiente').toString(),
       ),
-      signedUrl:
-          (json['signed_url'] ?? json['signedUrl'])?.toString(),
+      signedUrl: (json['signed_url'] ?? json['signedUrl'])?.toString(),
       uploadedBy: (json['uploaded_by'] ?? json['uploadedBy'] ?? '').toString(),
-      validatedBy:
-          (json['validated_by'] ?? json['validatedBy'])?.toString(),
-      rejectReason:
-          (json['reject_reason'] ?? json['rejectReason'])?.toString(),
+      validatedBy: (json['validated_by'] ?? json['validatedBy'])?.toString(),
+      rejectReason: (json['reject_reason'] ?? json['rejectReason'])?.toString(),
       createdAt: DateTime.tryParse(
               (json['created_at'] ?? json['createdAt'] ?? '').toString()) ??
           DateTime.now(),

--- a/lib/features/materiales/data/models/material_category_model.dart
+++ b/lib/features/materiales/data/models/material_category_model.dart
@@ -1,0 +1,42 @@
+import '../../domain/entities/material_category.dart';
+
+/// Modelo de datos para [MaterialCategory].
+///
+/// Mapea la respuesta JSON del endpoint GET /materiales/catalogo/categorias.
+class MaterialCategoryModel extends MaterialCategory {
+  const MaterialCategoryModel({
+    required super.id,
+    required super.slug,
+    required super.label,
+    super.icon,
+    required super.sortOrder,
+  });
+
+  factory MaterialCategoryModel.fromJson(Map<String, dynamic> json) {
+    return MaterialCategoryModel(
+      id: (json['id'] ?? '').toString(),
+      slug: (json['slug'] ?? '').toString(),
+      label: (json['label'] ?? '').toString(),
+      icon: json['icon']?.toString(),
+      sortOrder: (json['sort_order'] ?? json['sortOrder'] ?? 0) as int,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'slug': slug,
+      'label': label,
+      if (icon != null) 'icon': icon,
+      'sort_order': sortOrder,
+    };
+  }
+
+  MaterialCategory toEntity() => MaterialCategory(
+        id: id,
+        slug: slug,
+        label: label,
+        icon: icon,
+        sortOrder: sortOrder,
+      );
+}

--- a/lib/features/materiales/data/models/material_config_model.dart
+++ b/lib/features/materiales/data/models/material_config_model.dart
@@ -1,0 +1,70 @@
+import '../../domain/entities/material_config.dart';
+import '../../domain/entities/material_entrega.dart';
+
+/// Modelo de datos para [MaterialConfig].
+///
+/// Mapea la respuesta JSON de GET /materiales/configuracion.
+class MaterialConfigModel extends MaterialConfig {
+  const MaterialConfigModel({
+    super.bankName,
+    super.bankAccountClabe,
+    super.accountHolder,
+    required super.envioCentavosDefault,
+    super.pickupAddress,
+    required super.deliveryOptions,
+    required super.updatedAt,
+  });
+
+  factory MaterialConfigModel.fromJson(Map<String, dynamic> json) {
+    // delivery_options: el backend devuelve un array de strings
+    // ej. ["recoger", "envio"] o un JSON array
+    final rawOptions = json['delivery_options'] ?? json['deliveryOptions'];
+    List<MaterialEntrega> deliveryOptions = [];
+    if (rawOptions is List) {
+      deliveryOptions = rawOptions
+          .map((o) => MaterialEntregaX.fromString(o.toString()))
+          .toList();
+    }
+
+    return MaterialConfigModel(
+      bankName:
+          (json['bank_name'] ?? json['bankName'])?.toString(),
+      bankAccountClabe:
+          (json['bank_account_clabe'] ?? json['bankAccountClabe'])?.toString(),
+      accountHolder:
+          (json['account_holder'] ?? json['accountHolder'])?.toString(),
+      envioCentavosDefault:
+          (json['envio_centavos_default'] ?? json['envioCentavosDefault'] ?? 0)
+              as int,
+      pickupAddress:
+          (json['pickup_address'] ?? json['pickupAddress'])?.toString(),
+      deliveryOptions: deliveryOptions,
+      updatedAt: DateTime.tryParse(
+              (json['updated_at'] ?? json['updatedAt'] ?? '').toString()) ??
+          DateTime.now(),
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      if (bankName != null) 'bank_name': bankName,
+      if (bankAccountClabe != null) 'bank_account_clabe': bankAccountClabe,
+      if (accountHolder != null) 'account_holder': accountHolder,
+      'envio_centavos_default': envioCentavosDefault,
+      if (pickupAddress != null) 'pickup_address': pickupAddress,
+      'delivery_options':
+          deliveryOptions.map((o) => o.toApiString()).toList(),
+      'updated_at': updatedAt.toIso8601String(),
+    };
+  }
+
+  MaterialConfig toEntity() => MaterialConfig(
+        bankName: bankName,
+        bankAccountClabe: bankAccountClabe,
+        accountHolder: accountHolder,
+        envioCentavosDefault: envioCentavosDefault,
+        pickupAddress: pickupAddress,
+        deliveryOptions: deliveryOptions,
+        updatedAt: updatedAt,
+      );
+}

--- a/lib/features/materiales/data/models/material_config_model.dart
+++ b/lib/features/materiales/data/models/material_config_model.dart
@@ -27,15 +27,14 @@ class MaterialConfigModel extends MaterialConfig {
     }
 
     return MaterialConfigModel(
-      bankName:
-          (json['bank_name'] ?? json['bankName'])?.toString(),
+      bankName: (json['bank_name'] ?? json['bankName'])?.toString(),
       bankAccountClabe:
           (json['bank_account_clabe'] ?? json['bankAccountClabe'])?.toString(),
       accountHolder:
           (json['account_holder'] ?? json['accountHolder'])?.toString(),
-      envioCentavosDefault:
-          (json['envio_centavos_default'] ?? json['envioCentavosDefault'] ?? 0)
-              as int,
+      envioCentavosDefault: (json['envio_centavos_default'] ??
+          json['envioCentavosDefault'] ??
+          0) as int,
       pickupAddress:
           (json['pickup_address'] ?? json['pickupAddress'])?.toString(),
       deliveryOptions: deliveryOptions,
@@ -52,8 +51,7 @@ class MaterialConfigModel extends MaterialConfig {
       if (accountHolder != null) 'account_holder': accountHolder,
       'envio_centavos_default': envioCentavosDefault,
       if (pickupAddress != null) 'pickup_address': pickupAddress,
-      'delivery_options':
-          deliveryOptions.map((o) => o.toApiString()).toList(),
+      'delivery_options': deliveryOptions.map((o) => o.toApiString()).toList(),
       'updated_at': updatedAt.toIso8601String(),
     };
   }

--- a/lib/features/materiales/data/models/material_item_model.dart
+++ b/lib/features/materiales/data/models/material_item_model.dart
@@ -1,0 +1,98 @@
+import '../../domain/entities/material_item.dart';
+import 'material_category_model.dart';
+import 'material_programa_model.dart';
+import 'material_variant_model.dart';
+
+/// Modelo de datos para [MaterialItem].
+///
+/// Mapea la respuesta JSON del endpoint GET /materiales/catalogo y GET /materiales/catalogo/:id.
+class MaterialItemModel extends MaterialItem {
+  const MaterialItemModel({
+    required super.id,
+    required super.sku,
+    required super.title,
+    super.description,
+    required super.category,
+    required super.programa,
+    required super.priceCentavos,
+    required super.stock,
+    required super.active,
+    super.variant,
+  });
+
+  factory MaterialItemModel.fromJson(Map<String, dynamic> json) {
+    final catJson = json['cat'] as Map<String, dynamic>?;
+    final programaJson = json['programa'] as Map<String, dynamic>?;
+
+    // variants?: el backend envía el objeto variante directamente (no array)
+    // cuando el producto tiene variantes (v1: máximo una).
+    final variantJson = json['variants'] as Map<String, dynamic>?;
+
+    return MaterialItemModel(
+      id: (json['id'] ?? '').toString(),
+      sku: (json['sku'] ?? '').toString(),
+      title: (json['title'] ?? '').toString(),
+      description: json['description']?.toString(),
+      category: catJson != null
+          ? MaterialCategoryModel.fromJson(catJson)
+          : const MaterialCategoryModel(
+              id: '',
+              slug: '',
+              label: '',
+              sortOrder: 0,
+            ),
+      programa: programaJson != null
+          ? MaterialProgramaModel.fromJson(programaJson)
+          : const MaterialProgramaModel(id: 0, label: ''),
+      priceCentavos:
+          (json['price_centavos'] ?? json['priceCentavos'] ?? 0) as int,
+      stock: (json['stock'] ?? 0) as int,
+      active: (json['active'] ?? true) as bool,
+      variant: variantJson != null
+          ? MaterialVariantModel.fromJson(variantJson)
+          : null,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    final cat = category;
+    final prog = programa;
+    return {
+      'id': id,
+      'sku': sku,
+      'title': title,
+      if (description != null) 'description': description,
+      'cat': {
+        'id': cat.id,
+        'slug': cat.slug,
+        'label': cat.label,
+      },
+      'programa': {
+        'id': prog.id,
+        'label': prog.label,
+      },
+      'price_centavos': priceCentavos,
+      'stock': stock,
+      'active': active,
+      if (variant != null)
+        'variants': MaterialVariantModel(
+          id: variant!.id,
+          type: variant!.type,
+          options: variant!.options,
+        ).toJson(),
+    };
+  }
+
+  MaterialItem toEntity() => MaterialItem(
+        id: id,
+        sku: sku,
+        title: title,
+        description: description,
+        category: category,
+        programa: programa,
+        priceCentavos: priceCentavos,
+        stock: stock,
+        active: active,
+        variant: variant,
+      );
+}

--- a/lib/features/materiales/data/models/material_programa_model.dart
+++ b/lib/features/materiales/data/models/material_programa_model.dart
@@ -1,0 +1,28 @@
+import '../../domain/entities/material_programa.dart';
+
+/// Modelo de datos para [MaterialPrograma].
+///
+/// Mapea la respuesta JSON del endpoint GET /materiales/catalogo/programas.
+/// Los datos provienen de la tabla `club_types` del backend.
+class MaterialProgramaModel extends MaterialPrograma {
+  const MaterialProgramaModel({
+    required super.id,
+    required super.label,
+  });
+
+  factory MaterialProgramaModel.fromJson(Map<String, dynamic> json) {
+    return MaterialProgramaModel(
+      id: (json['id'] as num).toInt(),
+      label: (json['label'] ?? '').toString(),
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'label': label,
+    };
+  }
+
+  MaterialPrograma toEntity() => MaterialPrograma(id: id, label: label);
+}

--- a/lib/features/materiales/data/models/material_variant_model.dart
+++ b/lib/features/materiales/data/models/material_variant_model.dart
@@ -1,0 +1,46 @@
+import '../../domain/entities/material_variant.dart';
+import '../../domain/entities/material_variant_type.dart';
+import 'material_variant_option_model.dart';
+
+/// Modelo de datos para [MaterialVariant].
+class MaterialVariantModel extends MaterialVariant {
+  const MaterialVariantModel({
+    required super.id,
+    required super.type,
+    required super.options,
+  });
+
+  factory MaterialVariantModel.fromJson(Map<String, dynamic> json) {
+    final rawOptions = json['options'] as List<dynamic>? ?? [];
+    return MaterialVariantModel(
+      id: (json['id'] ?? '').toString(),
+      type: MaterialVariantTypeX.fromString(
+        (json['type'] ?? '').toString(),
+      ),
+      options: rawOptions
+          .map((o) =>
+              MaterialVariantOptionModel.fromJson(o as Map<String, dynamic>))
+          .toList(),
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'type': type.toApiString(),
+      'options': options
+          .map((o) => MaterialVariantOptionModel(
+                id: o.id,
+                label: o.label,
+                stock: o.stock,
+              ).toJson())
+          .toList(),
+    };
+  }
+
+  MaterialVariant toEntity() => MaterialVariant(
+        id: id,
+        type: type,
+        options: options,
+      );
+}

--- a/lib/features/materiales/data/models/material_variant_option_model.dart
+++ b/lib/features/materiales/data/models/material_variant_option_model.dart
@@ -1,0 +1,32 @@
+import '../../domain/entities/material_variant_option.dart';
+
+/// Modelo de datos para [MaterialVariantOption].
+class MaterialVariantOptionModel extends MaterialVariantOption {
+  const MaterialVariantOptionModel({
+    required super.id,
+    required super.label,
+    required super.stock,
+  });
+
+  factory MaterialVariantOptionModel.fromJson(Map<String, dynamic> json) {
+    return MaterialVariantOptionModel(
+      id: (json['id'] ?? '').toString(),
+      label: (json['label'] ?? '').toString(),
+      stock: (json['stock'] ?? 0) as int,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'label': label,
+      'stock': stock,
+    };
+  }
+
+  MaterialVariantOption toEntity() => MaterialVariantOption(
+        id: id,
+        label: label,
+        stock: stock,
+      );
+}

--- a/lib/features/materiales/data/models/orden_line_model.dart
+++ b/lib/features/materiales/data/models/orden_line_model.dart
@@ -1,0 +1,83 @@
+import '../../domain/entities/material_disponibilidad.dart';
+import '../../domain/entities/orden_line.dart';
+
+/// Modelo de datos para [OrdenLine].
+class OrdenLineModel extends OrdenLine {
+  const OrdenLineModel({
+    required super.id,
+    required super.productId,
+    super.variantOptionId,
+    required super.qty,
+    required super.priceCentavos,
+    required super.disponibilidad,
+    super.qtyDisponible,
+    required super.lineTotalCentavos,
+    required super.product,
+  });
+
+  factory OrdenLineModel.fromJson(Map<String, dynamic> json) {
+    final productJson = json['product'] as Map<String, dynamic>?;
+
+    return OrdenLineModel(
+      id: (json['id'] ?? '').toString(),
+      productId: (json['product_id'] ?? json['productId'] ?? '').toString(),
+      variantOptionId:
+          (json['variant_option_id'] ?? json['variantOptionId'])?.toString(),
+      qty: (json['qty'] ?? 1) as int,
+      priceCentavos:
+          (json['price_centavos'] ?? json['priceCentavos'] ?? 0) as int,
+      disponibilidad: MaterialDisponibilidadX.fromString(
+        (json['disponibilidad'] ?? 'pendiente').toString(),
+      ),
+      qtyDisponible:
+          (json['qty_disponible'] ?? json['qtyDisponible']) as int?,
+      lineTotalCentavos:
+          (json['line_total_centavos'] ?? json['lineTotalCentavos'] ?? 0) as int,
+      product: productJson != null
+          ? _productFromJson(productJson)
+          : OrdenLineProduct(
+              id: (json['product_id'] ?? '').toString(),
+              sku: '',
+              title: '',
+            ),
+    );
+  }
+
+  static OrdenLineProduct _productFromJson(Map<String, dynamic> json) {
+    return OrdenLineProduct(
+      id: (json['id'] ?? '').toString(),
+      sku: (json['sku'] ?? '').toString(),
+      title: (json['title'] ?? '').toString(),
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'product_id': productId,
+      if (variantOptionId != null) 'variant_option_id': variantOptionId,
+      'qty': qty,
+      'price_centavos': priceCentavos,
+      'disponibilidad': disponibilidad.toApiString(),
+      if (qtyDisponible != null) 'qty_disponible': qtyDisponible,
+      'line_total_centavos': lineTotalCentavos,
+      'product': {
+        'id': product.id,
+        'sku': product.sku,
+        'title': product.title,
+      },
+    };
+  }
+
+  OrdenLine toEntity() => OrdenLine(
+        id: id,
+        productId: productId,
+        variantOptionId: variantOptionId,
+        qty: qty,
+        priceCentavos: priceCentavos,
+        disponibilidad: disponibilidad,
+        qtyDisponible: qtyDisponible,
+        lineTotalCentavos: lineTotalCentavos,
+        product: product,
+      );
+}

--- a/lib/features/materiales/data/models/orden_line_model.dart
+++ b/lib/features/materiales/data/models/orden_line_model.dart
@@ -29,10 +29,10 @@ class OrdenLineModel extends OrdenLine {
       disponibilidad: MaterialDisponibilidadX.fromString(
         (json['disponibilidad'] ?? 'pendiente').toString(),
       ),
-      qtyDisponible:
-          (json['qty_disponible'] ?? json['qtyDisponible']) as int?,
-      lineTotalCentavos:
-          (json['line_total_centavos'] ?? json['lineTotalCentavos'] ?? 0) as int,
+      qtyDisponible: (json['qty_disponible'] ?? json['qtyDisponible']) as int?,
+      lineTotalCentavos: (json['line_total_centavos'] ??
+          json['lineTotalCentavos'] ??
+          0) as int,
       product: productJson != null
           ? _productFromJson(productJson)
           : OrdenLineProduct(

--- a/lib/features/materiales/data/models/orden_model.dart
+++ b/lib/features/materiales/data/models/orden_model.dart
@@ -1,0 +1,199 @@
+import '../../domain/entities/material_entrega.dart';
+import '../../domain/entities/material_estado.dart';
+import '../../domain/entities/orden.dart';
+import 'comprobante_model.dart';
+import 'orden_line_model.dart';
+
+/// Modelo de datos para [Orden].
+///
+/// Mapea la respuesta JSON de POST /materiales/ordenes, GET /materiales/ordenes/:folio,
+/// y GET /materiales/ordenes/historial.
+class OrdenModel extends Orden {
+  const OrdenModel({
+    required super.id,
+    super.folioReferencia,
+    required super.estado,
+    required super.clubSectionId,
+    required super.createdBy,
+    super.approvedBy,
+    super.validatedBy,
+    super.deliveredBy,
+    super.cancelledBy,
+    required super.subtotalCentavos,
+    required super.envioCentavos,
+    required super.totalCentavos,
+    required super.entrega,
+    super.notas,
+    super.cancelReason,
+    super.bankName,
+    super.bankAccountClabe,
+    super.accountHolder,
+    super.pickupAddress,
+    required super.createdAt,
+    super.approvedAt,
+    super.paidAt,
+    super.deliveredAt,
+    super.cancelledAt,
+    required super.lines,
+    required super.comprobantes,
+  });
+
+  factory OrdenModel.fromJson(Map<String, dynamic> json) {
+    final rawLines = json['lines'] as List<dynamic>? ?? [];
+    final rawComprobantes = json['comprobantes'] as List<dynamic>? ?? [];
+
+    DateTime? parseDate(dynamic raw) {
+      if (raw == null) return null;
+      return DateTime.tryParse(raw.toString());
+    }
+
+    return OrdenModel(
+      id: (json['id'] ?? '').toString(),
+      folioReferencia:
+          (json['folio_referencia'] ?? json['folioReferencia'])?.toString(),
+      estado: MaterialEstadoX.fromString(
+        (json['estado'] ?? 'en_revision').toString(),
+      ),
+      clubSectionId:
+          (json['club_section_id'] ?? json['clubSectionId'] as num? ?? 0)
+              .toInt(),
+      createdBy:
+          (json['created_by'] ?? json['createdBy'] ?? '').toString(),
+      approvedBy:
+          (json['approved_by'] ?? json['approvedBy'])?.toString(),
+      validatedBy:
+          (json['validated_by'] ?? json['validatedBy'])?.toString(),
+      deliveredBy:
+          (json['delivered_by'] ?? json['deliveredBy'])?.toString(),
+      cancelledBy:
+          (json['cancelled_by'] ?? json['cancelledBy'])?.toString(),
+      subtotalCentavos:
+          (json['subtotal_centavos'] ?? json['subtotalCentavos'] ?? 0) as int,
+      envioCentavos:
+          (json['envio_centavos'] ?? json['envioCentavos'] ?? 0) as int,
+      totalCentavos:
+          (json['total_centavos'] ?? json['totalCentavos'] ?? 0) as int,
+      entrega: MaterialEntregaX.fromString(
+        (json['entrega'] ?? 'recoger').toString(),
+      ),
+      notas: json['notas']?.toString(),
+      cancelReason:
+          (json['cancel_reason'] ?? json['cancelReason'])?.toString(),
+      bankName:
+          (json['bank_name'] ?? json['bankName'])?.toString(),
+      bankAccountClabe:
+          (json['bank_account_clabe'] ?? json['bankAccountClabe'])?.toString(),
+      accountHolder:
+          (json['account_holder'] ?? json['accountHolder'])?.toString(),
+      pickupAddress:
+          (json['pickup_address'] ?? json['pickupAddress'])?.toString(),
+      createdAt: parseDate(json['created_at'] ?? json['createdAt']) ??
+          DateTime.now(),
+      approvedAt:
+          parseDate(json['approved_at'] ?? json['approvedAt']),
+      paidAt: parseDate(json['paid_at'] ?? json['paidAt']),
+      deliveredAt:
+          parseDate(json['delivered_at'] ?? json['deliveredAt']),
+      cancelledAt:
+          parseDate(json['cancelled_at'] ?? json['cancelledAt']),
+      lines: rawLines
+          .map((l) => OrdenLineModel.fromJson(l as Map<String, dynamic>))
+          .toList(),
+      comprobantes: rawComprobantes
+          .map((c) =>
+              ComprobanteModel.fromJson(c as Map<String, dynamic>))
+          .toList(),
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      if (folioReferencia != null) 'folio_referencia': folioReferencia,
+      'estado': estado.toApiString(),
+      'club_section_id': clubSectionId,
+      'created_by': createdBy,
+      if (approvedBy != null) 'approved_by': approvedBy,
+      if (validatedBy != null) 'validated_by': validatedBy,
+      if (deliveredBy != null) 'delivered_by': deliveredBy,
+      if (cancelledBy != null) 'cancelled_by': cancelledBy,
+      'subtotal_centavos': subtotalCentavos,
+      'envio_centavos': envioCentavos,
+      'total_centavos': totalCentavos,
+      'entrega': entrega.toApiString(),
+      if (notas != null) 'notas': notas,
+      if (cancelReason != null) 'cancel_reason': cancelReason,
+      if (bankName != null) 'bank_name': bankName,
+      if (bankAccountClabe != null) 'bank_account_clabe': bankAccountClabe,
+      if (accountHolder != null) 'account_holder': accountHolder,
+      if (pickupAddress != null) 'pickup_address': pickupAddress,
+      'created_at': createdAt.toIso8601String(),
+      if (approvedAt != null) 'approved_at': approvedAt!.toIso8601String(),
+      if (paidAt != null) 'paid_at': paidAt!.toIso8601String(),
+      if (deliveredAt != null) 'delivered_at': deliveredAt!.toIso8601String(),
+      if (cancelledAt != null) 'cancelled_at': cancelledAt!.toIso8601String(),
+      'lines': lines
+          .map((l) => OrdenLineModel(
+                id: l.id,
+                productId: l.productId,
+                variantOptionId: l.variantOptionId,
+                qty: l.qty,
+                priceCentavos: l.priceCentavos,
+                disponibilidad: l.disponibilidad,
+                qtyDisponible: l.qtyDisponible,
+                lineTotalCentavos: l.lineTotalCentavos,
+                product: l.product,
+              ).toJson())
+          .toList(),
+      'comprobantes': comprobantes
+          .map((c) => ComprobanteModel(
+                id: c.id,
+                orderId: c.orderId,
+                r2Key: c.r2Key,
+                fileName: c.fileName,
+                mimeType: c.mimeType,
+                sizeBytes: c.sizeBytes,
+                montoCentavos: c.montoCentavos,
+                refBancariaDeclarada: c.refBancariaDeclarada,
+                fechaPago: c.fechaPago,
+                status: c.status,
+                signedUrl: c.signedUrl,
+                uploadedBy: c.uploadedBy,
+                validatedBy: c.validatedBy,
+                rejectReason: c.rejectReason,
+                createdAt: c.createdAt,
+                validatedAt: c.validatedAt,
+              ).toJson())
+          .toList(),
+    };
+  }
+
+  Orden toEntity() => Orden(
+        id: id,
+        folioReferencia: folioReferencia,
+        estado: estado,
+        clubSectionId: clubSectionId,
+        createdBy: createdBy,
+        approvedBy: approvedBy,
+        validatedBy: validatedBy,
+        deliveredBy: deliveredBy,
+        cancelledBy: cancelledBy,
+        subtotalCentavos: subtotalCentavos,
+        envioCentavos: envioCentavos,
+        totalCentavos: totalCentavos,
+        entrega: entrega,
+        notas: notas,
+        cancelReason: cancelReason,
+        bankName: bankName,
+        bankAccountClabe: bankAccountClabe,
+        accountHolder: accountHolder,
+        pickupAddress: pickupAddress,
+        createdAt: createdAt,
+        approvedAt: approvedAt,
+        paidAt: paidAt,
+        deliveredAt: deliveredAt,
+        cancelledAt: cancelledAt,
+        lines: lines,
+        comprobantes: comprobantes,
+      );
+}

--- a/lib/features/materiales/data/models/orden_model.dart
+++ b/lib/features/materiales/data/models/orden_model.dart
@@ -57,16 +57,11 @@ class OrdenModel extends Orden {
       clubSectionId:
           (json['club_section_id'] ?? json['clubSectionId'] as num? ?? 0)
               .toInt(),
-      createdBy:
-          (json['created_by'] ?? json['createdBy'] ?? '').toString(),
-      approvedBy:
-          (json['approved_by'] ?? json['approvedBy'])?.toString(),
-      validatedBy:
-          (json['validated_by'] ?? json['validatedBy'])?.toString(),
-      deliveredBy:
-          (json['delivered_by'] ?? json['deliveredBy'])?.toString(),
-      cancelledBy:
-          (json['cancelled_by'] ?? json['cancelledBy'])?.toString(),
+      createdBy: (json['created_by'] ?? json['createdBy'] ?? '').toString(),
+      approvedBy: (json['approved_by'] ?? json['approvedBy'])?.toString(),
+      validatedBy: (json['validated_by'] ?? json['validatedBy'])?.toString(),
+      deliveredBy: (json['delivered_by'] ?? json['deliveredBy'])?.toString(),
+      cancelledBy: (json['cancelled_by'] ?? json['cancelledBy'])?.toString(),
       subtotalCentavos:
           (json['subtotal_centavos'] ?? json['subtotalCentavos'] ?? 0) as int,
       envioCentavos:
@@ -77,31 +72,25 @@ class OrdenModel extends Orden {
         (json['entrega'] ?? 'recoger').toString(),
       ),
       notas: json['notas']?.toString(),
-      cancelReason:
-          (json['cancel_reason'] ?? json['cancelReason'])?.toString(),
-      bankName:
-          (json['bank_name'] ?? json['bankName'])?.toString(),
+      cancelReason: (json['cancel_reason'] ?? json['cancelReason'])?.toString(),
+      bankName: (json['bank_name'] ?? json['bankName'])?.toString(),
       bankAccountClabe:
           (json['bank_account_clabe'] ?? json['bankAccountClabe'])?.toString(),
       accountHolder:
           (json['account_holder'] ?? json['accountHolder'])?.toString(),
       pickupAddress:
           (json['pickup_address'] ?? json['pickupAddress'])?.toString(),
-      createdAt: parseDate(json['created_at'] ?? json['createdAt']) ??
-          DateTime.now(),
-      approvedAt:
-          parseDate(json['approved_at'] ?? json['approvedAt']),
+      createdAt:
+          parseDate(json['created_at'] ?? json['createdAt']) ?? DateTime.now(),
+      approvedAt: parseDate(json['approved_at'] ?? json['approvedAt']),
       paidAt: parseDate(json['paid_at'] ?? json['paidAt']),
-      deliveredAt:
-          parseDate(json['delivered_at'] ?? json['deliveredAt']),
-      cancelledAt:
-          parseDate(json['cancelled_at'] ?? json['cancelledAt']),
+      deliveredAt: parseDate(json['delivered_at'] ?? json['deliveredAt']),
+      cancelledAt: parseDate(json['cancelled_at'] ?? json['cancelledAt']),
       lines: rawLines
           .map((l) => OrdenLineModel.fromJson(l as Map<String, dynamic>))
           .toList(),
       comprobantes: rawComprobantes
-          .map((c) =>
-              ComprobanteModel.fromJson(c as Map<String, dynamic>))
+          .map((c) => ComprobanteModel.fromJson(c as Map<String, dynamic>))
           .toList(),
     );
   }

--- a/lib/features/materiales/data/repositories/materiales_repository_impl.dart
+++ b/lib/features/materiales/data/repositories/materiales_repository_impl.dart
@@ -1,0 +1,274 @@
+import 'dart:io';
+
+import 'package:dartz/dartz.dart';
+
+import '../../../../core/errors/exceptions.dart';
+import '../../../../core/errors/failures.dart';
+import '../../../../core/network/network_info.dart';
+import '../../domain/entities/comprobante.dart';
+import '../../domain/entities/material_category.dart';
+import '../../domain/entities/material_config.dart';
+import '../../domain/entities/material_entrega.dart';
+import '../../domain/entities/material_item.dart';
+import '../../domain/entities/material_programa.dart';
+import '../../domain/entities/orden.dart';
+import '../../domain/repositories/materiales_repository.dart';
+import '../datasources/materiales_remote_data_source.dart';
+
+/// Implementación concreta del [MaterialesRepository].
+///
+/// Delega llamadas de red al [MaterialesRemoteDataSource] y convierte
+/// excepciones en valores de tipo [Either<Failure, T>].
+class MaterialesRepositoryImpl implements MaterialesRepository {
+  final MaterialesRemoteDataSource remoteDataSource;
+  final NetworkInfo networkInfo;
+
+  MaterialesRepositoryImpl({
+    required this.remoteDataSource,
+    required this.networkInfo,
+  });
+
+  // ── Catálogo ───────────────────────────────────────────────────────────────
+
+  @override
+  Future<Either<Failure, List<MaterialItem>>> browseCatalog({
+    String? cat,
+    int? programaId,
+    String? q,
+    int page = 1,
+    int pageSize = 20,
+  }) async {
+    try {
+      final models = await remoteDataSource.browseCatalog(
+        cat: cat,
+        programaId: programaId,
+        q: q,
+        page: page,
+        pageSize: pageSize,
+      );
+      return Right(models.map((m) => m.toEntity()).toList());
+    } on NotFoundException catch (e) {
+      return Left(NotFoundFailure(message: e.message, code: e.code));
+    } on ServerException catch (e) {
+      return Left(ServerFailure(message: e.message, code: e.code));
+    } on AuthException catch (e) {
+      return Left(AuthFailure(message: e.message, code: e.code));
+    } catch (e) {
+      return Left(UnexpectedFailure(message: e.toString()));
+    }
+  }
+
+  @override
+  Future<Either<Failure, MaterialItem>> getProductDetail(String id) async {
+    try {
+      final model = await remoteDataSource.getProductDetail(id);
+      return Right(model.toEntity());
+    } on NotFoundException catch (e) {
+      return Left(NotFoundFailure(message: e.message, code: e.code));
+    } on ServerException catch (e) {
+      return Left(ServerFailure(message: e.message, code: e.code));
+    } on AuthException catch (e) {
+      return Left(AuthFailure(message: e.message, code: e.code));
+    } catch (e) {
+      return Left(UnexpectedFailure(message: e.toString()));
+    }
+  }
+
+  @override
+  Future<Either<Failure, List<MaterialCategory>>> listCategorias() async {
+    try {
+      final models = await remoteDataSource.listCategorias();
+      return Right(models.map((m) => m.toEntity()).toList());
+    } on ServerException catch (e) {
+      return Left(ServerFailure(message: e.message, code: e.code));
+    } on AuthException catch (e) {
+      return Left(AuthFailure(message: e.message, code: e.code));
+    } catch (e) {
+      return Left(UnexpectedFailure(message: e.toString()));
+    }
+  }
+
+  @override
+  Future<Either<Failure, List<MaterialPrograma>>> listProgramas() async {
+    try {
+      final models = await remoteDataSource.listProgramas();
+      return Right(models.map((m) => m.toEntity()).toList());
+    } on ServerException catch (e) {
+      return Left(ServerFailure(message: e.message, code: e.code));
+    } on AuthException catch (e) {
+      return Left(AuthFailure(message: e.message, code: e.code));
+    } catch (e) {
+      return Left(UnexpectedFailure(message: e.toString()));
+    }
+  }
+
+  // ── Órdenes ────────────────────────────────────────────────────────────────
+
+  @override
+  Future<Either<Failure, Orden>> createOrder({
+    required int clubSectionId,
+    required List<({String productId, String? variantOptionId, int qty})> lines,
+    required MaterialEntrega entrega,
+    String? notas,
+  }) async {
+    try {
+      final model = await remoteDataSource.createOrder(
+        clubSectionId: clubSectionId,
+        lines: lines,
+        entrega: entrega,
+        notas: notas,
+      );
+      return Right(model.toEntity());
+    } on NotFoundException catch (e) {
+      return Left(NotFoundFailure(message: e.message, code: e.code));
+    } on ServerException catch (e) {
+      return Left(ServerFailure(message: e.message, code: e.code));
+    } on AuthException catch (e) {
+      return Left(AuthFailure(message: e.message, code: e.code));
+    } catch (e) {
+      return Left(UnexpectedFailure(message: e.toString()));
+    }
+  }
+
+  @override
+  Future<Either<Failure, List<Orden>>> listOrdenes({
+    String? estado,
+    int page = 1,
+    int pageSize = 20,
+  }) async {
+    try {
+      final models = await remoteDataSource.listOrdenes(
+        estado: estado,
+        page: page,
+        pageSize: pageSize,
+      );
+      return Right(models.map((m) => m.toEntity()).toList());
+    } on ServerException catch (e) {
+      return Left(ServerFailure(message: e.message, code: e.code));
+    } on AuthException catch (e) {
+      return Left(AuthFailure(message: e.message, code: e.code));
+    } catch (e) {
+      return Left(UnexpectedFailure(message: e.toString()));
+    }
+  }
+
+  @override
+  Future<Either<Failure, List<Orden>>> getOrderHistory({
+    int page = 1,
+    int pageSize = 20,
+  }) async {
+    try {
+      final models = await remoteDataSource.getOrderHistory(
+        page: page,
+        pageSize: pageSize,
+      );
+      return Right(models.map((m) => m.toEntity()).toList());
+    } on ServerException catch (e) {
+      return Left(ServerFailure(message: e.message, code: e.code));
+    } on AuthException catch (e) {
+      return Left(AuthFailure(message: e.message, code: e.code));
+    } catch (e) {
+      return Left(UnexpectedFailure(message: e.toString()));
+    }
+  }
+
+  @override
+  Future<Either<Failure, Orden>> getOrderByFolio(String folioOrId) async {
+    try {
+      final model = await remoteDataSource.getOrderByFolio(folioOrId);
+      return Right(model.toEntity());
+    } on NotFoundException catch (e) {
+      return Left(NotFoundFailure(message: e.message, code: e.code));
+    } on ServerException catch (e) {
+      return Left(ServerFailure(message: e.message, code: e.code));
+    } on AuthException catch (e) {
+      return Left(AuthFailure(message: e.message, code: e.code));
+    } catch (e) {
+      return Left(UnexpectedFailure(message: e.toString()));
+    }
+  }
+
+  @override
+  Future<Either<Failure, Orden>> cancelOrder(
+      String folioOrId, String reason) async {
+    try {
+      final model =
+          await remoteDataSource.cancelOrder(folioOrId, reason);
+      return Right(model.toEntity());
+    } on NotFoundException catch (e) {
+      return Left(NotFoundFailure(message: e.message, code: e.code));
+    } on ServerException catch (e) {
+      return Left(ServerFailure(message: e.message, code: e.code));
+    } on AuthException catch (e) {
+      return Left(AuthFailure(message: e.message, code: e.code));
+    } catch (e) {
+      return Left(UnexpectedFailure(message: e.toString()));
+    }
+  }
+
+  // ── Comprobantes ──────────────────────────────────────────────────────────
+
+  @override
+  Future<Either<Failure, List<Comprobante>>> listComprobantes(
+      String folioOrId) async {
+    try {
+      final models =
+          await remoteDataSource.listComprobantes(folioOrId);
+      return Right(models.map((m) => m.toEntity()).toList());
+    } on NotFoundException catch (e) {
+      return Left(NotFoundFailure(message: e.message, code: e.code));
+    } on ServerException catch (e) {
+      return Left(ServerFailure(message: e.message, code: e.code));
+    } on AuthException catch (e) {
+      return Left(AuthFailure(message: e.message, code: e.code));
+    } catch (e) {
+      return Left(UnexpectedFailure(message: e.toString()));
+    }
+  }
+
+  @override
+  Future<Either<Failure, Comprobante>> uploadComprobante({
+    required String folioOrId,
+    required File file,
+    required int montoCentavos,
+    required String refBancariaDeclarada,
+    required DateTime fechaPago,
+    void Function(double)? onProgress,
+  }) async {
+    try {
+      final model = await remoteDataSource.uploadComprobante(
+        folioOrId: folioOrId,
+        file: file,
+        montoCentavos: montoCentavos,
+        refBancariaDeclarada: refBancariaDeclarada,
+        fechaPago: fechaPago,
+        onProgress: onProgress,
+      );
+      return Right(model.toEntity());
+    } on NotFoundException catch (e) {
+      return Left(NotFoundFailure(message: e.message, code: e.code));
+    } on ServerException catch (e) {
+      return Left(ServerFailure(message: e.message, code: e.code));
+    } on AuthException catch (e) {
+      return Left(AuthFailure(message: e.message, code: e.code));
+    } catch (e) {
+      return Left(UnexpectedFailure(message: e.toString()));
+    }
+  }
+
+  // ── Configuración ──────────────────────────────────────────────────────────
+
+  @override
+  Future<Either<Failure, MaterialConfig>> getConfig() async {
+    try {
+      final model = await remoteDataSource.getConfig();
+      return Right(model.toEntity());
+    } on ServerException catch (e) {
+      return Left(ServerFailure(message: e.message, code: e.code));
+    } on AuthException catch (e) {
+      return Left(AuthFailure(message: e.message, code: e.code));
+    } catch (e) {
+      return Left(UnexpectedFailure(message: e.toString()));
+    }
+  }
+}

--- a/lib/features/materiales/data/repositories/materiales_repository_impl.dart
+++ b/lib/features/materiales/data/repositories/materiales_repository_impl.dart
@@ -192,8 +192,7 @@ class MaterialesRepositoryImpl implements MaterialesRepository {
   Future<Either<Failure, Orden>> cancelOrder(
       String folioOrId, String reason) async {
     try {
-      final model =
-          await remoteDataSource.cancelOrder(folioOrId, reason);
+      final model = await remoteDataSource.cancelOrder(folioOrId, reason);
       return Right(model.toEntity());
     } on NotFoundException catch (e) {
       return Left(NotFoundFailure(message: e.message, code: e.code));
@@ -212,8 +211,7 @@ class MaterialesRepositoryImpl implements MaterialesRepository {
   Future<Either<Failure, List<Comprobante>>> listComprobantes(
       String folioOrId) async {
     try {
-      final models =
-          await remoteDataSource.listComprobantes(folioOrId);
+      final models = await remoteDataSource.listComprobantes(folioOrId);
       return Right(models.map((m) => m.toEntity()).toList());
     } on NotFoundException catch (e) {
       return Left(NotFoundFailure(message: e.message, code: e.code));

--- a/lib/features/materiales/domain/domain.dart
+++ b/lib/features/materiales/domain/domain.dart
@@ -1,0 +1,24 @@
+// Domain barrel — entities, repositories, usecases
+export 'entities/comprobante.dart';
+export 'entities/material_category.dart';
+export 'entities/material_comprobante_status.dart';
+export 'entities/material_config.dart';
+export 'entities/material_disponibilidad.dart';
+export 'entities/material_entrega.dart';
+export 'entities/material_estado.dart';
+export 'entities/material_item.dart';
+export 'entities/material_programa.dart';
+export 'entities/material_variant.dart';
+export 'entities/material_variant_option.dart';
+export 'entities/material_variant_type.dart';
+export 'entities/orden.dart';
+export 'entities/orden_line.dart';
+export 'repositories/materiales_repository.dart';
+export 'usecases/browse_catalog.dart';
+export 'usecases/cancel_order.dart';
+export 'usecases/create_order.dart';
+export 'usecases/get_config.dart';
+export 'usecases/get_order_detail.dart';
+export 'usecases/get_order_history.dart';
+export 'usecases/get_product_detail.dart';
+export 'usecases/upload_comprobante.dart';

--- a/lib/features/materiales/domain/entities/comprobante.dart
+++ b/lib/features/materiales/domain/entities/comprobante.dart
@@ -1,0 +1,72 @@
+import 'package:equatable/equatable.dart';
+
+import 'material_comprobante_status.dart';
+
+/// Comprobante de pago subido por un director para una orden aprobada.
+class Comprobante extends Equatable {
+  final String id;
+  final String orderId;
+  final String r2Key;
+  final String fileName;
+  final String mimeType;
+  final int sizeBytes;
+
+  /// Monto declarado por el director en centavos (MXN).
+  final int montoCentavos;
+
+  final String? refBancariaDeclarada;
+  final DateTime? fechaPago;
+  final MaterialComprobanteStatus status;
+
+  /// URL firmada de R2 con TTL 15 minutos. Null si no está disponible.
+  final String? signedUrl;
+
+  final String uploadedBy;
+  final String? validatedBy;
+  final String? rejectReason;
+  final DateTime createdAt;
+  final DateTime? validatedAt;
+
+  const Comprobante({
+    required this.id,
+    required this.orderId,
+    required this.r2Key,
+    required this.fileName,
+    required this.mimeType,
+    required this.sizeBytes,
+    required this.montoCentavos,
+    this.refBancariaDeclarada,
+    this.fechaPago,
+    required this.status,
+    this.signedUrl,
+    required this.uploadedBy,
+    this.validatedBy,
+    this.rejectReason,
+    required this.createdAt,
+    this.validatedAt,
+  });
+
+  bool get isPending => status == MaterialComprobanteStatus.pendiente;
+  bool get isApproved => status == MaterialComprobanteStatus.aprobado;
+  bool get isRejected => status == MaterialComprobanteStatus.rechazado;
+
+  @override
+  List<Object?> get props => [
+        id,
+        orderId,
+        r2Key,
+        fileName,
+        mimeType,
+        sizeBytes,
+        montoCentavos,
+        refBancariaDeclarada,
+        fechaPago,
+        status,
+        signedUrl,
+        uploadedBy,
+        validatedBy,
+        rejectReason,
+        createdAt,
+        validatedAt,
+      ];
+}

--- a/lib/features/materiales/domain/entities/material_category.dart
+++ b/lib/features/materiales/domain/entities/material_category.dart
@@ -1,0 +1,21 @@
+import 'package:equatable/equatable.dart';
+
+/// Categoría de producto en el catálogo de materiales.
+class MaterialCategory extends Equatable {
+  final String id;
+  final String slug;
+  final String label;
+  final String? icon;
+  final int sortOrder;
+
+  const MaterialCategory({
+    required this.id,
+    required this.slug,
+    required this.label,
+    this.icon,
+    required this.sortOrder,
+  });
+
+  @override
+  List<Object?> get props => [id, slug, label, icon, sortOrder];
+}

--- a/lib/features/materiales/domain/entities/material_comprobante_status.dart
+++ b/lib/features/materiales/domain/entities/material_comprobante_status.dart
@@ -1,0 +1,31 @@
+/// Estado de un comprobante de pago.
+enum MaterialComprobanteStatus {
+  pendiente,
+  aprobado,
+  rechazado,
+}
+
+/// Extensiones de utilidad para [MaterialComprobanteStatus].
+extension MaterialComprobanteStatusX on MaterialComprobanteStatus {
+  static MaterialComprobanteStatus fromString(String value) {
+    switch (value) {
+      case 'aprobado':
+        return MaterialComprobanteStatus.aprobado;
+      case 'rechazado':
+        return MaterialComprobanteStatus.rechazado;
+      default:
+        return MaterialComprobanteStatus.pendiente;
+    }
+  }
+
+  String toApiString() {
+    switch (this) {
+      case MaterialComprobanteStatus.pendiente:
+        return 'pendiente';
+      case MaterialComprobanteStatus.aprobado:
+        return 'aprobado';
+      case MaterialComprobanteStatus.rechazado:
+        return 'rechazado';
+    }
+  }
+}

--- a/lib/features/materiales/domain/entities/material_config.dart
+++ b/lib/features/materiales/domain/entities/material_config.dart
@@ -1,0 +1,46 @@
+import 'package:equatable/equatable.dart';
+
+import 'material_entrega.dart';
+
+/// Configuración bancaria y de entrega del módulo de materiales.
+///
+/// Singleton en el backend (fila id=1). El app solo la lee — no la escribe.
+class MaterialConfig extends Equatable {
+  final String? bankName;
+  final String? bankAccountClabe;
+  final String? accountHolder;
+
+  /// Costo de envío por defecto en centavos (MXN).
+  final int envioCentavosDefault;
+
+  final String? pickupAddress;
+
+  /// Opciones de entrega habilitadas (lista de [MaterialEntrega]).
+  final List<MaterialEntrega> deliveryOptions;
+
+  final DateTime updatedAt;
+
+  const MaterialConfig({
+    this.bankName,
+    this.bankAccountClabe,
+    this.accountHolder,
+    required this.envioCentavosDefault,
+    this.pickupAddress,
+    required this.deliveryOptions,
+    required this.updatedAt,
+  });
+
+  bool get hasPickup => deliveryOptions.contains(MaterialEntrega.recoger);
+  bool get hasShipping => deliveryOptions.contains(MaterialEntrega.envio);
+
+  @override
+  List<Object?> get props => [
+        bankName,
+        bankAccountClabe,
+        accountHolder,
+        envioCentavosDefault,
+        pickupAddress,
+        deliveryOptions,
+        updatedAt,
+      ];
+}

--- a/lib/features/materiales/domain/entities/material_disponibilidad.dart
+++ b/lib/features/materiales/domain/entities/material_disponibilidad.dart
@@ -1,0 +1,36 @@
+/// Estado de disponibilidad de una línea de orden.
+enum MaterialDisponibilidad {
+  pendiente,
+  disponible,
+  parcial,
+  agotado,
+}
+
+/// Extensiones de utilidad para [MaterialDisponibilidad].
+extension MaterialDisponibilidadX on MaterialDisponibilidad {
+  static MaterialDisponibilidad fromString(String value) {
+    switch (value) {
+      case 'disponible':
+        return MaterialDisponibilidad.disponible;
+      case 'parcial':
+        return MaterialDisponibilidad.parcial;
+      case 'agotado':
+        return MaterialDisponibilidad.agotado;
+      default:
+        return MaterialDisponibilidad.pendiente;
+    }
+  }
+
+  String toApiString() {
+    switch (this) {
+      case MaterialDisponibilidad.pendiente:
+        return 'pendiente';
+      case MaterialDisponibilidad.disponible:
+        return 'disponible';
+      case MaterialDisponibilidad.parcial:
+        return 'parcial';
+      case MaterialDisponibilidad.agotado:
+        return 'agotado';
+    }
+  }
+}

--- a/lib/features/materiales/domain/entities/material_entrega.dart
+++ b/lib/features/materiales/domain/entities/material_entrega.dart
@@ -1,0 +1,26 @@
+/// Modalidad de entrega para una orden de materiales.
+enum MaterialEntrega {
+  recoger,
+  envio,
+}
+
+/// Extensiones de utilidad para [MaterialEntrega].
+extension MaterialEntregaX on MaterialEntrega {
+  static MaterialEntrega fromString(String value) {
+    switch (value) {
+      case 'envio':
+        return MaterialEntrega.envio;
+      default:
+        return MaterialEntrega.recoger;
+    }
+  }
+
+  String toApiString() {
+    switch (this) {
+      case MaterialEntrega.recoger:
+        return 'recoger';
+      case MaterialEntrega.envio:
+        return 'envio';
+    }
+  }
+}

--- a/lib/features/materiales/domain/entities/material_estado.dart
+++ b/lib/features/materiales/domain/entities/material_estado.dart
@@ -1,0 +1,48 @@
+/// Estado de una orden de materiales.
+enum MaterialEstado {
+  enRevision,
+  aprobada,
+  pagada,
+  entregada,
+  cancelada,
+}
+
+/// Extensiones de utilidad para [MaterialEstado].
+extension MaterialEstadoX on MaterialEstado {
+  /// Convierte el string que devuelve la API al enum correspondiente.
+  static MaterialEstado fromString(String value) {
+    switch (value) {
+      case 'en_revision':
+        return MaterialEstado.enRevision;
+      case 'aprobada':
+        return MaterialEstado.aprobada;
+      case 'pagada':
+        return MaterialEstado.pagada;
+      case 'entregada':
+        return MaterialEstado.entregada;
+      case 'cancelada':
+        return MaterialEstado.cancelada;
+      default:
+        return MaterialEstado.enRevision;
+    }
+  }
+
+  /// Devuelve la representación string que espera la API.
+  String toApiString() {
+    switch (this) {
+      case MaterialEstado.enRevision:
+        return 'en_revision';
+      case MaterialEstado.aprobada:
+        return 'aprobada';
+      case MaterialEstado.pagada:
+        return 'pagada';
+      case MaterialEstado.entregada:
+        return 'entregada';
+      case MaterialEstado.cancelada:
+        return 'cancelada';
+    }
+  }
+
+  bool get isTerminal =>
+      this == MaterialEstado.entregada || this == MaterialEstado.cancelada;
+}

--- a/lib/features/materiales/domain/entities/material_item.dart
+++ b/lib/features/materiales/domain/entities/material_item.dart
@@ -1,0 +1,48 @@
+import 'package:equatable/equatable.dart';
+
+import 'material_category.dart';
+import 'material_programa.dart';
+import 'material_variant.dart';
+
+/// Producto del catálogo de materiales.
+class MaterialItem extends Equatable {
+  final String id;
+  final String sku;
+  final String title;
+  final String? description;
+  final MaterialCategory category;
+  final MaterialPrograma programa;
+
+  /// Precio en centavos (MXN). Nunca float.
+  final int priceCentavos;
+
+  /// Stock total del producto. Si tiene variantes, es la suma de todos los
+  /// stocks de opciones. Si no tiene variantes, es el stock directo.
+  final int stock;
+
+  final bool active;
+
+  /// Variante del producto (máximo una en v1).
+  /// Null si el producto no tiene variantes.
+  final MaterialVariant? variant;
+
+  const MaterialItem({
+    required this.id,
+    required this.sku,
+    required this.title,
+    this.description,
+    required this.category,
+    required this.programa,
+    required this.priceCentavos,
+    required this.stock,
+    required this.active,
+    this.variant,
+  });
+
+  bool get hasVariants => variant != null;
+  bool get hasStock => stock > 0;
+
+  @override
+  List<Object?> get props =>
+      [id, sku, title, description, category, programa, priceCentavos, stock, active, variant];
+}

--- a/lib/features/materiales/domain/entities/material_item.dart
+++ b/lib/features/materiales/domain/entities/material_item.dart
@@ -43,6 +43,16 @@ class MaterialItem extends Equatable {
   bool get hasStock => stock > 0;
 
   @override
-  List<Object?> get props =>
-      [id, sku, title, description, category, programa, priceCentavos, stock, active, variant];
+  List<Object?> get props => [
+        id,
+        sku,
+        title,
+        description,
+        category,
+        programa,
+        priceCentavos,
+        stock,
+        active,
+        variant
+      ];
 }

--- a/lib/features/materiales/domain/entities/material_programa.dart
+++ b/lib/features/materiales/domain/entities/material_programa.dart
@@ -1,0 +1,17 @@
+import 'package:equatable/equatable.dart';
+
+/// Programa (tipo de club) al que aplica un producto.
+///
+/// Los datos provienen de la tabla `club_types` del backend.
+class MaterialPrograma extends Equatable {
+  final int id;
+  final String label;
+
+  const MaterialPrograma({
+    required this.id,
+    required this.label,
+  });
+
+  @override
+  List<Object?> get props => [id, label];
+}

--- a/lib/features/materiales/domain/entities/material_variant.dart
+++ b/lib/features/materiales/domain/entities/material_variant.dart
@@ -1,0 +1,26 @@
+import 'package:equatable/equatable.dart';
+
+import 'material_variant_option.dart';
+import 'material_variant_type.dart';
+
+/// Variante de un producto (ej. tallas, colores disponibles).
+///
+/// Un producto tiene como máximo una variante en v1 (invariante de negocio).
+class MaterialVariant extends Equatable {
+  final String id;
+  final MaterialVariantType type;
+  final List<MaterialVariantOption> options;
+
+  const MaterialVariant({
+    required this.id,
+    required this.type,
+    required this.options,
+  });
+
+  /// Opciones con stock disponible.
+  List<MaterialVariantOption> get availableOptions =>
+      options.where((o) => o.hasStock).toList();
+
+  @override
+  List<Object?> get props => [id, type, options];
+}

--- a/lib/features/materiales/domain/entities/material_variant_option.dart
+++ b/lib/features/materiales/domain/entities/material_variant_option.dart
@@ -1,0 +1,19 @@
+import 'package:equatable/equatable.dart';
+
+/// Opción individual dentro de una variante de producto (ej. talla "M", color "azul").
+class MaterialVariantOption extends Equatable {
+  final String id;
+  final String label;
+  final int stock;
+
+  const MaterialVariantOption({
+    required this.id,
+    required this.label,
+    required this.stock,
+  });
+
+  bool get hasStock => stock > 0;
+
+  @override
+  List<Object?> get props => [id, label, stock];
+}

--- a/lib/features/materiales/domain/entities/material_variant_type.dart
+++ b/lib/features/materiales/domain/entities/material_variant_type.dart
@@ -1,0 +1,26 @@
+/// Tipo de variante de un producto de materiales.
+enum MaterialVariantType {
+  talla,
+  color,
+}
+
+/// Extensiones de utilidad para [MaterialVariantType].
+extension MaterialVariantTypeX on MaterialVariantType {
+  static MaterialVariantType fromString(String value) {
+    switch (value) {
+      case 'color':
+        return MaterialVariantType.color;
+      default:
+        return MaterialVariantType.talla;
+    }
+  }
+
+  String toApiString() {
+    switch (this) {
+      case MaterialVariantType.talla:
+        return 'talla';
+      case MaterialVariantType.color:
+        return 'color';
+    }
+  }
+}

--- a/lib/features/materiales/domain/entities/orden.dart
+++ b/lib/features/materiales/domain/entities/orden.dart
@@ -1,0 +1,101 @@
+import 'package:equatable/equatable.dart';
+
+import 'comprobante.dart';
+import 'material_entrega.dart';
+import 'material_estado.dart';
+import 'orden_line.dart';
+
+/// Orden de materiales completa.
+///
+/// Incluye líneas y comprobantes cuando la API los embeds (GET /ordenes/:folio).
+/// Todos los montos en centavos (MXN).
+class Orden extends Equatable {
+  final String id;
+
+  /// Folio único asignado al aprobar la orden (ej. "SOL20260001").
+  /// Null mientras la orden esté en estado `en_revision`.
+  final String? folioReferencia;
+
+  final MaterialEstado estado;
+  final int clubSectionId;
+  final String createdBy;
+  final String? approvedBy;
+  final String? validatedBy;
+  final String? deliveredBy;
+  final String? cancelledBy;
+
+  final int subtotalCentavos;
+  final int envioCentavos;
+  final int totalCentavos;
+
+  final MaterialEntrega entrega;
+  final String? notas;
+  final String? cancelReason;
+
+  // Snapshot del banco al momento de aprobación
+  final String? bankName;
+  final String? bankAccountClabe;
+  final String? accountHolder;
+  final String? pickupAddress;
+
+  final DateTime createdAt;
+  final DateTime? approvedAt;
+  final DateTime? paidAt;
+  final DateTime? deliveredAt;
+  final DateTime? cancelledAt;
+
+  final List<OrdenLine> lines;
+  final List<Comprobante> comprobantes;
+
+  const Orden({
+    required this.id,
+    this.folioReferencia,
+    required this.estado,
+    required this.clubSectionId,
+    required this.createdBy,
+    this.approvedBy,
+    this.validatedBy,
+    this.deliveredBy,
+    this.cancelledBy,
+    required this.subtotalCentavos,
+    required this.envioCentavos,
+    required this.totalCentavos,
+    required this.entrega,
+    this.notas,
+    this.cancelReason,
+    this.bankName,
+    this.bankAccountClabe,
+    this.accountHolder,
+    this.pickupAddress,
+    required this.createdAt,
+    this.approvedAt,
+    this.paidAt,
+    this.deliveredAt,
+    this.cancelledAt,
+    required this.lines,
+    required this.comprobantes,
+  });
+
+  bool get isApproved => estado == MaterialEstado.aprobada;
+  bool get isPaid => estado == MaterialEstado.pagada;
+  bool get isDelivered => estado == MaterialEstado.entregada;
+  bool get isCancelled => estado == MaterialEstado.cancelada;
+  bool get isInReview => estado == MaterialEstado.enRevision;
+  bool get isTerminal => estado.isTerminal;
+
+  @override
+  List<Object?> get props => [
+        id,
+        folioReferencia,
+        estado,
+        clubSectionId,
+        createdBy,
+        subtotalCentavos,
+        envioCentavos,
+        totalCentavos,
+        entrega,
+        createdAt,
+        lines,
+        comprobantes,
+      ];
+}

--- a/lib/features/materiales/domain/entities/orden_line.dart
+++ b/lib/features/materiales/domain/entities/orden_line.dart
@@ -1,0 +1,68 @@
+import 'package:equatable/equatable.dart';
+
+import 'material_disponibilidad.dart';
+
+/// Snapshot mínimo de producto embebido en una línea de orden.
+class OrdenLineProduct extends Equatable {
+  final String id;
+  final String sku;
+  final String title;
+
+  const OrdenLineProduct({
+    required this.id,
+    required this.sku,
+    required this.title,
+  });
+
+  @override
+  List<Object?> get props => [id, sku, title];
+}
+
+/// Línea de una orden de materiales.
+///
+/// Todos los montos en centavos (MXN).
+class OrdenLine extends Equatable {
+  final String id;
+  final String productId;
+  final String? variantOptionId;
+  final int qty;
+
+  /// Precio snapshot al momento de crear la orden (centavos).
+  final int priceCentavos;
+
+  final MaterialDisponibilidad disponibilidad;
+
+  /// Cantidad disponible confirmada por campo. Null hasta que campo lo revise.
+  final int? qtyDisponible;
+
+  /// Total de la línea en centavos (qty_disponible × price_centavos).
+  final int lineTotalCentavos;
+
+  /// Snapshot mínimo del producto para mostrar en UI sin refetch.
+  final OrdenLineProduct product;
+
+  const OrdenLine({
+    required this.id,
+    required this.productId,
+    this.variantOptionId,
+    required this.qty,
+    required this.priceCentavos,
+    required this.disponibilidad,
+    this.qtyDisponible,
+    required this.lineTotalCentavos,
+    required this.product,
+  });
+
+  @override
+  List<Object?> get props => [
+        id,
+        productId,
+        variantOptionId,
+        qty,
+        priceCentavos,
+        disponibilidad,
+        qtyDisponible,
+        lineTotalCentavos,
+        product,
+      ];
+}

--- a/lib/features/materiales/domain/repositories/materiales_repository.dart
+++ b/lib/features/materiales/domain/repositories/materiales_repository.dart
@@ -67,14 +67,12 @@ abstract class MaterialesRepository {
   Future<Either<Failure, Orden>> getOrderByFolio(String folioOrId);
 
   /// Cancela una orden con un motivo.
-  Future<Either<Failure, Orden>> cancelOrder(
-      String folioOrId, String reason);
+  Future<Either<Failure, Orden>> cancelOrder(String folioOrId, String reason);
 
   // ── Comprobantes ──────────────────────────────────────────────────────────
 
   /// Lista los comprobantes de una orden.
-  Future<Either<Failure, List<Comprobante>>> listComprobantes(
-      String folioOrId);
+  Future<Either<Failure, List<Comprobante>>> listComprobantes(String folioOrId);
 
   /// Sube un comprobante de pago para una orden aprobada.
   Future<Either<Failure, Comprobante>> uploadComprobante({

--- a/lib/features/materiales/domain/repositories/materiales_repository.dart
+++ b/lib/features/materiales/domain/repositories/materiales_repository.dart
@@ -1,0 +1,93 @@
+import 'dart:io';
+
+import 'package:dartz/dartz.dart';
+
+import '../../../../core/errors/failures.dart';
+import '../entities/comprobante.dart';
+import '../entities/material_category.dart';
+import '../entities/material_config.dart';
+import '../entities/material_entrega.dart';
+import '../entities/material_item.dart';
+import '../entities/material_programa.dart';
+import '../entities/orden.dart';
+
+/// Contrato del repositorio de Materiales.
+///
+/// Todas las operaciones devuelven [Either<Failure, T>] para manejar
+/// errores de forma funcional sin excepciones sin tratar.
+abstract class MaterialesRepository {
+  // ── Catálogo ───────────────────────────────────────────────────────────────
+
+  /// Obtiene productos del catálogo con filtros opcionales.
+  Future<Either<Failure, List<MaterialItem>>> browseCatalog({
+    String? cat,
+    int? programaId,
+    String? q,
+    int page = 1,
+    int pageSize = 20,
+  });
+
+  /// Obtiene el detalle completo de un producto por su ID.
+  Future<Either<Failure, MaterialItem>> getProductDetail(String id);
+
+  /// Lista todas las categorías activas.
+  Future<Either<Failure, List<MaterialCategory>>> listCategorias();
+
+  /// Lista los programas (tipos de club) disponibles.
+  Future<Either<Failure, List<MaterialPrograma>>> listProgramas();
+
+  // ── Órdenes ────────────────────────────────────────────────────────────────
+
+  /// Crea una nueva orden de materiales.
+  ///
+  /// [lines] es la lista de líneas: producto + variante opcional + cantidad.
+  Future<Either<Failure, Orden>> createOrder({
+    required int clubSectionId,
+    required List<({String productId, String? variantOptionId, int qty})> lines,
+    required MaterialEntrega entrega,
+    String? notas,
+  });
+
+  /// Lista órdenes (visibilidad controlada por el backend según permisos).
+  Future<Either<Failure, List<Orden>>> listOrdenes({
+    String? estado,
+    int page = 1,
+    int pageSize = 20,
+  });
+
+  /// Historial de órdenes propias del usuario autenticado.
+  ///
+  /// Alias de GET /ordenes/historial — siempre filtrado por created_by del caller.
+  Future<Either<Failure, List<Orden>>> getOrderHistory({
+    int page = 1,
+    int pageSize = 20,
+  });
+
+  /// Obtiene una orden por su folio o ID.
+  Future<Either<Failure, Orden>> getOrderByFolio(String folioOrId);
+
+  /// Cancela una orden con un motivo.
+  Future<Either<Failure, Orden>> cancelOrder(
+      String folioOrId, String reason);
+
+  // ── Comprobantes ──────────────────────────────────────────────────────────
+
+  /// Lista los comprobantes de una orden.
+  Future<Either<Failure, List<Comprobante>>> listComprobantes(
+      String folioOrId);
+
+  /// Sube un comprobante de pago para una orden aprobada.
+  Future<Either<Failure, Comprobante>> uploadComprobante({
+    required String folioOrId,
+    required File file,
+    required int montoCentavos,
+    required String refBancariaDeclarada,
+    required DateTime fechaPago,
+    void Function(double)? onProgress,
+  });
+
+  // ── Configuración ──────────────────────────────────────────────────────────
+
+  /// Obtiene la configuración bancaria y de entrega del módulo.
+  Future<Either<Failure, MaterialConfig>> getConfig();
+}

--- a/lib/features/materiales/domain/usecases/browse_catalog.dart
+++ b/lib/features/materiales/domain/usecases/browse_catalog.dart
@@ -1,0 +1,43 @@
+import 'package:dartz/dartz.dart';
+import 'package:equatable/equatable.dart';
+
+import '../../../../core/errors/failures.dart';
+import '../../../../core/usecases/usecase.dart';
+import '../entities/material_item.dart';
+import '../repositories/materiales_repository.dart';
+
+class BrowseCatalogParams extends Equatable {
+  final String? cat;
+  final int? programaId;
+  final String? q;
+  final int page;
+  final int pageSize;
+
+  const BrowseCatalogParams({
+    this.cat,
+    this.programaId,
+    this.q,
+    this.page = 1,
+    this.pageSize = 20,
+  });
+
+  @override
+  List<Object?> get props => [cat, programaId, q, page, pageSize];
+}
+
+/// Caso de uso: obtener catálogo de productos con filtros opcionales.
+class BrowseCatalog implements UseCase<List<MaterialItem>, BrowseCatalogParams> {
+  BrowseCatalog(this._repo);
+  final MaterialesRepository _repo;
+
+  @override
+  Future<Either<Failure, List<MaterialItem>>> call(
+      BrowseCatalogParams params) =>
+      _repo.browseCatalog(
+        cat: params.cat,
+        programaId: params.programaId,
+        q: params.q,
+        page: params.page,
+        pageSize: params.pageSize,
+      );
+}

--- a/lib/features/materiales/domain/usecases/browse_catalog.dart
+++ b/lib/features/materiales/domain/usecases/browse_catalog.dart
@@ -26,13 +26,14 @@ class BrowseCatalogParams extends Equatable {
 }
 
 /// Caso de uso: obtener catálogo de productos con filtros opcionales.
-class BrowseCatalog implements UseCase<List<MaterialItem>, BrowseCatalogParams> {
+class BrowseCatalog
+    implements UseCase<List<MaterialItem>, BrowseCatalogParams> {
   BrowseCatalog(this._repo);
   final MaterialesRepository _repo;
 
   @override
   Future<Either<Failure, List<MaterialItem>>> call(
-      BrowseCatalogParams params) =>
+          BrowseCatalogParams params) =>
       _repo.browseCatalog(
         cat: params.cat,
         programaId: params.programaId,

--- a/lib/features/materiales/domain/usecases/cancel_order.dart
+++ b/lib/features/materiales/domain/usecases/cancel_order.dart
@@ -1,0 +1,27 @@
+import 'package:dartz/dartz.dart';
+import 'package:equatable/equatable.dart';
+
+import '../../../../core/errors/failures.dart';
+import '../../../../core/usecases/usecase.dart';
+import '../entities/orden.dart';
+import '../repositories/materiales_repository.dart';
+
+class CancelOrderParams extends Equatable {
+  final String folioOrId;
+  final String reason;
+
+  const CancelOrderParams({required this.folioOrId, required this.reason});
+
+  @override
+  List<Object?> get props => [folioOrId, reason];
+}
+
+/// Caso de uso: cancelar una orden con motivo de cancelación.
+class CancelOrder implements UseCase<Orden, CancelOrderParams> {
+  CancelOrder(this._repo);
+  final MaterialesRepository _repo;
+
+  @override
+  Future<Either<Failure, Orden>> call(CancelOrderParams params) =>
+      _repo.cancelOrder(params.folioOrId, params.reason);
+}

--- a/lib/features/materiales/domain/usecases/create_order.dart
+++ b/lib/features/materiales/domain/usecases/create_order.dart
@@ -1,0 +1,40 @@
+import 'package:dartz/dartz.dart';
+import 'package:equatable/equatable.dart';
+
+import '../../../../core/errors/failures.dart';
+import '../../../../core/usecases/usecase.dart';
+import '../entities/material_entrega.dart';
+import '../entities/orden.dart';
+import '../repositories/materiales_repository.dart';
+
+class CreateOrderParams extends Equatable {
+  final int clubSectionId;
+  final List<({String productId, String? variantOptionId, int qty})> lines;
+  final MaterialEntrega entrega;
+  final String? notas;
+
+  const CreateOrderParams({
+    required this.clubSectionId,
+    required this.lines,
+    required this.entrega,
+    this.notas,
+  });
+
+  @override
+  List<Object?> get props => [clubSectionId, lines, entrega, notas];
+}
+
+/// Caso de uso: crear una nueva orden de materiales.
+class CreateOrder implements UseCase<Orden, CreateOrderParams> {
+  CreateOrder(this._repo);
+  final MaterialesRepository _repo;
+
+  @override
+  Future<Either<Failure, Orden>> call(CreateOrderParams params) =>
+      _repo.createOrder(
+        clubSectionId: params.clubSectionId,
+        lines: params.lines,
+        entrega: params.entrega,
+        notas: params.notas,
+      );
+}

--- a/lib/features/materiales/domain/usecases/get_config.dart
+++ b/lib/features/materiales/domain/usecases/get_config.dart
@@ -1,0 +1,15 @@
+import 'package:dartz/dartz.dart';
+
+import '../../../../core/errors/failures.dart';
+import '../../../../core/usecases/usecase.dart';
+import '../entities/material_config.dart';
+import '../repositories/materiales_repository.dart';
+
+/// Caso de uso: obtener configuración bancaria y de entrega del módulo.
+class GetConfig implements NoParamsUseCase<MaterialConfig> {
+  GetConfig(this._repo);
+  final MaterialesRepository _repo;
+
+  @override
+  Future<Either<Failure, MaterialConfig>> call() => _repo.getConfig();
+}

--- a/lib/features/materiales/domain/usecases/get_order_detail.dart
+++ b/lib/features/materiales/domain/usecases/get_order_detail.dart
@@ -1,0 +1,26 @@
+import 'package:dartz/dartz.dart';
+import 'package:equatable/equatable.dart';
+
+import '../../../../core/errors/failures.dart';
+import '../../../../core/usecases/usecase.dart';
+import '../entities/orden.dart';
+import '../repositories/materiales_repository.dart';
+
+class GetOrderDetailParams extends Equatable {
+  final String folioOrId;
+
+  const GetOrderDetailParams({required this.folioOrId});
+
+  @override
+  List<Object?> get props => [folioOrId];
+}
+
+/// Caso de uso: obtener detalle completo de una orden por folio o ID.
+class GetOrderDetail implements UseCase<Orden, GetOrderDetailParams> {
+  GetOrderDetail(this._repo);
+  final MaterialesRepository _repo;
+
+  @override
+  Future<Either<Failure, Orden>> call(GetOrderDetailParams params) =>
+      _repo.getOrderByFolio(params.folioOrId);
+}

--- a/lib/features/materiales/domain/usecases/get_order_history.dart
+++ b/lib/features/materiales/domain/usecases/get_order_history.dart
@@ -1,0 +1,29 @@
+import 'package:dartz/dartz.dart';
+import 'package:equatable/equatable.dart';
+
+import '../../../../core/errors/failures.dart';
+import '../../../../core/usecases/usecase.dart';
+import '../entities/orden.dart';
+import '../repositories/materiales_repository.dart';
+
+class GetOrderHistoryParams extends Equatable {
+  final int page;
+  final int pageSize;
+
+  const GetOrderHistoryParams({this.page = 1, this.pageSize = 20});
+
+  @override
+  List<Object?> get props => [page, pageSize];
+}
+
+/// Caso de uso: obtener historial de órdenes propias del usuario.
+///
+/// Usa GET /ordenes/historial — siempre filtrado por created_by del caller.
+class GetOrderHistory implements UseCase<List<Orden>, GetOrderHistoryParams> {
+  GetOrderHistory(this._repo);
+  final MaterialesRepository _repo;
+
+  @override
+  Future<Either<Failure, List<Orden>>> call(GetOrderHistoryParams params) =>
+      _repo.getOrderHistory(page: params.page, pageSize: params.pageSize);
+}

--- a/lib/features/materiales/domain/usecases/get_product_detail.dart
+++ b/lib/features/materiales/domain/usecases/get_product_detail.dart
@@ -1,0 +1,28 @@
+import 'package:dartz/dartz.dart';
+import 'package:equatable/equatable.dart';
+
+import '../../../../core/errors/failures.dart';
+import '../../../../core/usecases/usecase.dart';
+import '../entities/material_item.dart';
+import '../repositories/materiales_repository.dart';
+
+class GetProductDetailParams extends Equatable {
+  final String id;
+
+  const GetProductDetailParams({required this.id});
+
+  @override
+  List<Object?> get props => [id];
+}
+
+/// Caso de uso: obtener detalle completo de un producto del catálogo.
+class GetProductDetail
+    implements UseCase<MaterialItem, GetProductDetailParams> {
+  GetProductDetail(this._repo);
+  final MaterialesRepository _repo;
+
+  @override
+  Future<Either<Failure, MaterialItem>> call(
+          GetProductDetailParams params) =>
+      _repo.getProductDetail(params.id);
+}

--- a/lib/features/materiales/domain/usecases/get_product_detail.dart
+++ b/lib/features/materiales/domain/usecases/get_product_detail.dart
@@ -22,7 +22,6 @@ class GetProductDetail
   final MaterialesRepository _repo;
 
   @override
-  Future<Either<Failure, MaterialItem>> call(
-          GetProductDetailParams params) =>
+  Future<Either<Failure, MaterialItem>> call(GetProductDetailParams params) =>
       _repo.getProductDetail(params.id);
 }

--- a/lib/features/materiales/domain/usecases/upload_comprobante.dart
+++ b/lib/features/materiales/domain/usecases/upload_comprobante.dart
@@ -1,0 +1,50 @@
+import 'dart:io';
+
+import 'package:dartz/dartz.dart';
+import 'package:equatable/equatable.dart';
+
+import '../../../../core/errors/failures.dart';
+import '../../../../core/usecases/usecase.dart';
+import '../entities/comprobante.dart';
+import '../repositories/materiales_repository.dart';
+
+class UploadComprobanteParams extends Equatable {
+  final String folioOrId;
+  final File file;
+  final int montoCentavos;
+  final String refBancariaDeclarada;
+  final DateTime fechaPago;
+  final void Function(double)? onProgress;
+
+  const UploadComprobanteParams({
+    required this.folioOrId,
+    required this.file,
+    required this.montoCentavos,
+    required this.refBancariaDeclarada,
+    required this.fechaPago,
+    this.onProgress,
+  });
+
+  @override
+  List<Object?> get props =>
+      [folioOrId, file.path, montoCentavos, refBancariaDeclarada, fechaPago];
+}
+
+/// Caso de uso: subir un comprobante de pago para una orden aprobada.
+class UploadComprobante
+    implements UseCase<Comprobante, UploadComprobanteParams> {
+  UploadComprobante(this._repo);
+  final MaterialesRepository _repo;
+
+  @override
+  Future<Either<Failure, Comprobante>> call(
+          UploadComprobanteParams params) =>
+      _repo.uploadComprobante(
+        folioOrId: params.folioOrId,
+        file: params.file,
+        montoCentavos: params.montoCentavos,
+        refBancariaDeclarada: params.refBancariaDeclarada,
+        fechaPago: params.fechaPago,
+        onProgress: params.onProgress,
+      );
+}

--- a/lib/features/materiales/domain/usecases/upload_comprobante.dart
+++ b/lib/features/materiales/domain/usecases/upload_comprobante.dart
@@ -37,8 +37,7 @@ class UploadComprobante
   final MaterialesRepository _repo;
 
   @override
-  Future<Either<Failure, Comprobante>> call(
-          UploadComprobanteParams params) =>
+  Future<Either<Failure, Comprobante>> call(UploadComprobanteParams params) =>
       _repo.uploadComprobante(
         folioOrId: params.folioOrId,
         file: params.file,

--- a/lib/features/materiales/presentation/providers/cancel_order_provider.dart
+++ b/lib/features/materiales/presentation/providers/cancel_order_provider.dart
@@ -1,0 +1,53 @@
+import 'package:dartz/dartz.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../../core/errors/failures.dart';
+import '../../domain/entities/orden.dart';
+import '../../domain/usecases/cancel_order.dart';
+import 'materiales_providers.dart';
+
+/// Estado del proceso de cancelación de una orden.
+class CancelOrderState {
+  final bool isLoading;
+  final String? errorMessage;
+
+  const CancelOrderState({
+    this.isLoading = false,
+    this.errorMessage,
+  });
+
+  CancelOrderState copyWith({bool? isLoading, String? errorMessage}) {
+    return CancelOrderState(
+      isLoading: isLoading ?? this.isLoading,
+      errorMessage: errorMessage ?? this.errorMessage,
+    );
+  }
+}
+
+/// Notifier para cancelar una orden con motivo.
+class CancelOrderNotifier extends AutoDisposeNotifier<CancelOrderState> {
+  @override
+  CancelOrderState build() => const CancelOrderState();
+
+  Future<Either<Failure, Orden>> cancel({
+    required String folioOrId,
+    required String reason,
+  }) async {
+    state = const CancelOrderState(isLoading: true);
+    final useCase = ref.read(cancelOrderUseCaseProvider);
+    final result = await useCase(
+      CancelOrderParams(folioOrId: folioOrId, reason: reason),
+    );
+    state = result.fold(
+      (failure) => CancelOrderState(errorMessage: failure.message),
+      (_) => const CancelOrderState(),
+    );
+    return result;
+  }
+}
+
+/// Provider del notifier de cancelación de orden.
+final cancelOrderProvider =
+    NotifierProvider.autoDispose<CancelOrderNotifier, CancelOrderState>(
+  CancelOrderNotifier.new,
+);

--- a/lib/features/materiales/presentation/providers/cart_provider.dart
+++ b/lib/features/materiales/presentation/providers/cart_provider.dart
@@ -1,0 +1,166 @@
+import 'package:equatable/equatable.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../domain/entities/material_item.dart';
+import '../../domain/entities/material_variant_option.dart';
+
+/// Línea del carrito en memoria.
+class CartLine extends Equatable {
+  final String productId;
+  final String? variantOptionId;
+  final int qty;
+
+  /// Precio snapshot en centavos tomado al momento de agregar al carrito.
+  final int priceSnapshotCentavos;
+
+  final String productTitle;
+  final String productSku;
+
+  /// Etiqueta de la opción de variante, si aplica.
+  final String? variantLabel;
+
+  const CartLine({
+    required this.productId,
+    this.variantOptionId,
+    required this.qty,
+    required this.priceSnapshotCentavos,
+    required this.productTitle,
+    required this.productSku,
+    this.variantLabel,
+  });
+
+  /// Total de esta línea en centavos.
+  int get lineTotalCentavos => priceSnapshotCentavos * qty;
+
+  CartLine copyWith({int? qty}) {
+    return CartLine(
+      productId: productId,
+      variantOptionId: variantOptionId,
+      qty: qty ?? this.qty,
+      priceSnapshotCentavos: priceSnapshotCentavos,
+      productTitle: productTitle,
+      productSku: productSku,
+      variantLabel: variantLabel,
+    );
+  }
+
+  @override
+  List<Object?> get props => [
+        productId,
+        variantOptionId,
+        qty,
+        priceSnapshotCentavos,
+        productTitle,
+        productSku,
+        variantLabel,
+      ];
+}
+
+/// Estado del carrito de compras (en memoria, sin persistencia en v1).
+class CartState extends Equatable {
+  final List<CartLine> lines;
+
+  const CartState({this.lines = const []});
+
+  /// Total de unidades en el carrito.
+  int get itemCount => lines.fold(0, (acc, l) => acc + l.qty);
+
+  /// Subtotal en centavos.
+  int get subtotalCentavos =>
+      lines.fold(0, (acc, l) => acc + l.lineTotalCentavos);
+
+  @override
+  List<Object?> get props => [lines];
+}
+
+/// Gestiona el estado del carrito de materiales.
+///
+/// v1: en memoria solamente. Sin persistencia local.
+class CartNotifier extends AutoDisposeNotifier<CartState> {
+  @override
+  CartState build() => const CartState();
+
+  /// Agrega un producto al carrito.
+  ///
+  /// Si ya existe una línea con el mismo [productId] y [variantOptionId],
+  /// incrementa la cantidad.
+  void addLine(
+    MaterialItem item, {
+    MaterialVariantOption? variantOption,
+    int qty = 1,
+  }) {
+    assert(qty > 0, 'qty must be positive');
+    final existing = _findLine(item.id, variantOption?.id);
+    if (existing != null) {
+      _updateQty(item.id, variantOption?.id, existing.qty + qty);
+      return;
+    }
+
+    final line = CartLine(
+      productId: item.id,
+      variantOptionId: variantOption?.id,
+      qty: qty,
+      priceSnapshotCentavos: item.priceCentavos,
+      productTitle: item.title,
+      productSku: item.sku,
+      variantLabel: variantOption?.label,
+    );
+
+    state = CartState(lines: [...state.lines, line]);
+  }
+
+  /// Elimina la línea con el [productId] y [variantOptionId] dados.
+  void removeLine(String productId, [String? variantOptionId]) {
+    state = CartState(
+      lines: state.lines
+          .where((l) =>
+              !(l.productId == productId &&
+                  l.variantOptionId == variantOptionId))
+          .toList(),
+    );
+  }
+
+  /// Actualiza la cantidad de una línea. Si [qty] ≤ 0, la elimina.
+  void updateQty(String productId, String? variantOptionId, int qty) {
+    if (qty <= 0) {
+      removeLine(productId, variantOptionId);
+      return;
+    }
+    _updateQty(productId, variantOptionId, qty);
+  }
+
+  /// Vacía el carrito.
+  void clear() => state = const CartState();
+
+  // ── Private helpers ───────────────────────────────────────────────────────
+
+  CartLine? _findLine(String productId, String? variantOptionId) {
+    try {
+      return state.lines.firstWhere(
+        (l) =>
+            l.productId == productId && l.variantOptionId == variantOptionId,
+      );
+    } catch (_) {
+      return null;
+    }
+  }
+
+  void _updateQty(String productId, String? variantOptionId, int qty) {
+    state = CartState(
+      lines: state.lines.map((l) {
+        if (l.productId == productId &&
+            l.variantOptionId == variantOptionId) {
+          return l.copyWith(qty: qty);
+        }
+        return l;
+      }).toList(),
+    );
+  }
+}
+
+/// Provider del carrito de materiales.
+///
+/// autoDispose: el carrito se descarta automáticamente cuando ya no hay
+/// listeners activos (ej. al salir del flujo de pedidos).
+final cartProvider =
+    NotifierProvider.autoDispose<CartNotifier, CartState>(CartNotifier.new);

--- a/lib/features/materiales/presentation/providers/cart_provider.dart
+++ b/lib/features/materiales/presentation/providers/cart_provider.dart
@@ -113,9 +113,8 @@ class CartNotifier extends AutoDisposeNotifier<CartState> {
   void removeLine(String productId, [String? variantOptionId]) {
     state = CartState(
       lines: state.lines
-          .where((l) =>
-              !(l.productId == productId &&
-                  l.variantOptionId == variantOptionId))
+          .where((l) => !(l.productId == productId &&
+              l.variantOptionId == variantOptionId))
           .toList(),
     );
   }
@@ -137,8 +136,7 @@ class CartNotifier extends AutoDisposeNotifier<CartState> {
   CartLine? _findLine(String productId, String? variantOptionId) {
     try {
       return state.lines.firstWhere(
-        (l) =>
-            l.productId == productId && l.variantOptionId == variantOptionId,
+        (l) => l.productId == productId && l.variantOptionId == variantOptionId,
       );
     } catch (_) {
       return null;
@@ -148,8 +146,7 @@ class CartNotifier extends AutoDisposeNotifier<CartState> {
   void _updateQty(String productId, String? variantOptionId, int qty) {
     state = CartState(
       lines: state.lines.map((l) {
-        if (l.productId == productId &&
-            l.variantOptionId == variantOptionId) {
+        if (l.productId == productId && l.variantOptionId == variantOptionId) {
           return l.copyWith(qty: qty);
         }
         return l;

--- a/lib/features/materiales/presentation/providers/catalog_provider.dart
+++ b/lib/features/materiales/presentation/providers/catalog_provider.dart
@@ -1,0 +1,144 @@
+import 'package:equatable/equatable.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../domain/entities/material_item.dart';
+import '../../domain/usecases/browse_catalog.dart';
+import 'materiales_providers.dart';
+
+/// Parámetros de consulta del catálogo.
+class CatalogQuery extends Equatable {
+  final String? cat;
+  final int? programaId;
+  final String? q;
+
+  const CatalogQuery({
+    this.cat,
+    this.programaId,
+    this.q,
+  });
+
+  @override
+  List<Object?> get props => [cat, programaId, q];
+}
+
+/// Estado del catálogo paginado.
+class CatalogState extends Equatable {
+  final List<MaterialItem> items;
+  final int total;
+  final int page;
+  final bool hasMore;
+  final bool isLoadingMore;
+  final String? errorMessage;
+
+  const CatalogState({
+    this.items = const [],
+    this.total = 0,
+    this.page = 1,
+    this.hasMore = false,
+    this.isLoadingMore = false,
+    this.errorMessage,
+  });
+
+  CatalogState copyWith({
+    List<MaterialItem>? items,
+    int? total,
+    int? page,
+    bool? hasMore,
+    bool? isLoadingMore,
+    String? errorMessage,
+  }) {
+    return CatalogState(
+      items: items ?? this.items,
+      total: total ?? this.total,
+      page: page ?? this.page,
+      hasMore: hasMore ?? this.hasMore,
+      isLoadingMore: isLoadingMore ?? this.isLoadingMore,
+      errorMessage: errorMessage,
+    );
+  }
+
+  @override
+  List<Object?> get props =>
+      [items, total, page, hasMore, isLoadingMore, errorMessage];
+}
+
+/// Notifier del catálogo con soporte de paginación incremental.
+///
+/// La primera carga se dispara automáticamente en [build].
+/// Llama [loadMore] para añadir la siguiente página.
+class CatalogNotifier
+    extends AutoDisposeFamilyAsyncNotifier<CatalogState, CatalogQuery> {
+  static const _pageSize = 20;
+
+  @override
+  Future<CatalogState> build(CatalogQuery query) async {
+    return _fetchPage(query: query, page: 1, existing: const []);
+  }
+
+  /// Carga la siguiente página y la añade a los items existentes.
+  Future<void> loadMore() async {
+    final current = state.valueOrNull;
+    if (current == null || !current.hasMore || current.isLoadingMore) return;
+
+    state = AsyncData(current.copyWith(isLoadingMore: true));
+
+    final result = await _fetchPage(
+      query: arg,
+      page: current.page + 1,
+      existing: current.items,
+    );
+
+    state = AsyncData(result);
+  }
+
+  /// Recarga desde la primera página con los parámetros actuales.
+  Future<void> refresh() async {
+    state = const AsyncLoading();
+    state = await AsyncValue.guard(
+      () => _fetchPage(query: arg, page: 1, existing: const []),
+    );
+  }
+
+  Future<CatalogState> _fetchPage({
+    required CatalogQuery query,
+    required int page,
+    required List<MaterialItem> existing,
+  }) async {
+    final useCase = ref.read(browseCatalogUseCaseProvider);
+    final result = await useCase(BrowseCatalogParams(
+      cat: query.cat,
+      programaId: query.programaId,
+      q: query.q,
+      page: page,
+      pageSize: _pageSize,
+    ));
+
+    return result.fold(
+      (failure) => CatalogState(
+        items: existing,
+        page: page,
+        errorMessage: failure.message,
+      ),
+      (newItems) {
+        final all = [...existing, ...newItems];
+        return CatalogState(
+          items: all,
+          total: all.length, // approximate; backend total not exposed by repo
+          page: page,
+          hasMore: newItems.length == _pageSize,
+        );
+      },
+    );
+  }
+}
+
+/// Provider family del catálogo indexado por [CatalogQuery].
+///
+/// Uso:
+/// ```dart
+/// final state = ref.watch(catalogProvider(CatalogQuery(q: 'camisa')));
+/// ```
+final catalogProvider = AsyncNotifierProvider.autoDispose
+    .family<CatalogNotifier, CatalogState, CatalogQuery>(
+  CatalogNotifier.new,
+);

--- a/lib/features/materiales/presentation/providers/categorias_provider.dart
+++ b/lib/features/materiales/presentation/providers/categorias_provider.dart
@@ -1,0 +1,20 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../domain/entities/material_category.dart';
+import 'materiales_providers.dart';
+
+/// Lista de categorías activas.
+///
+/// keepAlive: los datos de catálogo son estables durante la sesión — se
+/// evita re-fetching innecesario cuando el usuario navega entre pantallas.
+final categoriasProvider =
+    FutureProvider<List<MaterialCategory>>((ref) async {
+  ref.keepAlive();
+
+  final repo = ref.read(materialesRepositoryProvider);
+  final result = await repo.listCategorias();
+  return result.fold(
+    (failure) => throw Exception(failure.message),
+    (categories) => categories,
+  );
+});

--- a/lib/features/materiales/presentation/providers/categorias_provider.dart
+++ b/lib/features/materiales/presentation/providers/categorias_provider.dart
@@ -7,8 +7,7 @@ import 'materiales_providers.dart';
 ///
 /// keepAlive: los datos de catálogo son estables durante la sesión — se
 /// evita re-fetching innecesario cuando el usuario navega entre pantallas.
-final categoriasProvider =
-    FutureProvider<List<MaterialCategory>>((ref) async {
+final categoriasProvider = FutureProvider<List<MaterialCategory>>((ref) async {
   ref.keepAlive();
 
   final repo = ref.read(materialesRepositoryProvider);

--- a/lib/features/materiales/presentation/providers/comprobantes_provider.dart
+++ b/lib/features/materiales/presentation/providers/comprobantes_provider.dart
@@ -1,0 +1,119 @@
+import 'dart:io';
+
+import 'package:equatable/equatable.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../domain/entities/comprobante.dart';
+import '../../domain/usecases/upload_comprobante.dart';
+import 'materiales_providers.dart';
+
+// ── List comprobantes ─────────────────────────────────────────────────────────
+
+/// Provider que lista los comprobantes de una orden por folio o ID.
+///
+/// autoDispose: se libera al salir de la pantalla. family: por folioOrId.
+final comprobantesProvider = FutureProvider.autoDispose
+    .family<List<Comprobante>, String>((ref, folioOrId) async {
+  final repo = ref.watch(materialesRepositoryProvider);
+  final result = await repo.listComprobantes(folioOrId);
+  return result.fold(
+    (failure) => throw Exception(failure.message),
+    (list) => list,
+  );
+});
+
+// ── Upload comprobante (stateful Notifier) ────────────────────────────────────
+
+/// Argumentos para el caso de uso de subida de comprobante.
+class UploadComprobanteArgs extends Equatable {
+  final String folioOrId;
+  final File file;
+  final int montoCentavos;
+  final String refBancariaDeclarada;
+  final DateTime fechaPago;
+
+  const UploadComprobanteArgs({
+    required this.folioOrId,
+    required this.file,
+    required this.montoCentavos,
+    required this.refBancariaDeclarada,
+    required this.fechaPago,
+  });
+
+  @override
+  List<Object?> get props =>
+      [folioOrId, file.path, montoCentavos, refBancariaDeclarada, fechaPago];
+}
+
+/// Estado del proceso de subida de comprobante.
+class UploadComprobanteState {
+  final bool isLoading;
+  final double progress; // 0.0 – 1.0
+  final String? errorMessage;
+  final Comprobante? result;
+
+  const UploadComprobanteState({
+    this.isLoading = false,
+    this.progress = 0.0,
+    this.errorMessage,
+    this.result,
+  });
+
+  UploadComprobanteState copyWith({
+    bool? isLoading,
+    double? progress,
+    String? errorMessage,
+    Comprobante? result,
+  }) {
+    return UploadComprobanteState(
+      isLoading: isLoading ?? this.isLoading,
+      progress: progress ?? this.progress,
+      errorMessage: errorMessage,
+      result: result ?? this.result,
+    );
+  }
+}
+
+/// Notifier que maneja la subida de un comprobante de pago.
+///
+/// Expone el progreso de upload (0.0–1.0) para mostrar una barra de progreso.
+class UploadComprobanteNotifier
+    extends AutoDisposeNotifier<UploadComprobanteState> {
+  @override
+  UploadComprobanteState build() => const UploadComprobanteState();
+
+  Future<void> upload(UploadComprobanteArgs args) async {
+    state = const UploadComprobanteState(isLoading: true);
+
+    final useCase = ref.read(uploadComprobanteUseCaseProvider);
+    final params = UploadComprobanteParams(
+      folioOrId: args.folioOrId,
+      file: args.file,
+      montoCentavos: args.montoCentavos,
+      refBancariaDeclarada: args.refBancariaDeclarada,
+      fechaPago: args.fechaPago,
+      onProgress: (fraction) {
+        state = state.copyWith(progress: fraction);
+      },
+    );
+
+    final result = await useCase(params);
+
+    result.fold(
+      (failure) {
+        state = UploadComprobanteState(errorMessage: failure.message);
+      },
+      (comprobante) {
+        state = UploadComprobanteState(result: comprobante);
+      },
+    );
+  }
+
+  void reset() {
+    state = const UploadComprobanteState();
+  }
+}
+
+final uploadComprobanteNotifierProvider = AutoDisposeNotifierProvider<
+    UploadComprobanteNotifier,
+    UploadComprobanteState>(UploadComprobanteNotifier.new);

--- a/lib/features/materiales/presentation/providers/config_provider.dart
+++ b/lib/features/materiales/presentation/providers/config_provider.dart
@@ -1,0 +1,18 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../domain/entities/material_config.dart';
+import 'materiales_providers.dart';
+
+/// Provider de la configuración del módulo de materiales.
+///
+/// keepAlive: la config es estable durante la sesión — no necesitamos refetch
+/// entre navegaciones dentro del flujo de pedidos.
+final configProvider = FutureProvider<MaterialConfig>((ref) async {
+  ref.keepAlive();
+  final useCase = ref.read(getConfigUseCaseProvider);
+  final result = await useCase();
+  return result.fold(
+    (failure) => throw Exception(failure.message),
+    (config) => config,
+  );
+});

--- a/lib/features/materiales/presentation/providers/create_order_provider.dart
+++ b/lib/features/materiales/presentation/providers/create_order_provider.dart
@@ -1,0 +1,67 @@
+import 'package:dartz/dartz.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../../core/errors/failures.dart';
+import '../../domain/entities/material_entrega.dart';
+import '../../domain/entities/orden.dart';
+import '../../domain/usecases/create_order.dart';
+import 'materiales_providers.dart';
+
+/// Estado del proceso de creación de una orden.
+class CreateOrderState {
+  final bool isLoading;
+  final String? errorMessage;
+
+  const CreateOrderState({
+    this.isLoading = false,
+    this.errorMessage,
+  });
+
+  CreateOrderState copyWith({bool? isLoading, String? errorMessage}) {
+    return CreateOrderState(
+      isLoading: isLoading ?? this.isLoading,
+      errorMessage: errorMessage ?? this.errorMessage,
+    );
+  }
+}
+
+/// Notifier que gestiona el ciclo de vida de la llamada createOrder.
+class CreateOrderNotifier extends AutoDisposeNotifier<CreateOrderState> {
+  @override
+  CreateOrderState build() => const CreateOrderState();
+
+  /// Ejecuta el caso de uso [CreateOrder] y retorna el resultado.
+  ///
+  /// El estado [isLoading] se activa durante la llamada. Si hay error,
+  /// [errorMessage] se rellena y el caller muestra el snackbar adecuado.
+  Future<Either<Failure, Orden>> confirm({
+    required int clubSectionId,
+    required List<
+            ({String productId, String? variantOptionId, int qty})>
+        lines,
+    required MaterialEntrega entrega,
+    String? notas,
+  }) async {
+    state = const CreateOrderState(isLoading: true);
+    final useCase = ref.read(createOrderUseCaseProvider);
+    final result = await useCase(
+      CreateOrderParams(
+        clubSectionId: clubSectionId,
+        lines: lines,
+        entrega: entrega,
+        notas: notas,
+      ),
+    );
+    state = result.fold(
+      (failure) => CreateOrderState(errorMessage: failure.message),
+      (_) => const CreateOrderState(),
+    );
+    return result;
+  }
+}
+
+/// Provider del notifier de creación de orden.
+final createOrderProvider =
+    NotifierProvider.autoDispose<CreateOrderNotifier, CreateOrderState>(
+  CreateOrderNotifier.new,
+);

--- a/lib/features/materiales/presentation/providers/create_order_provider.dart
+++ b/lib/features/materiales/presentation/providers/create_order_provider.dart
@@ -36,9 +36,7 @@ class CreateOrderNotifier extends AutoDisposeNotifier<CreateOrderState> {
   /// [errorMessage] se rellena y el caller muestra el snackbar adecuado.
   Future<Either<Failure, Orden>> confirm({
     required int clubSectionId,
-    required List<
-            ({String productId, String? variantOptionId, int qty})>
-        lines,
+    required List<({String productId, String? variantOptionId, int qty})> lines,
     required MaterialEntrega entrega,
     String? notas,
   }) async {

--- a/lib/features/materiales/presentation/providers/historial_provider.dart
+++ b/lib/features/materiales/presentation/providers/historial_provider.dart
@@ -1,0 +1,21 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../domain/entities/orden.dart';
+import '../../domain/usecases/get_order_history.dart';
+import 'materiales_providers.dart';
+
+/// Provider del historial de órdenes del usuario autenticado.
+///
+/// Carga la primera página (20 registros). autoDispose para limpiar al salir.
+/// Usar [ref.invalidateSelf()] para hacer pull-to-refresh.
+final historialProvider =
+    FutureProvider.autoDispose<List<Orden>>((ref) async {
+  final useCase = ref.read(getOrderHistoryUseCaseProvider);
+  final result = await useCase(
+    const GetOrderHistoryParams(page: 1, pageSize: 20),
+  );
+  return result.fold(
+    (failure) => throw Exception(failure.message),
+    (list) => list,
+  );
+});

--- a/lib/features/materiales/presentation/providers/historial_provider.dart
+++ b/lib/features/materiales/presentation/providers/historial_provider.dart
@@ -8,8 +8,7 @@ import 'materiales_providers.dart';
 ///
 /// Carga la primera página (20 registros). autoDispose para limpiar al salir.
 /// Usar [ref.invalidateSelf()] para hacer pull-to-refresh.
-final historialProvider =
-    FutureProvider.autoDispose<List<Orden>>((ref) async {
+final historialProvider = FutureProvider.autoDispose<List<Orden>>((ref) async {
   final useCase = ref.read(getOrderHistoryUseCaseProvider);
   final result = await useCase(
     const GetOrderHistoryParams(page: 1, pageSize: 20),

--- a/lib/features/materiales/presentation/providers/materiales_providers.dart
+++ b/lib/features/materiales/presentation/providers/materiales_providers.dart
@@ -1,0 +1,66 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../../features/auth/presentation/providers/auth_providers.dart';
+import '../../../../providers/dio_provider.dart';
+import '../../data/datasources/materiales_remote_data_source.dart';
+import '../../data/repositories/materiales_repository_impl.dart';
+import '../../domain/repositories/materiales_repository.dart';
+import '../../domain/usecases/browse_catalog.dart';
+import '../../domain/usecases/cancel_order.dart';
+import '../../domain/usecases/create_order.dart';
+import '../../domain/usecases/get_config.dart';
+import '../../domain/usecases/get_order_detail.dart';
+import '../../domain/usecases/get_order_history.dart';
+import '../../domain/usecases/get_product_detail.dart';
+import '../../domain/usecases/upload_comprobante.dart';
+
+// ── Infrastructure ─────────────────────────────────────────────────────────────
+
+final materialesRemoteDataSourceProvider =
+    Provider<MaterialesRemoteDataSource>((ref) {
+  return MaterialesRemoteDataSourceImpl(
+    dio: ref.read(dioProvider),
+    baseUrl: ref.read(apiBaseUrlProvider),
+  );
+});
+
+final materialesRepositoryProvider = Provider<MaterialesRepository>((ref) {
+  return MaterialesRepositoryImpl(
+    remoteDataSource: ref.read(materialesRemoteDataSourceProvider),
+    networkInfo: ref.read(networkInfoProvider),
+  );
+});
+
+// ── Use case providers ─────────────────────────────────────────────────────────
+
+final browseCatalogUseCaseProvider = Provider<BrowseCatalog>((ref) {
+  return BrowseCatalog(ref.read(materialesRepositoryProvider));
+});
+
+final getProductDetailUseCaseProvider = Provider<GetProductDetail>((ref) {
+  return GetProductDetail(ref.read(materialesRepositoryProvider));
+});
+
+final createOrderUseCaseProvider = Provider<CreateOrder>((ref) {
+  return CreateOrder(ref.read(materialesRepositoryProvider));
+});
+
+final getOrderDetailUseCaseProvider = Provider<GetOrderDetail>((ref) {
+  return GetOrderDetail(ref.read(materialesRepositoryProvider));
+});
+
+final getOrderHistoryUseCaseProvider = Provider<GetOrderHistory>((ref) {
+  return GetOrderHistory(ref.read(materialesRepositoryProvider));
+});
+
+final uploadComprobanteUseCaseProvider = Provider<UploadComprobante>((ref) {
+  return UploadComprobante(ref.read(materialesRepositoryProvider));
+});
+
+final cancelOrderUseCaseProvider = Provider<CancelOrder>((ref) {
+  return CancelOrder(ref.read(materialesRepositoryProvider));
+});
+
+final getConfigUseCaseProvider = Provider<GetConfig>((ref) {
+  return GetConfig(ref.read(materialesRepositoryProvider));
+});

--- a/lib/features/materiales/presentation/providers/orden_detail_provider.dart
+++ b/lib/features/materiales/presentation/providers/orden_detail_provider.dart
@@ -1,0 +1,23 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../domain/entities/orden.dart';
+import '../../domain/usecases/get_order_detail.dart';
+import 'materiales_providers.dart';
+
+/// Provider family que obtiene el detalle de una orden por folio o ID.
+///
+/// autoDispose: se limpia al abandonar la pantalla de detalle.
+///
+/// Uso:
+/// ```dart
+/// final ordenAsync = ref.watch(ordenDetailProvider('abc-123'));
+/// ```
+final ordenDetailProvider =
+    FutureProvider.autoDispose.family<Orden, String>((ref, folioOrId) async {
+  final useCase = ref.read(getOrderDetailUseCaseProvider);
+  final result = await useCase(GetOrderDetailParams(folioOrId: folioOrId));
+  return result.fold(
+    (failure) => throw Exception(failure.message),
+    (orden) => orden,
+  );
+});

--- a/lib/features/materiales/presentation/providers/product_detail_provider.dart
+++ b/lib/features/materiales/presentation/providers/product_detail_provider.dart
@@ -1,0 +1,21 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../domain/entities/material_item.dart';
+import '../../domain/usecases/get_product_detail.dart';
+import 'materiales_providers.dart';
+
+/// Provider family que obtiene el detalle de un producto por su ID.
+///
+/// Uso:
+/// ```dart
+/// final itemAsync = ref.watch(productDetailProvider('abc-123'));
+/// ```
+final productDetailProvider =
+    FutureProvider.autoDispose.family<MaterialItem, String>((ref, id) async {
+  final useCase = ref.read(getProductDetailUseCaseProvider);
+  final result = await useCase(GetProductDetailParams(id: id));
+  return result.fold(
+    (failure) => throw Exception(failure.message),
+    (item) => item,
+  );
+});

--- a/lib/features/materiales/presentation/providers/programas_provider.dart
+++ b/lib/features/materiales/presentation/providers/programas_provider.dart
@@ -7,8 +7,7 @@ import 'materiales_providers.dart';
 ///
 /// keepAlive: los programas son estables durante la sesión de usuario — se
 /// evita re-fetching innecesario al navegar entre pantallas.
-final programasProvider =
-    FutureProvider<List<MaterialPrograma>>((ref) async {
+final programasProvider = FutureProvider<List<MaterialPrograma>>((ref) async {
   ref.keepAlive();
 
   final repo = ref.read(materialesRepositoryProvider);

--- a/lib/features/materiales/presentation/providers/programas_provider.dart
+++ b/lib/features/materiales/presentation/providers/programas_provider.dart
@@ -1,0 +1,20 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../domain/entities/material_programa.dart';
+import 'materiales_providers.dart';
+
+/// Lista de programas (tipos de club) disponibles en el catálogo.
+///
+/// keepAlive: los programas son estables durante la sesión de usuario — se
+/// evita re-fetching innecesario al navegar entre pantallas.
+final programasProvider =
+    FutureProvider<List<MaterialPrograma>>((ref) async {
+  ref.keepAlive();
+
+  final repo = ref.read(materialesRepositoryProvider);
+  final result = await repo.listProgramas();
+  return result.fold(
+    (failure) => throw Exception(failure.message),
+    (programas) => programas,
+  );
+});

--- a/lib/features/materiales/presentation/screens/carrito_screen.dart
+++ b/lib/features/materiales/presentation/screens/carrito_screen.dart
@@ -107,10 +107,8 @@ class CarritoScreen extends ConsumerWidget {
                           borderRadius: BorderRadius.circular(12),
                         ),
                       ),
-                      // PR12 defines the resumen route — placeholder push for now
-                      onPressed: () => context.push(
-                        '${RouteNames.homeMateriales}/resumen',
-                      ),
+                      onPressed: () =>
+                          context.push(RouteNames.materialesResumen),
                       child: const Text(
                         'Continuar',
                         style: TextStyle(

--- a/lib/features/materiales/presentation/screens/carrito_screen.dart
+++ b/lib/features/materiales/presentation/screens/carrito_screen.dart
@@ -1,0 +1,308 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../../../core/config/route_names.dart';
+import '../../../../core/theme/app_colors.dart';
+import '../providers/cart_provider.dart';
+import '../utils/money_format.dart';
+import '../widgets/qty_stepper.dart';
+
+/// Pantalla del carrito de materiales.
+///
+/// Muestra las líneas del carrito con posibilidad de editar cantidad o
+/// eliminar cada una. El footer muestra el subtotal y el CTA para continuar
+/// hacia la pantalla de resumen (PR12).
+class CarritoScreen extends ConsumerWidget {
+  const CarritoScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final cart = ref.watch(cartProvider);
+    final theme = Theme.of(context);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Carrito'),
+        actions: [
+          if (cart.lines.isNotEmpty)
+            TextButton(
+              onPressed: () => _confirmClear(context, ref),
+              child: const Text(
+                'Vaciar',
+                style: TextStyle(color: AppColors.error),
+              ),
+            ),
+        ],
+      ),
+      body: cart.lines.isEmpty
+          ? _EmptyCart(
+              onBackToCatalog: () => context.pop(),
+            )
+          : ListView.separated(
+              padding: const EdgeInsets.fromLTRB(16, 16, 16, 120),
+              itemCount: cart.lines.length,
+              separatorBuilder: (_, __) => const Divider(height: 1),
+              itemBuilder: (context, index) {
+                final line = cart.lines[index];
+                return _CartLineItem(
+                  line: line,
+                  onQtyChanged: (qty) => ref
+                      .read(cartProvider.notifier)
+                      .updateQty(line.productId, line.variantOptionId, qty),
+                  onRemove: () => ref
+                      .read(cartProvider.notifier)
+                      .removeLine(line.productId, line.variantOptionId),
+                );
+              },
+            ),
+      bottomSheet: cart.lines.isEmpty
+          ? null
+          : Container(
+              width: double.infinity,
+              padding: const EdgeInsets.fromLTRB(20, 16, 20, 32),
+              decoration: BoxDecoration(
+                color: theme.scaffoldBackgroundColor,
+                border: const Border(
+                  top: BorderSide(color: AppColors.lightBorder),
+                ),
+                boxShadow: const [
+                  BoxShadow(
+                    color: Color(0x14000000),
+                    blurRadius: 12,
+                    offset: Offset(0, -4),
+                  ),
+                ],
+              ),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    children: [
+                      Text(
+                        'Subtotal',
+                        style: theme.textTheme.titleMedium?.copyWith(
+                          fontWeight: FontWeight.w600,
+                        ),
+                      ),
+                      Text(
+                        formatMxn(cart.subtotalCentavos),
+                        style: theme.textTheme.titleMedium?.copyWith(
+                          fontWeight: FontWeight.bold,
+                          color: AppColors.primary,
+                        ),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 12),
+                  SizedBox(
+                    width: double.infinity,
+                    child: FilledButton(
+                      style: FilledButton.styleFrom(
+                        backgroundColor: AppColors.primary,
+                        padding:
+                            const EdgeInsets.symmetric(vertical: 16),
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(12),
+                        ),
+                      ),
+                      // PR12 defines the resumen route — placeholder push for now
+                      onPressed: () => context.push(
+                        '${RouteNames.homeMateriales}/resumen',
+                      ),
+                      child: const Text(
+                        'Continuar',
+                        style: TextStyle(
+                          fontSize: 16,
+                          fontWeight: FontWeight.w600,
+                        ),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+    );
+  }
+
+  Future<void> _confirmClear(BuildContext context, WidgetRef ref) async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('Vaciar carrito'),
+        content: const Text(
+            '¿Querés eliminar todos los productos del carrito?'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(false),
+            child: const Text('Cancelar'),
+          ),
+          FilledButton(
+            style: FilledButton.styleFrom(backgroundColor: AppColors.error),
+            onPressed: () => Navigator.of(ctx).pop(true),
+            child: const Text('Vaciar'),
+          ),
+        ],
+      ),
+    );
+    if (confirmed == true) {
+      ref.read(cartProvider.notifier).clear();
+    }
+  }
+}
+
+// ── Sub-widgets ────────────────────────────────────────────────────────────────
+
+class _CartLineItem extends StatelessWidget {
+  final CartLine line;
+  final ValueChanged<int> onQtyChanged;
+  final VoidCallback onRemove;
+
+  const _CartLineItem({
+    required this.line,
+    required this.onQtyChanged,
+    required this.onRemove,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 12),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // Thumbnail placeholder
+          Container(
+            width: 56,
+            height: 56,
+            decoration: BoxDecoration(
+              color: AppColors.primarySurface,
+              borderRadius: BorderRadius.circular(8),
+            ),
+            alignment: Alignment.center,
+            child: Text(
+              line.productTitle.isNotEmpty
+                  ? line.productTitle[0].toUpperCase()
+                  : '?',
+              style: const TextStyle(
+                fontSize: 22,
+                fontWeight: FontWeight.bold,
+                color: AppColors.primary,
+              ),
+            ),
+          ),
+          const SizedBox(width: 12),
+
+          // Details
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  line.productTitle,
+                  style: theme.textTheme.bodyMedium?.copyWith(
+                    fontWeight: FontWeight.w600,
+                  ),
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                ),
+                if (line.variantLabel != null) ...[
+                  const SizedBox(height: 2),
+                  Text(
+                    line.variantLabel!,
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: AppColors.lightTextSecondary,
+                    ),
+                  ),
+                ],
+                const SizedBox(height: 6),
+                Text(
+                  formatMxn(line.priceSnapshotCentavos),
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: AppColors.primary,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+                const SizedBox(height: 8),
+                Row(
+                  children: [
+                    QtyStepper(
+                      value: line.qty,
+                      min: 1,
+                      max: 99,
+                      onChanged: onQtyChanged,
+                    ),
+                    const Spacer(),
+                    Text(
+                      formatMxn(line.lineTotalCentavos),
+                      style: theme.textTheme.bodyMedium?.copyWith(
+                        fontWeight: FontWeight.bold,
+                        color: AppColors.lightText,
+                      ),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+
+          // Remove button
+          IconButton(
+            icon: const Icon(Icons.close, size: 20),
+            color: AppColors.lightTextTertiary,
+            onPressed: onRemove,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _EmptyCart extends StatelessWidget {
+  final VoidCallback onBackToCatalog;
+
+  const _EmptyCart({required this.onBackToCatalog});
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          const Icon(
+            Icons.shopping_cart_outlined,
+            size: 72,
+            color: AppColors.lightTextTertiary,
+          ),
+          const SizedBox(height: 16),
+          const Text(
+            'Tu carrito está vacío',
+            style: TextStyle(
+              fontSize: 18,
+              fontWeight: FontWeight.w600,
+              color: AppColors.lightTextSecondary,
+            ),
+          ),
+          const SizedBox(height: 8),
+          const Text(
+            'Agregá productos desde el catálogo',
+            style: TextStyle(color: AppColors.lightTextTertiary),
+          ),
+          const SizedBox(height: 24),
+          OutlinedButton.icon(
+            icon: const Icon(Icons.arrow_back),
+            label: const Text('Ir al catálogo'),
+            style: OutlinedButton.styleFrom(
+              foregroundColor: AppColors.primary,
+              side: const BorderSide(color: AppColors.primary),
+            ),
+            onPressed: onBackToCatalog,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/materiales/presentation/screens/carrito_screen.dart
+++ b/lib/features/materiales/presentation/screens/carrito_screen.dart
@@ -101,8 +101,7 @@ class CarritoScreen extends ConsumerWidget {
                     child: FilledButton(
                       style: FilledButton.styleFrom(
                         backgroundColor: AppColors.primary,
-                        padding:
-                            const EdgeInsets.symmetric(vertical: 16),
+                        padding: const EdgeInsets.symmetric(vertical: 16),
                         shape: RoundedRectangleBorder(
                           borderRadius: BorderRadius.circular(12),
                         ),
@@ -129,8 +128,8 @@ class CarritoScreen extends ConsumerWidget {
       context: context,
       builder: (ctx) => AlertDialog(
         title: const Text('Vaciar carrito'),
-        content: const Text(
-            '¿Querés eliminar todos los productos del carrito?'),
+        content:
+            const Text('¿Querés eliminar todos los productos del carrito?'),
         actions: [
           TextButton(
             onPressed: () => Navigator.of(ctx).pop(false),

--- a/lib/features/materiales/presentation/screens/catalogo_screen.dart
+++ b/lib/features/materiales/presentation/screens/catalogo_screen.dart
@@ -106,8 +106,7 @@ class _CatalogoScreenState extends ConsumerState<CatalogoScreen> {
         children: [
           // ── Search ──
           Padding(
-            padding:
-                const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
             child: TextField(
               controller: _searchController,
               onChanged: _onSearchChanged,
@@ -116,16 +115,13 @@ class _CatalogoScreenState extends ConsumerState<CatalogoScreen> {
                 prefixIcon: const Icon(Icons.search),
                 border: OutlineInputBorder(
                   borderRadius: BorderRadius.circular(12),
-                  borderSide:
-                      const BorderSide(color: AppColors.lightBorder),
+                  borderSide: const BorderSide(color: AppColors.lightBorder),
                 ),
                 enabledBorder: OutlineInputBorder(
                   borderRadius: BorderRadius.circular(12),
-                  borderSide:
-                      const BorderSide(color: AppColors.lightBorder),
+                  borderSide: const BorderSide(color: AppColors.lightBorder),
                 ),
-                contentPadding:
-                    const EdgeInsets.symmetric(vertical: 10),
+                contentPadding: const EdgeInsets.symmetric(vertical: 10),
               ),
             ),
           ),
@@ -145,15 +141,13 @@ class _CatalogoScreenState extends ConsumerState<CatalogoScreen> {
                     _FilterChip(
                       label: 'Todos',
                       selected: _selectedProgramaId == null,
-                      onTap: () =>
-                          setState(() => _selectedProgramaId = null),
+                      onTap: () => setState(() => _selectedProgramaId = null),
                     ),
                     ...programas.map(
                       (p) => _FilterChip(
                         label: p.label,
                         selected: _selectedProgramaId == p.id,
-                        onTap: () =>
-                            setState(() => _selectedProgramaId = p.id),
+                        onTap: () => setState(() => _selectedProgramaId = p.id),
                       ),
                     ),
                   ],
@@ -174,21 +168,18 @@ class _CatalogoScreenState extends ConsumerState<CatalogoScreen> {
                   height: 36,
                   child: ListView(
                     scrollDirection: Axis.horizontal,
-                    padding:
-                        const EdgeInsets.symmetric(horizontal: 16),
+                    padding: const EdgeInsets.symmetric(horizontal: 16),
                     children: [
                       _FilterChip(
                         label: 'Categorías',
                         selected: _selectedCat == null,
-                        onTap: () =>
-                            setState(() => _selectedCat = null),
+                        onTap: () => setState(() => _selectedCat = null),
                       ),
                       ...cats.map(
                         (c) => _FilterChip(
                           label: c.label,
                           selected: _selectedCat == c.slug,
-                          onTap: () =>
-                              setState(() => _selectedCat = c.slug),
+                          onTap: () => setState(() => _selectedCat = c.slug),
                         ),
                       ),
                     ],
@@ -218,21 +209,18 @@ class _CatalogoScreenState extends ConsumerState<CatalogoScreen> {
                 if (state.items.isEmpty && state.errorMessage != null) {
                   return _ErrorState(
                     message: state.errorMessage!,
-                    onRetry: () =>
-                        ref.invalidate(catalogProvider(_query)),
+                    onRetry: () => ref.invalidate(catalogProvider(_query)),
                   );
                 }
                 return GridView.builder(
                   padding: const EdgeInsets.fromLTRB(16, 0, 16, 100),
-                  gridDelegate:
-                      const SliverGridDelegateWithFixedCrossAxisCount(
+                  gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
                     crossAxisCount: 2,
                     mainAxisSpacing: 12,
                     crossAxisSpacing: 12,
                     childAspectRatio: 0.75,
                   ),
-                  itemCount:
-                      state.items.length + (state.hasMore ? 1 : 0),
+                  itemCount: state.items.length + (state.hasMore ? 1 : 0),
                   itemBuilder: (context, index) {
                     if (index == state.items.length) {
                       return _LoadMoreButton(
@@ -281,15 +269,12 @@ class _FilterChip extends StatelessWidget {
         onTap: onTap,
         child: AnimatedContainer(
           duration: const Duration(milliseconds: 150),
-          padding:
-              const EdgeInsets.symmetric(horizontal: 14, vertical: 6),
+          padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 6),
           decoration: BoxDecoration(
             color: selected ? AppColors.primary : AppColors.lightSurface,
             borderRadius: BorderRadius.circular(20),
             border: Border.all(
-              color: selected
-                  ? AppColors.primary
-                  : AppColors.lightBorder,
+              color: selected ? AppColors.primary : AppColors.lightBorder,
             ),
           ),
           child: Text(
@@ -315,7 +300,8 @@ class _EmptyState extends StatelessWidget {
       child: Column(
         mainAxisAlignment: MainAxisAlignment.center,
         children: [
-          Icon(Icons.inventory_2_outlined, size: 56, color: AppColors.lightTextTertiary),
+          Icon(Icons.inventory_2_outlined,
+              size: 56, color: AppColors.lightTextTertiary),
           SizedBox(height: 16),
           Text(
             'No hay productos disponibles',

--- a/lib/features/materiales/presentation/screens/catalogo_screen.dart
+++ b/lib/features/materiales/presentation/screens/catalogo_screen.dart
@@ -1,0 +1,385 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../../../core/config/route_names.dart';
+import '../../../../core/theme/app_colors.dart';
+import '../providers/cart_provider.dart';
+import '../providers/catalog_provider.dart';
+import '../providers/categorias_provider.dart';
+import '../providers/programas_provider.dart';
+import '../widgets/product_card.dart';
+
+/// Pantalla principal del catálogo de materiales.
+///
+/// Muestra un grid 2×N de productos con filtros de búsqueda, programa y
+/// categoría. Soporta paginación incremental mediante "Cargar más".
+class CatalogoScreen extends ConsumerStatefulWidget {
+  const CatalogoScreen({super.key});
+
+  @override
+  ConsumerState<CatalogoScreen> createState() => _CatalogoScreenState();
+}
+
+class _CatalogoScreenState extends ConsumerState<CatalogoScreen> {
+  final _searchController = TextEditingController();
+  Timer? _debounce;
+
+  String? _selectedCat;
+  int? _selectedProgramaId;
+  String? _searchQ;
+
+  CatalogQuery get _query => CatalogQuery(
+        cat: _selectedCat,
+        programaId: _selectedProgramaId,
+        q: _searchQ,
+      );
+
+  @override
+  void dispose() {
+    _searchController.dispose();
+    _debounce?.cancel();
+    super.dispose();
+  }
+
+  void _onSearchChanged(String value) {
+    _debounce?.cancel();
+    _debounce = Timer(const Duration(milliseconds: 400), () {
+      if (mounted) {
+        setState(() => _searchQ = value.isEmpty ? null : value);
+      }
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final cartState = ref.watch(cartProvider);
+    final catalogAsync = ref.watch(catalogProvider(_query));
+    final categoriasAsync = ref.watch(categoriasProvider);
+    final programasAsync = ref.watch(programasProvider);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Materiales'),
+        actions: [
+          Stack(
+            alignment: Alignment.topRight,
+            children: [
+              IconButton(
+                icon: const Icon(Icons.shopping_cart_outlined),
+                onPressed: () => context.push(RouteNames.materialesCarrito),
+              ),
+              if (cartState.itemCount > 0)
+                Positioned(
+                  right: 6,
+                  top: 6,
+                  child: Container(
+                    width: 16,
+                    height: 16,
+                    decoration: const BoxDecoration(
+                      color: AppColors.primary,
+                      shape: BoxShape.circle,
+                    ),
+                    alignment: Alignment.center,
+                    child: Text(
+                      '${cartState.itemCount > 9 ? '9+' : cartState.itemCount}',
+                      style: const TextStyle(
+                        color: Colors.white,
+                        fontSize: 9,
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                  ),
+                ),
+            ],
+          ),
+        ],
+      ),
+      body: Column(
+        children: [
+          // ── Search ──
+          Padding(
+            padding:
+                const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+            child: TextField(
+              controller: _searchController,
+              onChanged: _onSearchChanged,
+              decoration: InputDecoration(
+                hintText: 'Buscar productos...',
+                prefixIcon: const Icon(Icons.search),
+                border: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(12),
+                  borderSide:
+                      const BorderSide(color: AppColors.lightBorder),
+                ),
+                enabledBorder: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(12),
+                  borderSide:
+                      const BorderSide(color: AppColors.lightBorder),
+                ),
+                contentPadding:
+                    const EdgeInsets.symmetric(vertical: 10),
+              ),
+            ),
+          ),
+
+          // ── Program filter ──
+          programasAsync.when(
+            loading: () => const SizedBox.shrink(),
+            error: (_, __) => const SizedBox.shrink(),
+            data: (programas) {
+              if (programas.isEmpty) return const SizedBox.shrink();
+              return SizedBox(
+                height: 36,
+                child: ListView(
+                  scrollDirection: Axis.horizontal,
+                  padding: const EdgeInsets.symmetric(horizontal: 16),
+                  children: [
+                    _FilterChip(
+                      label: 'Todos',
+                      selected: _selectedProgramaId == null,
+                      onTap: () =>
+                          setState(() => _selectedProgramaId = null),
+                    ),
+                    ...programas.map(
+                      (p) => _FilterChip(
+                        label: p.label,
+                        selected: _selectedProgramaId == p.id,
+                        onTap: () =>
+                            setState(() => _selectedProgramaId = p.id),
+                      ),
+                    ),
+                  ],
+                ),
+              );
+            },
+          ),
+
+          // ── Category chips ──
+          categoriasAsync.when(
+            loading: () => const SizedBox.shrink(),
+            error: (_, __) => const SizedBox.shrink(),
+            data: (cats) {
+              if (cats.isEmpty) return const SizedBox.shrink();
+              return Padding(
+                padding: const EdgeInsets.only(top: 6),
+                child: SizedBox(
+                  height: 36,
+                  child: ListView(
+                    scrollDirection: Axis.horizontal,
+                    padding:
+                        const EdgeInsets.symmetric(horizontal: 16),
+                    children: [
+                      _FilterChip(
+                        label: 'Categorías',
+                        selected: _selectedCat == null,
+                        onTap: () =>
+                            setState(() => _selectedCat = null),
+                      ),
+                      ...cats.map(
+                        (c) => _FilterChip(
+                          label: c.label,
+                          selected: _selectedCat == c.slug,
+                          onTap: () =>
+                              setState(() => _selectedCat = c.slug),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              );
+            },
+          ),
+
+          const SizedBox(height: 8),
+
+          // ── Product grid ──
+          Expanded(
+            child: catalogAsync.when(
+              loading: () => const Center(
+                  child: CircularProgressIndicator(
+                color: AppColors.primary,
+              )),
+              error: (error, _) => _ErrorState(
+                message: error.toString(),
+                onRetry: () => ref.invalidate(catalogProvider(_query)),
+              ),
+              data: (state) {
+                if (state.items.isEmpty && state.errorMessage == null) {
+                  return const _EmptyState();
+                }
+                if (state.items.isEmpty && state.errorMessage != null) {
+                  return _ErrorState(
+                    message: state.errorMessage!,
+                    onRetry: () =>
+                        ref.invalidate(catalogProvider(_query)),
+                  );
+                }
+                return GridView.builder(
+                  padding: const EdgeInsets.fromLTRB(16, 0, 16, 100),
+                  gridDelegate:
+                      const SliverGridDelegateWithFixedCrossAxisCount(
+                    crossAxisCount: 2,
+                    mainAxisSpacing: 12,
+                    crossAxisSpacing: 12,
+                    childAspectRatio: 0.75,
+                  ),
+                  itemCount:
+                      state.items.length + (state.hasMore ? 1 : 0),
+                  itemBuilder: (context, index) {
+                    if (index == state.items.length) {
+                      return _LoadMoreButton(
+                        isLoading: state.isLoadingMore,
+                        onTap: () => ref
+                            .read(catalogProvider(_query).notifier)
+                            .loadMore(),
+                      );
+                    }
+                    final item = state.items[index];
+                    return ProductCard(
+                      item: item,
+                      onTap: () => context.push(
+                        RouteNames.materialesProductDetailPath(item.id),
+                      ),
+                    );
+                  },
+                );
+              },
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+// ── Sub-widgets ────────────────────────────────────────────────────────────────
+
+class _FilterChip extends StatelessWidget {
+  final String label;
+  final bool selected;
+  final VoidCallback onTap;
+
+  const _FilterChip({
+    required this.label,
+    required this.selected,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(right: 8),
+      child: GestureDetector(
+        onTap: onTap,
+        child: AnimatedContainer(
+          duration: const Duration(milliseconds: 150),
+          padding:
+              const EdgeInsets.symmetric(horizontal: 14, vertical: 6),
+          decoration: BoxDecoration(
+            color: selected ? AppColors.primary : AppColors.lightSurface,
+            borderRadius: BorderRadius.circular(20),
+            border: Border.all(
+              color: selected
+                  ? AppColors.primary
+                  : AppColors.lightBorder,
+            ),
+          ),
+          child: Text(
+            label,
+            style: TextStyle(
+              fontSize: 12,
+              fontWeight: FontWeight.w500,
+              color: selected ? Colors.white : AppColors.lightText,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _EmptyState extends StatelessWidget {
+  const _EmptyState();
+
+  @override
+  Widget build(BuildContext context) {
+    return const Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Icon(Icons.inventory_2_outlined, size: 56, color: AppColors.lightTextTertiary),
+          SizedBox(height: 16),
+          Text(
+            'No hay productos disponibles',
+            style: TextStyle(
+              color: AppColors.lightTextSecondary,
+              fontSize: 16,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ErrorState extends StatelessWidget {
+  final String message;
+  final VoidCallback onRetry;
+
+  const _ErrorState({required this.message, required this.onRetry});
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          const Icon(Icons.error_outline, size: 48, color: AppColors.error),
+          const SizedBox(height: 12),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 32),
+            child: Text(
+              message,
+              textAlign: TextAlign.center,
+              style: const TextStyle(color: AppColors.lightTextSecondary),
+            ),
+          ),
+          const SizedBox(height: 16),
+          FilledButton(
+            onPressed: onRetry,
+            style: FilledButton.styleFrom(backgroundColor: AppColors.primary),
+            child: const Text('Reintentar'),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _LoadMoreButton extends StatelessWidget {
+  final bool isLoading;
+  final VoidCallback onTap;
+
+  const _LoadMoreButton({required this.isLoading, required this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: isLoading
+          ? const CircularProgressIndicator(color: AppColors.primary)
+          : OutlinedButton(
+              onPressed: onTap,
+              style: OutlinedButton.styleFrom(
+                side: const BorderSide(color: AppColors.primary),
+              ),
+              child: const Text(
+                'Cargar más',
+                style: TextStyle(color: AppColors.primary),
+              ),
+            ),
+    );
+  }
+}

--- a/lib/features/materiales/presentation/screens/catalogo_screen.dart
+++ b/lib/features/materiales/presentation/screens/catalogo_screen.dart
@@ -64,6 +64,11 @@ class _CatalogoScreenState extends ConsumerState<CatalogoScreen> {
       appBar: AppBar(
         title: const Text('Materiales'),
         actions: [
+          IconButton(
+            icon: const Icon(Icons.receipt_long_outlined),
+            tooltip: 'Mis pedidos',
+            onPressed: () => context.push(RouteNames.materialesHistorial),
+          ),
           Stack(
             alignment: Alignment.topRight,
             children: [

--- a/lib/features/materiales/presentation/screens/datos_pago_screen.dart
+++ b/lib/features/materiales/presentation/screens/datos_pago_screen.dart
@@ -1,0 +1,394 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../../../core/config/route_names.dart';
+import '../../../../core/theme/app_colors.dart';
+import '../../domain/entities/material_estado.dart';
+import '../providers/orden_detail_provider.dart';
+import '../utils/money_format.dart';
+
+/// Pantalla "Datos para pago" — muestra la CLABE, referencia bancaria y
+/// total a pagar una vez que la orden fue aprobada.
+///
+/// El director usa esta información para realizar su transferencia antes de
+/// subir el comprobante.
+class DatosPagoScreen extends ConsumerWidget {
+  final String folioOrId;
+
+  const DatosPagoScreen({super.key, required this.folioOrId});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final ordenAsync = ref.watch(ordenDetailProvider(folioOrId));
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Datos para pago'),
+      ),
+      body: ordenAsync.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (e, _) => _ErrorBody(
+          message: e.toString(),
+          onRetry: () => ref.invalidate(ordenDetailProvider(folioOrId)),
+        ),
+        data: (orden) {
+          if (orden.estado != MaterialEstado.aprobada) {
+            return _NotRequiredBody(
+              onBack: () => context.pop(),
+            );
+          }
+          return _PagoBody(orden: orden, folioOrId: folioOrId);
+        },
+      ),
+    );
+  }
+}
+
+// ── Body cuando la orden está aprobada ────────────────────────────────────────
+
+class _PagoBody extends StatelessWidget {
+  final dynamic orden; // Orden entity
+  final String folioOrId;
+
+  const _PagoBody({required this.orden, required this.folioOrId});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return ListView(
+      padding: const EdgeInsets.fromLTRB(16, 16, 16, 32),
+      children: [
+        // ── Referencia bancaria ───────────────────────────────────────────────
+        if (orden.folioReferencia != null) ...[
+          _SectionLabel(label: 'Referencia bancaria'),
+          const SizedBox(height: 8),
+          _CopyCard(
+            label: 'Referencia',
+            value: orden.folioReferencia!,
+            mono: true,
+          ),
+          const SizedBox(height: 20),
+        ],
+
+        // ── Datos de la cuenta ────────────────────────────────────────────────
+        _SectionLabel(label: 'Datos de la cuenta'),
+        const SizedBox(height: 8),
+        Card(
+          elevation: 0,
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(12),
+            side: const BorderSide(color: AppColors.lightBorder),
+          ),
+          child: Padding(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              children: [
+                if (orden.bankName != null && orden.bankName!.isNotEmpty)
+                  _DataRow(label: 'Banco', value: orden.bankName!),
+                if (orden.accountHolder != null &&
+                    orden.accountHolder!.isNotEmpty)
+                  _DataRow(label: 'Titular', value: orden.accountHolder!),
+                if (orden.bankAccountClabe != null &&
+                    orden.bankAccountClabe!.isNotEmpty)
+                  _DataRow(
+                    label: 'CLABE',
+                    value: orden.bankAccountClabe!,
+                    mono: true,
+                    copyable: true,
+                  ),
+                _DataRow(
+                  label: 'Monto a pagar',
+                  value: formatMxn(orden.totalCentavos),
+                  bold: true,
+                ),
+              ],
+            ),
+          ),
+        ),
+
+        const SizedBox(height: 20),
+
+        // ── Nota instructiva ──────────────────────────────────────────────────
+        Container(
+          padding: const EdgeInsets.all(12),
+          decoration: BoxDecoration(
+            color: AppColors.statusInfoBgLight,
+            borderRadius: BorderRadius.circular(8),
+            border: Border.all(
+                color: AppColors.statusInfoText.withValues(alpha: 0.4)),
+          ),
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              const Icon(Icons.info_outline,
+                  size: 16, color: AppColors.statusInfoText),
+              const SizedBox(width: 8),
+              Expanded(
+                child: Text(
+                  'Realizá la transferencia a la CLABE de arriba. '
+                  'Usá la referencia como concepto de pago para que el '
+                  'campo local identifique tu depósito.',
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: AppColors.statusInfoText,
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+
+        const SizedBox(height: 32),
+
+        // ── CTA ───────────────────────────────────────────────────────────────
+        FilledButton.icon(
+          style: FilledButton.styleFrom(
+            backgroundColor: AppColors.primary,
+            padding: const EdgeInsets.symmetric(vertical: 14),
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(12),
+            ),
+          ),
+          icon: const Icon(Icons.upload_file_outlined),
+          label: const Text('Ya pagué, subir comprobante'),
+          onPressed: () =>
+              context.push(RouteNames.materialesOrdenComprobante(folioOrId)),
+        ),
+      ],
+    );
+  }
+}
+
+// ── Error state cuando el estado no requiere pago ─────────────────────────────
+
+class _NotRequiredBody extends StatelessWidget {
+  final VoidCallback onBack;
+  const _NotRequiredBody({required this.onBack});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(32),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            const Icon(Icons.block,
+                size: 48, color: AppColors.lightTextTertiary),
+            const SizedBox(height: 12),
+            Text(
+              'Esta orden no requiere pago',
+              style: theme.textTheme.titleMedium,
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 8),
+            Text(
+              'El estado actual de la orden no admite subir comprobante.',
+              style: const TextStyle(color: AppColors.lightTextSecondary),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 24),
+            OutlinedButton.icon(
+              icon: const Icon(Icons.arrow_back),
+              label: const Text('Volver'),
+              onPressed: onBack,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+// ── Error genérico ─────────────────────────────────────────────────────────────
+
+class _ErrorBody extends StatelessWidget {
+  final String message;
+  final VoidCallback onRetry;
+  const _ErrorBody({required this.message, required this.onRetry});
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(32),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            const Icon(Icons.error_outline,
+                size: 48, color: AppColors.lightTextTertiary),
+            const SizedBox(height: 12),
+            Text(
+              'No se pudo cargar el pedido',
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+            const SizedBox(height: 8),
+            Text(
+              message,
+              style: const TextStyle(color: AppColors.lightTextSecondary),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 24),
+            OutlinedButton.icon(
+              icon: const Icon(Icons.refresh),
+              label: const Text('Reintentar'),
+              onPressed: onRetry,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+// ── Supporting widgets ─────────────────────────────────────────────────────────
+
+class _SectionLabel extends StatelessWidget {
+  final String label;
+  const _SectionLabel({required this.label});
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(
+      label,
+      style: Theme.of(context).textTheme.titleSmall?.copyWith(
+            fontWeight: FontWeight.w700,
+            color: AppColors.lightText,
+          ),
+    );
+  }
+}
+
+/// Card con un valor copiable y fuente monoespaciada para CLABE / folio.
+class _CopyCard extends StatelessWidget {
+  final String label;
+  final String value;
+  final bool mono;
+
+  const _CopyCard({
+    required this.label,
+    required this.value,
+    this.mono = false,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      elevation: 0,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(12),
+        side: const BorderSide(color: AppColors.lightBorder),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+        child: Row(
+          children: [
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    label,
+                    style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                          color: AppColors.lightTextSecondary,
+                        ),
+                  ),
+                  const SizedBox(height: 4),
+                  Text(
+                    value,
+                    style: TextStyle(
+                      fontFamily: mono ? 'monospace' : null,
+                      fontSize: 16,
+                      fontWeight: FontWeight.w700,
+                      letterSpacing: mono ? 1.2 : null,
+                      color: AppColors.lightText,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            IconButton(
+              icon: const Icon(Icons.copy_outlined),
+              tooltip: 'Copiar',
+              color: AppColors.primary,
+              onPressed: () {
+                Clipboard.setData(ClipboardData(text: value));
+                ScaffoldMessenger.of(context).showSnackBar(
+                  SnackBar(content: Text('$label copiada')),
+                );
+              },
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _DataRow extends StatelessWidget {
+  final String label;
+  final String value;
+  final bool mono;
+  final bool copyable;
+  final bool bold;
+
+  const _DataRow({
+    required this.label,
+    required this.value,
+    this.mono = false,
+    this.copyable = false,
+    this.bold = false,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 6),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          SizedBox(
+            width: 80,
+            child: Text(
+              label,
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: AppColors.lightTextSecondary,
+              ),
+            ),
+          ),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(
+              value,
+              style: TextStyle(
+                fontFamily: mono ? 'monospace' : null,
+                fontSize: 14,
+                fontWeight: bold ? FontWeight.w700 : FontWeight.w500,
+                color: bold ? AppColors.primary : AppColors.lightText,
+                letterSpacing: mono ? 0.8 : null,
+              ),
+            ),
+          ),
+          if (copyable)
+            GestureDetector(
+              onTap: () {
+                Clipboard.setData(ClipboardData(text: value));
+                ScaffoldMessenger.of(context).showSnackBar(
+                  SnackBar(content: Text('$label copiada')),
+                );
+              },
+              child: const Padding(
+                padding: EdgeInsets.only(left: 4),
+                child: Icon(Icons.copy_outlined,
+                    size: 16, color: AppColors.primary),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/materiales/presentation/screens/detalle_producto_screen.dart
+++ b/lib/features/materiales/presentation/screens/detalle_producto_screen.dart
@@ -1,0 +1,343 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../../core/theme/app_colors.dart';
+import '../../domain/entities/material_item.dart';
+import '../../domain/entities/material_variant_option.dart';
+import '../providers/cart_provider.dart';
+import '../providers/product_detail_provider.dart';
+import '../utils/money_format.dart';
+import '../widgets/qty_stepper.dart';
+
+/// Pantalla de detalle de producto del catálogo de materiales.
+class DetalleProductoScreen extends ConsumerStatefulWidget {
+  final String productId;
+
+  const DetalleProductoScreen({super.key, required this.productId});
+
+  @override
+  ConsumerState<DetalleProductoScreen> createState() =>
+      _DetalleProductoScreenState();
+}
+
+class _DetalleProductoScreenState
+    extends ConsumerState<DetalleProductoScreen> {
+  MaterialVariantOption? _selectedVariant;
+  int _qty = 1;
+
+  @override
+  Widget build(BuildContext context) {
+    final itemAsync = ref.watch(productDetailProvider(widget.productId));
+    final theme = Theme.of(context);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Detalle del producto'),
+      ),
+      body: itemAsync.when(
+        loading: () => const Center(
+          child: CircularProgressIndicator(color: AppColors.primary),
+        ),
+        error: (e, _) => Center(
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              const Icon(Icons.error_outline,
+                  size: 48, color: AppColors.error),
+              const SizedBox(height: 12),
+              Text(
+                e.toString(),
+                textAlign: TextAlign.center,
+                style:
+                    const TextStyle(color: AppColors.lightTextSecondary),
+              ),
+              const SizedBox(height: 16),
+              FilledButton(
+                onPressed: () =>
+                    ref.invalidate(productDetailProvider(widget.productId)),
+                style: FilledButton.styleFrom(
+                    backgroundColor: AppColors.primary),
+                child: const Text('Reintentar'),
+              ),
+            ],
+          ),
+        ),
+        data: (item) {
+          // Determine stock limit for the stepper
+          final maxQty = _selectedVariant?.stock ?? item.stock;
+
+          return SingleChildScrollView(
+            padding: const EdgeInsets.all(20),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                // ── Hero area ──
+                Container(
+                  width: double.infinity,
+                  height: 200,
+                  decoration: BoxDecoration(
+                    color: AppColors.primarySurface,
+                    borderRadius: BorderRadius.circular(16),
+                  ),
+                  alignment: Alignment.center,
+                  child: Text(
+                    item.title.isNotEmpty
+                        ? item.title[0].toUpperCase()
+                        : '?',
+                    style: const TextStyle(
+                      fontSize: 72,
+                      fontWeight: FontWeight.bold,
+                      color: AppColors.primary,
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 20),
+
+                // ── Title & SKU ──
+                Text(
+                  item.title,
+                  style: theme.textTheme.titleLarge?.copyWith(
+                    fontWeight: FontWeight.w700,
+                    color: AppColors.lightText,
+                  ),
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  'SKU: ${item.sku}',
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: AppColors.lightTextSecondary,
+                  ),
+                ),
+                const SizedBox(height: 8),
+
+                // ── Badges ──
+                Wrap(
+                  spacing: 8,
+                  runSpacing: 4,
+                  children: [
+                    _Badge(
+                        label: item.category.label,
+                        color: AppColors.info),
+                    _Badge(
+                        label: item.programa.label,
+                        color: AppColors.secondary),
+                  ],
+                ),
+                const SizedBox(height: 16),
+
+                // ── Description ──
+                if (item.description != null &&
+                    item.description!.isNotEmpty) ...[
+                  Text(
+                    item.description!,
+                    style: theme.textTheme.bodyMedium?.copyWith(
+                      color: AppColors.lightTextSecondary,
+                      height: 1.5,
+                    ),
+                  ),
+                  const SizedBox(height: 16),
+                ],
+
+                // ── Price ──
+                Text(
+                  formatMxn(item.priceCentavos),
+                  style: theme.textTheme.headlineSmall?.copyWith(
+                    color: AppColors.primary,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+                const SizedBox(height: 20),
+
+                // ── Variant selector ──
+                if (item.hasVariants && item.variant != null) ...[
+                  Text(
+                    'Selecciona ${item.variant!.type.name}:',
+                    style: theme.textTheme.titleSmall?.copyWith(
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  Wrap(
+                    spacing: 8,
+                    runSpacing: 8,
+                    children: item.variant!.options.map((option) {
+                      final selected = _selectedVariant?.id == option.id;
+                      final outOfStock = option.stock == 0;
+                      return GestureDetector(
+                        onTap: outOfStock
+                            ? null
+                            : () {
+                                setState(() {
+                                  _selectedVariant = option;
+                                  // Reset qty if new variant has less stock
+                                  if (_qty > option.stock) {
+                                    _qty = option.stock.clamp(1, option.stock);
+                                  }
+                                });
+                              },
+                        child: AnimatedContainer(
+                          duration: const Duration(milliseconds: 150),
+                          padding: const EdgeInsets.symmetric(
+                              horizontal: 16, vertical: 10),
+                          decoration: BoxDecoration(
+                            color: selected
+                                ? AppColors.primary
+                                : outOfStock
+                                    ? AppColors.lightBorderLight
+                                    : AppColors.lightSurface,
+                            borderRadius: BorderRadius.circular(8),
+                            border: Border.all(
+                              color: selected
+                                  ? AppColors.primary
+                                  : AppColors.lightBorder,
+                            ),
+                          ),
+                          child: Column(
+                            children: [
+                              Text(
+                                option.label,
+                                style: TextStyle(
+                                  color: selected
+                                      ? Colors.white
+                                      : outOfStock
+                                          ? AppColors.lightTextTertiary
+                                          : AppColors.lightText,
+                                  fontWeight: FontWeight.w500,
+                                  decoration: outOfStock
+                                      ? TextDecoration.lineThrough
+                                      : null,
+                                ),
+                              ),
+                              if (!outOfStock)
+                                Text(
+                                  '${option.stock} disp.',
+                                  style: TextStyle(
+                                    fontSize: 10,
+                                    color: selected
+                                        ? Colors.white70
+                                        : AppColors.lightTextTertiary,
+                                  ),
+                                ),
+                            ],
+                          ),
+                        ),
+                      );
+                    }).toList(),
+                  ),
+                  const SizedBox(height: 20),
+                ],
+
+                // ── Qty stepper ──
+                Row(
+                  children: [
+                    Text(
+                      'Cantidad:',
+                      style: theme.textTheme.titleSmall?.copyWith(
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                    const SizedBox(width: 16),
+                    QtyStepper(
+                      value: _qty,
+                      min: 1,
+                      max: maxQty.clamp(1, 100),
+                      onChanged: (v) => setState(() => _qty = v),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 32),
+
+                // ── Add to cart CTA ──
+                SizedBox(
+                  width: double.infinity,
+                  child: FilledButton.icon(
+                    icon: const Icon(Icons.add_shopping_cart),
+                    label: const Text('Agregar al carrito'),
+                    style: FilledButton.styleFrom(
+                      backgroundColor: maxQty > 0
+                          ? AppColors.primary
+                          : AppColors.lightTextTertiary,
+                      padding:
+                          const EdgeInsets.symmetric(vertical: 16),
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(12),
+                      ),
+                    ),
+                    onPressed: maxQty > 0
+                        ? () => _addToCart(item, context)
+                        : null,
+                  ),
+                ),
+
+                if (maxQty == 0) ...[
+                  const SizedBox(height: 8),
+                  const Center(
+                    child: Text(
+                      'Producto agotado',
+                      style: TextStyle(
+                        color: AppColors.error,
+                        fontWeight: FontWeight.w500,
+                      ),
+                    ),
+                  ),
+                ],
+              ],
+            ),
+          );
+        },
+      ),
+    );
+  }
+
+  void _addToCart(MaterialItem item, BuildContext context) {
+    ref.read(cartProvider.notifier).addLine(
+          item,
+          variantOption: _selectedVariant,
+          qty: _qty,
+        );
+
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text('${item.title} agregado al carrito'),
+        backgroundColor: AppColors.secondary,
+        behavior: SnackBarBehavior.floating,
+        action: SnackBarAction(
+          label: 'Ver carrito',
+          textColor: Colors.white,
+          onPressed: () {
+            ScaffoldMessenger.of(context).hideCurrentSnackBar();
+            // Navigate back and let the cart icon guide the user
+          },
+        ),
+      ),
+    );
+  }
+}
+
+// ── Helper widget ─────────────────────────────────────────────────────────────
+
+class _Badge extends StatelessWidget {
+  final String label;
+  final Color color;
+
+  const _Badge({required this.label, required this.color});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.12),
+        borderRadius: BorderRadius.circular(20),
+      ),
+      child: Text(
+        label,
+        style: TextStyle(
+          fontSize: 11,
+          color: color,
+          fontWeight: FontWeight.w600,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/materiales/presentation/screens/detalle_producto_screen.dart
+++ b/lib/features/materiales/presentation/screens/detalle_producto_screen.dart
@@ -20,8 +20,7 @@ class DetalleProductoScreen extends ConsumerStatefulWidget {
       _DetalleProductoScreenState();
 }
 
-class _DetalleProductoScreenState
-    extends ConsumerState<DetalleProductoScreen> {
+class _DetalleProductoScreenState extends ConsumerState<DetalleProductoScreen> {
   MaterialVariantOption? _selectedVariant;
   int _qty = 1;
 
@@ -42,21 +41,19 @@ class _DetalleProductoScreenState
           child: Column(
             mainAxisAlignment: MainAxisAlignment.center,
             children: [
-              const Icon(Icons.error_outline,
-                  size: 48, color: AppColors.error),
+              const Icon(Icons.error_outline, size: 48, color: AppColors.error),
               const SizedBox(height: 12),
               Text(
                 e.toString(),
                 textAlign: TextAlign.center,
-                style:
-                    const TextStyle(color: AppColors.lightTextSecondary),
+                style: const TextStyle(color: AppColors.lightTextSecondary),
               ),
               const SizedBox(height: 16),
               FilledButton(
                 onPressed: () =>
                     ref.invalidate(productDetailProvider(widget.productId)),
-                style: FilledButton.styleFrom(
-                    backgroundColor: AppColors.primary),
+                style:
+                    FilledButton.styleFrom(backgroundColor: AppColors.primary),
                 child: const Text('Reintentar'),
               ),
             ],
@@ -81,9 +78,7 @@ class _DetalleProductoScreenState
                   ),
                   alignment: Alignment.center,
                   child: Text(
-                    item.title.isNotEmpty
-                        ? item.title[0].toUpperCase()
-                        : '?',
+                    item.title.isNotEmpty ? item.title[0].toUpperCase() : '?',
                     style: const TextStyle(
                       fontSize: 72,
                       fontWeight: FontWeight.bold,
@@ -115,12 +110,9 @@ class _DetalleProductoScreenState
                   spacing: 8,
                   runSpacing: 4,
                   children: [
+                    _Badge(label: item.category.label, color: AppColors.info),
                     _Badge(
-                        label: item.category.label,
-                        color: AppColors.info),
-                    _Badge(
-                        label: item.programa.label,
-                        color: AppColors.secondary),
+                        label: item.programa.label, color: AppColors.secondary),
                   ],
                 ),
                 const SizedBox(height: 16),
@@ -257,15 +249,13 @@ class _DetalleProductoScreenState
                       backgroundColor: maxQty > 0
                           ? AppColors.primary
                           : AppColors.lightTextTertiary,
-                      padding:
-                          const EdgeInsets.symmetric(vertical: 16),
+                      padding: const EdgeInsets.symmetric(vertical: 16),
                       shape: RoundedRectangleBorder(
                         borderRadius: BorderRadius.circular(12),
                       ),
                     ),
-                    onPressed: maxQty > 0
-                        ? () => _addToCart(item, context)
-                        : null,
+                    onPressed:
+                        maxQty > 0 ? () => _addToCart(item, context) : null,
                   ),
                 ),
 

--- a/lib/features/materiales/presentation/screens/historial_screen.dart
+++ b/lib/features/materiales/presentation/screens/historial_screen.dart
@@ -1,0 +1,156 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../../../core/config/route_names.dart';
+import '../../../../core/theme/app_colors.dart';
+import '../providers/historial_provider.dart';
+import '../widgets/orden_card.dart';
+
+/// Pantalla de historial de pedidos del director.
+///
+/// Lista las órdenes propias del usuario ordenadas por fecha (más reciente
+/// primero). Soporta pull-to-refresh y tiene estado vacío.
+class HistorialScreen extends ConsumerWidget {
+  const HistorialScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final historialAsync = ref.watch(historialProvider);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Mis pedidos'),
+      ),
+      body: historialAsync.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (e, _) => _ErrorBody(
+          message: e.toString(),
+          onRetry: () => ref.invalidate(historialProvider),
+        ),
+        data: (ordenes) {
+          if (ordenes.isEmpty) {
+            return _EmptyHistorial(
+              onGoCatalog: () => context.go(RouteNames.homeMateriales),
+            );
+          }
+
+          return RefreshIndicator(
+            onRefresh: () async => ref.invalidate(historialProvider),
+            child: ListView.separated(
+              padding: const EdgeInsets.all(16),
+              itemCount: ordenes.length,
+              separatorBuilder: (_, __) => const SizedBox(height: 12),
+              itemBuilder: (context, index) {
+                final orden = ordenes[index];
+                return OrdenCard(
+                  orden: orden,
+                  onTap: () {
+                    final key = orden.folioReferencia ?? orden.id;
+                    context.push(RouteNames.materialesOrdenDetail(key));
+                  },
+                );
+              },
+            ),
+          );
+        },
+      ),
+    );
+  }
+}
+
+// ── Sub-widgets ────────────────────────────────────────────────────────────────
+
+class _EmptyHistorial extends StatelessWidget {
+  final VoidCallback onGoCatalog;
+  const _EmptyHistorial({required this.onGoCatalog});
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(32),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            const Icon(
+              Icons.receipt_long_outlined,
+              size: 72,
+              color: AppColors.lightTextTertiary,
+            ),
+            const SizedBox(height: 16),
+            const Text(
+              'Aún no has realizado pedidos',
+              style: TextStyle(
+                fontSize: 18,
+                fontWeight: FontWeight.w600,
+                color: AppColors.lightTextSecondary,
+              ),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 8),
+            const Text(
+              'Explorá el catálogo y hacé tu primer pedido.',
+              style: TextStyle(color: AppColors.lightTextTertiary),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 24),
+            FilledButton.icon(
+              style: FilledButton.styleFrom(
+                backgroundColor: AppColors.primary,
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(12),
+                ),
+              ),
+              icon: const Icon(Icons.storefront_outlined),
+              label: const Text('Ir al catálogo'),
+              onPressed: onGoCatalog,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _ErrorBody extends StatelessWidget {
+  final String message;
+  final VoidCallback onRetry;
+  const _ErrorBody({required this.message, required this.onRetry});
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(32),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            const Icon(
+              Icons.error_outline,
+              size: 48,
+              color: AppColors.lightTextTertiary,
+            ),
+            const SizedBox(height: 12),
+            Text(
+              'No se pudo cargar el historial',
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+            const SizedBox(height: 8),
+            Text(
+              message,
+              style: const TextStyle(color: AppColors.lightTextSecondary),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 24),
+            OutlinedButton.icon(
+              icon: const Icon(Icons.refresh),
+              label: const Text('Reintentar'),
+              onPressed: onRetry,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/materiales/presentation/screens/orden_review_screen.dart
+++ b/lib/features/materiales/presentation/screens/orden_review_screen.dart
@@ -50,8 +50,7 @@ class _OrdenReviewScreenState extends ConsumerState<OrdenReviewScreen> {
         loading: () => const Center(child: CircularProgressIndicator()),
         error: (e, _) => _ErrorBody(
           message: e.toString(),
-          onRetry: () =>
-              ref.invalidate(ordenDetailProvider(widget.folioOrId)),
+          onRetry: () => ref.invalidate(ordenDetailProvider(widget.folioOrId)),
         ),
         data: (orden) => _OrdenBody(orden: orden),
       ),
@@ -70,8 +69,8 @@ class _OrdenBody extends ConsumerWidget {
     final theme = Theme.of(context);
 
     return RefreshIndicator(
-      onRefresh: () async =>
-          ref.invalidate(ordenDetailProvider(orden.folioReferencia ?? orden.id)),
+      onRefresh: () async => ref
+          .invalidate(ordenDetailProvider(orden.folioReferencia ?? orden.id)),
       child: ListView(
         padding: const EdgeInsets.fromLTRB(16, 16, 16, 32),
         children: [
@@ -189,8 +188,7 @@ class _OrdenBody extends ConsumerWidget {
               orden.estado == MaterialEstado.entregada) ...[
             _SectionHeader(title: 'Comprobantes'),
             const SizedBox(height: 8),
-            _ComprobantesSection(
-                folioOrId: orden.folioReferencia ?? orden.id),
+            _ComprobantesSection(folioOrId: orden.folioReferencia ?? orden.id),
             const SizedBox(height: 24),
           ],
 
@@ -261,8 +259,8 @@ class _ActionCard extends ConsumerWidget {
               decoration: BoxDecoration(
                 color: AppColors.accentLight,
                 borderRadius: BorderRadius.circular(12),
-                border: Border.all(
-                    color: AppColors.accent.withValues(alpha: 0.3)),
+                border:
+                    Border.all(color: AppColors.accent.withValues(alpha: 0.3)),
               ),
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
@@ -635,7 +633,8 @@ class _TotalRow extends StatelessWidget {
         Text(
           label,
           style: isTotal
-              ? theme.textTheme.titleSmall?.copyWith(fontWeight: FontWeight.w700)
+              ? theme.textTheme.titleSmall
+                  ?.copyWith(fontWeight: FontWeight.w700)
               : theme.textTheme.bodyMedium?.copyWith(
                   color: AppColors.lightTextSecondary,
                 ),
@@ -694,7 +693,8 @@ class _ComprobantesSection extends ConsumerWidget {
           children: [
             for (int i = 0; i < comprobantes.length; i++)
               Padding(
-                padding: EdgeInsets.only(bottom: i < comprobantes.length - 1 ? 8 : 0),
+                padding: EdgeInsets.only(
+                    bottom: i < comprobantes.length - 1 ? 8 : 0),
                 child: _ComprobanteCard(comprobante: comprobantes[i]),
               ),
           ],

--- a/lib/features/materiales/presentation/screens/orden_review_screen.dart
+++ b/lib/features/materiales/presentation/screens/orden_review_screen.dart
@@ -4,10 +4,13 @@ import 'package:go_router/go_router.dart';
 
 import '../../../../core/config/route_names.dart';
 import '../../../../core/theme/app_colors.dart';
+import '../../domain/entities/comprobante.dart';
+import '../../domain/entities/material_comprobante_status.dart';
 import '../../domain/entities/material_estado.dart';
 import '../../domain/entities/orden.dart';
 import '../../domain/entities/orden_line.dart';
 import '../providers/cancel_order_provider.dart';
+import '../providers/comprobantes_provider.dart';
 import '../providers/orden_detail_provider.dart';
 import '../utils/money_format.dart';
 import '../widgets/material_estado_badge.dart';
@@ -180,6 +183,17 @@ class _OrdenBody extends ConsumerWidget {
 
           const SizedBox(height: 24),
 
+          // ── Comprobantes (aprobada / pagada / entregada) ───────────────────
+          if (orden.estado == MaterialEstado.aprobada ||
+              orden.estado == MaterialEstado.pagada ||
+              orden.estado == MaterialEstado.entregada) ...[
+            _SectionHeader(title: 'Comprobantes'),
+            const SizedBox(height: 8),
+            _ComprobantesSection(
+                folioOrId: orden.folioReferencia ?? orden.id),
+            const SizedBox(height: 24),
+          ],
+
           // ── Acción según estado ────────────────────────────────────────────
           _ActionCard(orden: orden),
         ],
@@ -269,7 +283,7 @@ class _ActionCard extends ConsumerWidget {
                   ),
                   const SizedBox(height: 6),
                   Text(
-                    'Tu pedido fue aprobado. El campo local te enviará los datos de pago.',
+                    'Tu pedido fue aprobado. Realizá la transferencia y subí el comprobante.',
                     style: theme.textTheme.bodySmall?.copyWith(
                       color: AppColors.accentDark,
                     ),
@@ -277,9 +291,25 @@ class _ActionCard extends ConsumerWidget {
                 ],
               ),
             ),
-            // TODO(PR13): replace with datos_pago route when available.
             const SizedBox(height: 12),
-            FilledButton(
+            OutlinedButton.icon(
+              style: OutlinedButton.styleFrom(
+                foregroundColor: AppColors.primary,
+                side: const BorderSide(color: AppColors.primary),
+                padding: const EdgeInsets.symmetric(vertical: 14),
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(12),
+                ),
+              ),
+              icon: const Icon(Icons.account_balance_outlined),
+              label: const Text('Ver datos de pago'),
+              onPressed: () => context.push(
+                RouteNames.materialesOrdenPago(
+                    orden.folioReferencia ?? orden.id),
+              ),
+            ),
+            const SizedBox(height: 8),
+            FilledButton.icon(
               style: FilledButton.styleFrom(
                 backgroundColor: AppColors.primary,
                 padding: const EdgeInsets.symmetric(vertical: 14),
@@ -287,8 +317,12 @@ class _ActionCard extends ConsumerWidget {
                   borderRadius: BorderRadius.circular(12),
                 ),
               ),
-              onPressed: null, // disabled until PR13
-              child: const Text('Subir comprobante de pago (próximamente)'),
+              icon: const Icon(Icons.upload_file_outlined),
+              label: const Text('Subir comprobante'),
+              onPressed: () => context.push(
+                RouteNames.materialesOrdenComprobante(
+                    orden.folioReferencia ?? orden.id),
+              ),
             ),
           ],
         );
@@ -618,6 +652,180 @@ class _TotalRow extends StatelessWidget {
                 ),
         ),
       ],
+    );
+  }
+}
+
+// ── Comprobantes section ───────────────────────────────────────────────────────
+
+/// Sección que muestra la lista de comprobantes de una orden.
+/// Usa [comprobantesProvider] para cargarlos de forma lazy.
+class _ComprobantesSection extends ConsumerWidget {
+  final String folioOrId;
+  const _ComprobantesSection({required this.folioOrId});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final comprobantesAsync = ref.watch(comprobantesProvider(folioOrId));
+
+    return comprobantesAsync.when(
+      loading: () => const Center(
+        child: Padding(
+          padding: EdgeInsets.all(16),
+          child: CircularProgressIndicator(),
+        ),
+      ),
+      error: (e, _) => const SizedBox.shrink(),
+      data: (comprobantes) {
+        if (comprobantes.isEmpty) {
+          return Container(
+            padding: const EdgeInsets.all(12),
+            decoration: BoxDecoration(
+              color: AppColors.ink100,
+              borderRadius: BorderRadius.circular(8),
+            ),
+            child: const Text(
+              'No hay comprobantes subidos aún.',
+              style: TextStyle(color: AppColors.lightTextSecondary),
+            ),
+          );
+        }
+        return Column(
+          children: [
+            for (int i = 0; i < comprobantes.length; i++)
+              Padding(
+                padding: EdgeInsets.only(bottom: i < comprobantes.length - 1 ? 8 : 0),
+                child: _ComprobanteCard(comprobante: comprobantes[i]),
+              ),
+          ],
+        );
+      },
+    );
+  }
+}
+
+class _ComprobanteCard extends StatelessWidget {
+  final Comprobante comprobante;
+  const _ComprobanteCard({required this.comprobante});
+
+  Color get _statusColor {
+    switch (comprobante.status) {
+      case MaterialComprobanteStatus.aprobado:
+        return AppColors.secondaryDark;
+      case MaterialComprobanteStatus.rechazado:
+        return AppColors.errorDark;
+      case MaterialComprobanteStatus.pendiente:
+        return AppColors.accentDark;
+    }
+  }
+
+  Color get _statusBg {
+    switch (comprobante.status) {
+      case MaterialComprobanteStatus.aprobado:
+        return AppColors.secondaryLight;
+      case MaterialComprobanteStatus.rechazado:
+        return AppColors.errorLight;
+      case MaterialComprobanteStatus.pendiente:
+        return AppColors.accentLight;
+    }
+  }
+
+  String get _statusLabel {
+    switch (comprobante.status) {
+      case MaterialComprobanteStatus.aprobado:
+        return 'Aprobado';
+      case MaterialComprobanteStatus.rechazado:
+        return 'Rechazado';
+      case MaterialComprobanteStatus.pendiente:
+        return 'Pendiente';
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Card(
+      elevation: 0,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(12),
+        side: const BorderSide(color: AppColors.lightBorder),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(12),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                const Icon(Icons.insert_drive_file_outlined,
+                    size: 18, color: AppColors.lightTextSecondary),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: Text(
+                    comprobante.fileName,
+                    style: theme.textTheme.bodyMedium?.copyWith(
+                      fontWeight: FontWeight.w600,
+                    ),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ),
+                const SizedBox(width: 8),
+                Container(
+                  padding:
+                      const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+                  decoration: BoxDecoration(
+                    color: _statusBg,
+                    borderRadius: BorderRadius.circular(100),
+                  ),
+                  child: Text(
+                    _statusLabel,
+                    style: TextStyle(
+                      fontSize: 11,
+                      fontWeight: FontWeight.w600,
+                      color: _statusColor,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 6),
+            Text(
+              formatMxn(comprobante.montoCentavos),
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: AppColors.lightTextSecondary,
+              ),
+            ),
+            if (comprobante.rejectReason != null &&
+                comprobante.rejectReason!.isNotEmpty) ...[
+              const SizedBox(height: 6),
+              Container(
+                padding: const EdgeInsets.all(8),
+                decoration: BoxDecoration(
+                  color: AppColors.errorLight,
+                  borderRadius: BorderRadius.circular(6),
+                ),
+                child: Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    const Icon(Icons.info_outline,
+                        size: 14, color: AppColors.errorDark),
+                    const SizedBox(width: 6),
+                    Expanded(
+                      child: Text(
+                        comprobante.rejectReason!,
+                        style: theme.textTheme.bodySmall?.copyWith(
+                          color: AppColors.errorDark,
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ],
+        ),
+      ),
     );
   }
 }

--- a/lib/features/materiales/presentation/screens/orden_review_screen.dart
+++ b/lib/features/materiales/presentation/screens/orden_review_screen.dart
@@ -1,0 +1,662 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../../../core/config/route_names.dart';
+import '../../../../core/theme/app_colors.dart';
+import '../../domain/entities/material_estado.dart';
+import '../../domain/entities/orden.dart';
+import '../../domain/entities/orden_line.dart';
+import '../providers/cancel_order_provider.dart';
+import '../providers/orden_detail_provider.dart';
+import '../utils/money_format.dart';
+import '../widgets/material_estado_badge.dart';
+
+/// Pantalla de revisión de una orden por folio o ID.
+///
+/// Muestra el estado actual, las líneas, los totales y las acciones
+/// disponibles según el estado (cancelar, enlace a pago, etc.).
+class OrdenReviewScreen extends ConsumerStatefulWidget {
+  final String folioOrId;
+
+  const OrdenReviewScreen({super.key, required this.folioOrId});
+
+  @override
+  ConsumerState<OrdenReviewScreen> createState() => _OrdenReviewScreenState();
+}
+
+class _OrdenReviewScreenState extends ConsumerState<OrdenReviewScreen> {
+  @override
+  Widget build(BuildContext context) {
+    final ordenAsync = ref.watch(ordenDetailProvider(widget.folioOrId));
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Detalle del pedido'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.refresh),
+            tooltip: 'Actualizar',
+            onPressed: () => ref.invalidate(
+              ordenDetailProvider(widget.folioOrId),
+            ),
+          ),
+        ],
+      ),
+      body: ordenAsync.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (e, _) => _ErrorBody(
+          message: e.toString(),
+          onRetry: () =>
+              ref.invalidate(ordenDetailProvider(widget.folioOrId)),
+        ),
+        data: (orden) => _OrdenBody(orden: orden),
+      ),
+    );
+  }
+}
+
+// ── Body when data loaded ──────────────────────────────────────────────────────
+
+class _OrdenBody extends ConsumerWidget {
+  final Orden orden;
+  const _OrdenBody({required this.orden});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final theme = Theme.of(context);
+
+    return RefreshIndicator(
+      onRefresh: () async =>
+          ref.invalidate(ordenDetailProvider(orden.folioReferencia ?? orden.id)),
+      child: ListView(
+        padding: const EdgeInsets.fromLTRB(16, 16, 16, 32),
+        children: [
+          // ── Estado + folio ─────────────────────────────────────────────────
+          Row(
+            children: [
+              MaterialEstadoBadge(estado: orden.estado),
+              const SizedBox(width: 12),
+              if (orden.folioReferencia != null)
+                _FolioPill(folio: orden.folioReferencia!)
+              else
+                _FolioPill(folio: '—'),
+            ],
+          ),
+          const SizedBox(height: 8),
+          Text(
+            'Creado el ${_formatDate(orden.createdAt)}',
+            style: theme.textTheme.bodySmall?.copyWith(
+              color: AppColors.lightTextSecondary,
+            ),
+          ),
+
+          // ── Banner en_revision ─────────────────────────────────────────────
+          if (orden.estado == MaterialEstado.enRevision) ...[
+            const SizedBox(height: 16),
+            Container(
+              padding: const EdgeInsets.all(12),
+              decoration: BoxDecoration(
+                color: AppColors.statusInfoBgLight,
+                borderRadius: BorderRadius.circular(8),
+                border: Border.all(color: AppColors.statusInfoText, width: 0.5),
+              ),
+              child: Row(
+                children: [
+                  const Icon(Icons.info_outline,
+                      size: 16, color: AppColors.statusInfoText),
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: Text(
+                      'Solicitud en revisión por el campo local.',
+                      style: theme.textTheme.bodySmall?.copyWith(
+                        color: AppColors.statusInfoText,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
+
+          const SizedBox(height: 24),
+
+          // ── Líneas ─────────────────────────────────────────────────────────
+          _SectionHeader(title: 'Productos'),
+          const SizedBox(height: 8),
+          Card(
+            elevation: 0,
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(12),
+              side: const BorderSide(color: AppColors.lightBorder),
+            ),
+            child: Column(
+              children: [
+                for (int i = 0; i < orden.lines.length; i++) ...[
+                  if (i > 0)
+                    const Divider(height: 1, indent: 16, endIndent: 16),
+                  _OrdenLineItem(line: orden.lines[i]),
+                ],
+              ],
+            ),
+          ),
+
+          const SizedBox(height: 24),
+
+          // ── Totales ────────────────────────────────────────────────────────
+          _SectionHeader(title: 'Totales'),
+          const SizedBox(height: 8),
+          Card(
+            elevation: 0,
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(12),
+              side: const BorderSide(color: AppColors.lightBorder),
+            ),
+            child: Padding(
+              padding: const EdgeInsets.all(16),
+              child: Column(
+                children: [
+                  _TotalRow(
+                    label: 'Subtotal',
+                    amount: orden.subtotalCentavos,
+                    isTotal: false,
+                  ),
+                  const SizedBox(height: 6),
+                  _TotalRow(
+                    label: 'Envío',
+                    amount: orden.envioCentavos,
+                    isTotal: false,
+                  ),
+                  const Divider(height: 16),
+                  _TotalRow(
+                    label: 'Total',
+                    amount: orden.totalCentavos,
+                    isTotal: true,
+                  ),
+                ],
+              ),
+            ),
+          ),
+
+          const SizedBox(height: 24),
+
+          // ── Acción según estado ────────────────────────────────────────────
+          _ActionCard(orden: orden),
+        ],
+      ),
+    );
+  }
+
+  String _formatDate(DateTime dt) {
+    return '${dt.day.toString().padLeft(2, '0')}/'
+        '${dt.month.toString().padLeft(2, '0')}/'
+        '${dt.year}';
+  }
+}
+
+// ── Action card ────────────────────────────────────────────────────────────────
+
+class _ActionCard extends ConsumerWidget {
+  final Orden orden;
+  const _ActionCard({required this.orden});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final theme = Theme.of(context);
+    final cancelState = ref.watch(cancelOrderProvider);
+
+    switch (orden.estado) {
+      case MaterialEstado.enRevision:
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            OutlinedButton.icon(
+              style: OutlinedButton.styleFrom(
+                foregroundColor: AppColors.error,
+                side: const BorderSide(color: AppColors.error),
+                padding: const EdgeInsets.symmetric(vertical: 14),
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(12),
+                ),
+              ),
+              icon: cancelState.isLoading
+                  ? const SizedBox(
+                      width: 16,
+                      height: 16,
+                      child: CircularProgressIndicator(
+                        strokeWidth: 2,
+                        valueColor:
+                            AlwaysStoppedAnimation<Color>(AppColors.error),
+                      ),
+                    )
+                  : const Icon(Icons.cancel_outlined),
+              label: const Text('Cancelar pedido'),
+              onPressed: cancelState.isLoading
+                  ? null
+                  : () => _confirmCancel(context, ref),
+            ),
+          ],
+        );
+
+      case MaterialEstado.aprobada:
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Container(
+              padding: const EdgeInsets.all(16),
+              decoration: BoxDecoration(
+                color: AppColors.accentLight,
+                borderRadius: BorderRadius.circular(12),
+                border: Border.all(
+                    color: AppColors.accent.withValues(alpha: 0.3)),
+              ),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Row(
+                    children: [
+                      const Icon(Icons.check_circle_outline,
+                          color: AppColors.accentDark, size: 20),
+                      const SizedBox(width: 8),
+                      Text(
+                        'Pedido aprobado',
+                        style: theme.textTheme.titleSmall?.copyWith(
+                          fontWeight: FontWeight.w700,
+                          color: AppColors.accentDark,
+                        ),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 6),
+                  Text(
+                    'Tu pedido fue aprobado. El campo local te enviará los datos de pago.',
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: AppColors.accentDark,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            // TODO(PR13): replace with datos_pago route when available.
+            const SizedBox(height: 12),
+            FilledButton(
+              style: FilledButton.styleFrom(
+                backgroundColor: AppColors.primary,
+                padding: const EdgeInsets.symmetric(vertical: 14),
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(12),
+                ),
+              ),
+              onPressed: null, // disabled until PR13
+              child: const Text('Subir comprobante de pago (próximamente)'),
+            ),
+          ],
+        );
+
+      case MaterialEstado.pagada:
+        return Container(
+          padding: const EdgeInsets.all(16),
+          decoration: BoxDecoration(
+            color: AppColors.secondaryLight,
+            borderRadius: BorderRadius.circular(12),
+            border:
+                Border.all(color: AppColors.secondary.withValues(alpha: 0.3)),
+          ),
+          child: Row(
+            children: [
+              const Icon(Icons.hourglass_bottom,
+                  color: AppColors.secondaryDark, size: 20),
+              const SizedBox(width: 8),
+              Expanded(
+                child: Text(
+                  'Pago validado. Esperando entrega.',
+                  style: theme.textTheme.bodyMedium?.copyWith(
+                    color: AppColors.secondaryDark,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+              ),
+            ],
+          ),
+        );
+
+      case MaterialEstado.entregada:
+        return Container(
+          padding: const EdgeInsets.all(20),
+          decoration: BoxDecoration(
+            color: AppColors.secondaryLight,
+            borderRadius: BorderRadius.circular(12),
+          ),
+          child: Column(
+            children: [
+              const Icon(Icons.check_circle,
+                  color: AppColors.secondaryDark, size: 40),
+              const SizedBox(height: 8),
+              Text(
+                'Tu pedido fue entregado',
+                style: theme.textTheme.titleMedium?.copyWith(
+                  fontWeight: FontWeight.w700,
+                  color: AppColors.secondaryDark,
+                ),
+                textAlign: TextAlign.center,
+              ),
+            ],
+          ),
+        );
+
+      case MaterialEstado.cancelada:
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            if (orden.cancelReason != null)
+              Container(
+                padding: const EdgeInsets.all(12),
+                decoration: BoxDecoration(
+                  color: AppColors.errorLight,
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      'Motivo de cancelación',
+                      style: theme.textTheme.labelSmall?.copyWith(
+                        color: AppColors.errorDark,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                    const SizedBox(height: 4),
+                    Text(
+                      orden.cancelReason!,
+                      style: theme.textTheme.bodySmall?.copyWith(
+                        color: AppColors.errorDark,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            const SizedBox(height: 12),
+            OutlinedButton(
+              style: OutlinedButton.styleFrom(
+                foregroundColor: AppColors.primary,
+                side: const BorderSide(color: AppColors.primary),
+                padding: const EdgeInsets.symmetric(vertical: 14),
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(12),
+                ),
+              ),
+              onPressed: () => context.go(RouteNames.homeMateriales),
+              child: const Text('Hacer un nuevo pedido'),
+            ),
+          ],
+        );
+    }
+  }
+
+  Future<void> _confirmCancel(BuildContext context, WidgetRef ref) async {
+    final reasonController = TextEditingController();
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('Cancelar pedido'),
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Text('¿Estás seguro de que querés cancelar este pedido?'),
+            const SizedBox(height: 12),
+            TextField(
+              controller: reasonController,
+              decoration: const InputDecoration(
+                labelText: 'Motivo (requerido)',
+                border: OutlineInputBorder(),
+              ),
+              maxLines: 2,
+            ),
+          ],
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(false),
+            child: const Text('Volver'),
+          ),
+          FilledButton(
+            style: FilledButton.styleFrom(backgroundColor: AppColors.error),
+            onPressed: () => Navigator.of(ctx).pop(true),
+            child: const Text('Cancelar pedido'),
+          ),
+        ],
+      ),
+    );
+
+    if (confirmed != true || !context.mounted) return;
+
+    final reason = reasonController.text.trim();
+    if (reason.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Ingresá un motivo de cancelación.')),
+      );
+      return;
+    }
+
+    final result = await ref.read(cancelOrderProvider.notifier).cancel(
+          folioOrId: orden.folioReferencia ?? orden.id,
+          reason: reason,
+        );
+
+    if (!context.mounted) return;
+
+    result.fold(
+      (failure) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(failure.message),
+            backgroundColor: AppColors.error,
+          ),
+        );
+      },
+      (_) {
+        ref.invalidate(ordenDetailProvider(orden.folioReferencia ?? orden.id));
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Pedido cancelado.')),
+        );
+      },
+    );
+  }
+}
+
+// ── Supporting widgets ─────────────────────────────────────────────────────────
+
+class _FolioPill extends StatelessWidget {
+  final String folio;
+  const _FolioPill({required this.folio});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+      decoration: BoxDecoration(
+        color: AppColors.ink100,
+        borderRadius: BorderRadius.circular(100),
+      ),
+      child: Text(
+        folio,
+        style: const TextStyle(
+          fontSize: 12,
+          fontWeight: FontWeight.w600,
+          color: AppColors.ink600,
+          fontFamily: 'monospace',
+        ),
+      ),
+    );
+  }
+}
+
+class _SectionHeader extends StatelessWidget {
+  final String title;
+  const _SectionHeader({required this.title});
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(
+      title,
+      style: Theme.of(context).textTheme.titleSmall?.copyWith(
+            fontWeight: FontWeight.w700,
+            color: AppColors.lightText,
+          ),
+    );
+  }
+}
+
+class _OrdenLineItem extends StatelessWidget {
+  final OrdenLine line;
+  const _OrdenLineItem({required this.line});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // Letter placeholder
+          Container(
+            width: 40,
+            height: 40,
+            decoration: BoxDecoration(
+              color: AppColors.primarySurface,
+              borderRadius: BorderRadius.circular(6),
+            ),
+            alignment: Alignment.center,
+            child: Text(
+              line.product.title.isNotEmpty
+                  ? line.product.title[0].toUpperCase()
+                  : '?',
+              style: const TextStyle(
+                fontSize: 16,
+                fontWeight: FontWeight.bold,
+                color: AppColors.primary,
+              ),
+            ),
+          ),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  line.product.title,
+                  style: theme.textTheme.bodyMedium?.copyWith(
+                    fontWeight: FontWeight.w600,
+                  ),
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                ),
+                Text(
+                  line.product.sku,
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: AppColors.lightTextTertiary,
+                  ),
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  '${line.qty} × ${formatMxn(line.priceCentavos)}',
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: AppColors.lightTextSecondary,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(width: 8),
+          Text(
+            formatMxn(line.lineTotalCentavos),
+            style: theme.textTheme.bodyMedium?.copyWith(
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _TotalRow extends StatelessWidget {
+  final String label;
+  final int amount;
+  final bool isTotal;
+  const _TotalRow({
+    required this.label,
+    required this.amount,
+    required this.isTotal,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      children: [
+        Text(
+          label,
+          style: isTotal
+              ? theme.textTheme.titleSmall?.copyWith(fontWeight: FontWeight.w700)
+              : theme.textTheme.bodyMedium?.copyWith(
+                  color: AppColors.lightTextSecondary,
+                ),
+        ),
+        Text(
+          formatMxn(amount),
+          style: isTotal
+              ? theme.textTheme.titleSmall?.copyWith(
+                  fontWeight: FontWeight.bold,
+                  color: AppColors.primary,
+                )
+              : theme.textTheme.bodyMedium?.copyWith(
+                  color: AppColors.lightTextSecondary,
+                ),
+        ),
+      ],
+    );
+  }
+}
+
+class _ErrorBody extends StatelessWidget {
+  final String message;
+  final VoidCallback onRetry;
+  const _ErrorBody({required this.message, required this.onRetry});
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(32),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            const Icon(Icons.error_outline,
+                size: 48, color: AppColors.lightTextTertiary),
+            const SizedBox(height: 12),
+            Text(
+              'No se pudo cargar el pedido',
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+            const SizedBox(height: 8),
+            Text(
+              message,
+              style: const TextStyle(color: AppColors.lightTextSecondary),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 24),
+            OutlinedButton.icon(
+              icon: const Icon(Icons.refresh),
+              label: const Text('Reintentar'),
+              onPressed: onRetry,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/materiales/presentation/screens/resumen_screen.dart
+++ b/lib/features/materiales/presentation/screens/resumen_screen.dart
@@ -241,9 +241,8 @@ class _ResumenScreenState extends ConsumerState<ResumenScreen> {
                     borderRadius: BorderRadius.circular(12),
                   ),
                 ),
-                onPressed: createState.isLoading
-                    ? null
-                    : () => _confirm(context, ref),
+                onPressed:
+                    createState.isLoading ? null : () => _confirm(context, ref),
                 child: createState.isLoading
                     ? const SizedBox(
                         width: 20,

--- a/lib/features/materiales/presentation/screens/resumen_screen.dart
+++ b/lib/features/materiales/presentation/screens/resumen_screen.dart
@@ -1,0 +1,456 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../../../core/config/route_names.dart';
+import '../../../../core/theme/app_colors.dart';
+import '../../../../features/members/presentation/providers/members_providers.dart';
+import '../../domain/entities/material_entrega.dart';
+import '../providers/cart_provider.dart';
+import '../providers/config_provider.dart';
+import '../providers/create_order_provider.dart';
+import '../utils/money_format.dart';
+
+/// Pantalla de resumen y confirmación de pedido.
+///
+/// Muestra los datos de entrega, el listado de líneas del carrito (solo
+/// lectura), notas opcionales y el footer con totales + CTA de confirmación.
+class ResumenScreen extends ConsumerStatefulWidget {
+  const ResumenScreen({super.key});
+
+  @override
+  ConsumerState<ResumenScreen> createState() => _ResumenScreenState();
+}
+
+class _ResumenScreenState extends ConsumerState<ResumenScreen> {
+  MaterialEntrega _entrega = MaterialEntrega.recoger;
+  final _notasController = TextEditingController();
+
+  @override
+  void dispose() {
+    _notasController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final cart = ref.watch(cartProvider);
+
+    // Redirect to catalog if cart is empty (e.g. after a back navigation).
+    if (cart.lines.isEmpty) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted) context.go(RouteNames.homeMateriales);
+      });
+      return const Scaffold(body: Center(child: CircularProgressIndicator()));
+    }
+
+    final configAsync = ref.watch(configProvider);
+    final createState = ref.watch(createOrderProvider);
+    final theme = Theme.of(context);
+
+    final envioCentavos = _entrega == MaterialEntrega.envio
+        ? (configAsync.valueOrNull?.envioCentavosDefault ?? 0)
+        : 0;
+    final total = cart.subtotalCentavos + envioCentavos;
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Confirmar pedido'),
+      ),
+      body: ListView(
+        padding: const EdgeInsets.fromLTRB(16, 16, 16, 140),
+        children: [
+          // ── Subtitle ─────────────────────────────────────────────────────
+          Text(
+            'Revisá los datos antes de confirmar tu pedido.',
+            style: theme.textTheme.bodyMedium?.copyWith(
+              color: AppColors.lightTextSecondary,
+            ),
+          ),
+          const SizedBox(height: 24),
+
+          // ── Datos de entrega ──────────────────────────────────────────────
+          _SectionHeader(title: 'Datos de entrega'),
+          const SizedBox(height: 12),
+          Card(
+            elevation: 0,
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(12),
+              side: const BorderSide(color: AppColors.lightBorder),
+            ),
+            child: Padding(
+              padding: const EdgeInsets.all(16),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    'Modalidad',
+                    style: theme.textTheme.labelMedium?.copyWith(
+                      color: AppColors.lightTextSecondary,
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  Container(
+                    padding: const EdgeInsets.symmetric(horizontal: 12),
+                    decoration: BoxDecoration(
+                      border: Border.all(color: AppColors.lightBorder),
+                      borderRadius: BorderRadius.circular(8),
+                    ),
+                    child: DropdownButton<MaterialEntrega>(
+                      value: _entrega,
+                      isExpanded: true,
+                      underline: const SizedBox.shrink(),
+                      items: const [
+                        DropdownMenuItem(
+                          value: MaterialEntrega.recoger,
+                          child: Text('Recoger en campo'),
+                        ),
+                        DropdownMenuItem(
+                          value: MaterialEntrega.envio,
+                          child: Text('Envío a domicilio'),
+                        ),
+                      ],
+                      onChanged: (v) {
+                        if (v != null) setState(() => _entrega = v);
+                      },
+                    ),
+                  ),
+                  if (_entrega == MaterialEntrega.envio) ...[
+                    const SizedBox(height: 12),
+                    Container(
+                      padding: const EdgeInsets.all(12),
+                      decoration: BoxDecoration(
+                        color: AppColors.accentLight,
+                        borderRadius: BorderRadius.circular(8),
+                      ),
+                      child: Row(
+                        children: [
+                          const Icon(
+                            Icons.info_outline,
+                            size: 16,
+                            color: AppColors.accentDark,
+                          ),
+                          const SizedBox(width: 8),
+                          Expanded(
+                            child: Text(
+                              'El campo local coordinará los datos de envío tras aprobar el pedido.',
+                              style: theme.textTheme.bodySmall?.copyWith(
+                                color: AppColors.accentDark,
+                              ),
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ],
+                ],
+              ),
+            ),
+          ),
+          const SizedBox(height: 24),
+
+          // ── Resumen del pedido ────────────────────────────────────────────
+          _SectionHeader(title: 'Resumen del pedido'),
+          const SizedBox(height: 12),
+          Card(
+            elevation: 0,
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(12),
+              side: const BorderSide(color: AppColors.lightBorder),
+            ),
+            child: Column(
+              children: [
+                for (int i = 0; i < cart.lines.length; i++) ...[
+                  if (i > 0)
+                    const Divider(height: 1, indent: 16, endIndent: 16),
+                  _ResumenLineItem(line: cart.lines[i]),
+                ],
+              ],
+            ),
+          ),
+          const SizedBox(height: 24),
+
+          // ── Notas opcionales ──────────────────────────────────────────────
+          _SectionHeader(title: 'Notas (opcional)'),
+          const SizedBox(height: 12),
+          TextFormField(
+            controller: _notasController,
+            maxLines: 3,
+            decoration: InputDecoration(
+              hintText: 'Instrucciones especiales, observaciones…',
+              hintStyle: TextStyle(color: AppColors.lightTextTertiary),
+              border: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(12),
+                borderSide: const BorderSide(color: AppColors.lightBorder),
+              ),
+              enabledBorder: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(12),
+                borderSide: const BorderSide(color: AppColors.lightBorder),
+              ),
+              contentPadding: const EdgeInsets.all(12),
+            ),
+          ),
+        ],
+      ),
+
+      // ── Footer fijo con totales + CTA ─────────────────────────────────────
+      bottomSheet: Container(
+        width: double.infinity,
+        padding: const EdgeInsets.fromLTRB(20, 16, 20, 36),
+        decoration: BoxDecoration(
+          color: theme.scaffoldBackgroundColor,
+          border: const Border(
+            top: BorderSide(color: AppColors.lightBorder),
+          ),
+          boxShadow: const [
+            BoxShadow(
+              color: Color(0x14000000),
+              blurRadius: 12,
+              offset: Offset(0, -4),
+            ),
+          ],
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            _TotalRow(
+              label: 'Subtotal',
+              amount: cart.subtotalCentavos,
+              isTotal: false,
+            ),
+            const SizedBox(height: 4),
+            _TotalRow(
+              label: 'Costo de envío',
+              amount: envioCentavos,
+              isTotal: false,
+            ),
+            const Divider(height: 16),
+            _TotalRow(
+              label: 'Total',
+              amount: total,
+              isTotal: true,
+            ),
+            const SizedBox(height: 12),
+            SizedBox(
+              width: double.infinity,
+              child: FilledButton(
+                style: FilledButton.styleFrom(
+                  backgroundColor: AppColors.primary,
+                  padding: const EdgeInsets.symmetric(vertical: 16),
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(12),
+                  ),
+                ),
+                onPressed: createState.isLoading
+                    ? null
+                    : () => _confirm(context, ref),
+                child: createState.isLoading
+                    ? const SizedBox(
+                        width: 20,
+                        height: 20,
+                        child: CircularProgressIndicator(
+                          strokeWidth: 2,
+                          valueColor:
+                              AlwaysStoppedAnimation<Color>(Colors.white),
+                        ),
+                      )
+                    : const Text(
+                        'Confirmar pedido',
+                        style: TextStyle(
+                          fontSize: 16,
+                          fontWeight: FontWeight.w600,
+                        ),
+                      ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Future<void> _confirm(BuildContext context, WidgetRef ref) async {
+    final cart = ref.read(cartProvider);
+    if (cart.lines.isEmpty) return;
+
+    // Resolve club_section_id from the active club context.
+    // TODO(integration): If the user has no active club context this will
+    // be null. Using 0 as sentinel causes a 404 on the backend; surface a
+    // proper error in that case.
+    final clubCtx = await ref.read(clubContextProvider.future);
+    final clubSectionId = clubCtx?.sectionId ?? 0;
+
+    final lines = cart.lines
+        .map((l) => (
+              productId: l.productId,
+              variantOptionId: l.variantOptionId,
+              qty: l.qty,
+            ))
+        .toList();
+
+    final result = await ref.read(createOrderProvider.notifier).confirm(
+          clubSectionId: clubSectionId,
+          lines: lines,
+          entrega: _entrega,
+          notas: _notasController.text.trim().isEmpty
+              ? null
+              : _notasController.text.trim(),
+        );
+
+    if (!mounted) return;
+
+    result.fold(
+      (failure) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(failure.message),
+            backgroundColor: AppColors.error,
+          ),
+        );
+      },
+      (orden) {
+        ref.read(cartProvider.notifier).clear();
+        context.go(RouteNames.materialesOrdenDetail(orden.id));
+      },
+    );
+  }
+}
+
+// ── Sub-widgets ────────────────────────────────────────────────────────────────
+
+class _SectionHeader extends StatelessWidget {
+  final String title;
+  const _SectionHeader({required this.title});
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(
+      title,
+      style: Theme.of(context).textTheme.titleSmall?.copyWith(
+            fontWeight: FontWeight.w700,
+            color: AppColors.lightText,
+          ),
+    );
+  }
+}
+
+class _ResumenLineItem extends StatelessWidget {
+  final CartLine line;
+  const _ResumenLineItem({required this.line});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // Letter placeholder thumbnail
+          Container(
+            width: 40,
+            height: 40,
+            decoration: BoxDecoration(
+              color: AppColors.primarySurface,
+              borderRadius: BorderRadius.circular(6),
+            ),
+            alignment: Alignment.center,
+            child: Text(
+              line.productTitle.isNotEmpty
+                  ? line.productTitle[0].toUpperCase()
+                  : '?',
+              style: const TextStyle(
+                fontSize: 16,
+                fontWeight: FontWeight.bold,
+                color: AppColors.primary,
+              ),
+            ),
+          ),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  line.productTitle,
+                  style: theme.textTheme.bodyMedium?.copyWith(
+                    fontWeight: FontWeight.w600,
+                  ),
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                ),
+                if (line.variantLabel != null) ...[
+                  const SizedBox(height: 2),
+                  Text(
+                    line.variantLabel!,
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: AppColors.lightTextSecondary,
+                    ),
+                  ),
+                ],
+                const SizedBox(height: 4),
+                Text(
+                  '${line.qty} × ${formatMxn(line.priceSnapshotCentavos)}',
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: AppColors.lightTextSecondary,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(width: 8),
+          Text(
+            formatMxn(line.lineTotalCentavos),
+            style: theme.textTheme.bodyMedium?.copyWith(
+              fontWeight: FontWeight.bold,
+              color: AppColors.lightText,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _TotalRow extends StatelessWidget {
+  final String label;
+  final int amount;
+  final bool isTotal;
+
+  const _TotalRow({
+    required this.label,
+    required this.amount,
+    required this.isTotal,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      children: [
+        Text(
+          label,
+          style: isTotal
+              ? theme.textTheme.titleMedium?.copyWith(
+                  fontWeight: FontWeight.w700,
+                )
+              : theme.textTheme.bodyMedium?.copyWith(
+                  color: AppColors.lightTextSecondary,
+                ),
+        ),
+        Text(
+          formatMxn(amount),
+          style: isTotal
+              ? theme.textTheme.titleMedium?.copyWith(
+                  fontWeight: FontWeight.bold,
+                  color: AppColors.primary,
+                )
+              : theme.textTheme.bodyMedium?.copyWith(
+                  color: AppColors.lightTextSecondary,
+                ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/materiales/presentation/screens/subir_comprobante_screen.dart
+++ b/lib/features/materiales/presentation/screens/subir_comprobante_screen.dart
@@ -1,0 +1,480 @@
+import 'dart:io';
+
+import 'package:file_picker/file_picker.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../../../core/config/route_names.dart';
+import '../../../../core/theme/app_colors.dart';
+import '../providers/comprobantes_provider.dart';
+import '../providers/orden_detail_provider.dart';
+import '../widgets/price_input.dart';
+
+// ── Constantes de validación ──────────────────────────────────────────────────
+
+const int _maxFileSizeBytes = 10 * 1024 * 1024; // 10 MB
+const List<String> _allowedExtensions = ['pdf', 'jpg', 'jpeg', 'png'];
+
+/// Pantalla "Subir comprobante" — el director selecciona un archivo PDF o
+/// imagen de su comprobante bancario, rellena el monto, referencia y fecha
+/// y envía el formulario.
+///
+/// Ruta: /home/materiales/orden/:folio/comprobante
+class SubirComprobanteScreen extends ConsumerStatefulWidget {
+  final String folioOrId;
+
+  const SubirComprobanteScreen({super.key, required this.folioOrId});
+
+  @override
+  ConsumerState<SubirComprobanteScreen> createState() =>
+      _SubirComprobanteScreenState();
+}
+
+class _SubirComprobanteScreenState
+    extends ConsumerState<SubirComprobanteScreen> {
+  final _formKey = GlobalKey<FormState>();
+
+  File? _selectedFile;
+  String? _selectedFileName;
+  int? _selectedFileSizeBytes;
+  String? _fileError;
+
+  int _montoCentavos = 0;
+  final _refController = TextEditingController();
+  DateTime? _fechaPago;
+
+  @override
+  void dispose() {
+    _refController.dispose();
+    super.dispose();
+  }
+
+  // ── File picker ─────────────────────────────────────────────────────────────
+
+  Future<void> _pickFile() async {
+    final result = await FilePicker.platform.pickFiles(
+      type: FileType.custom,
+      allowedExtensions: _allowedExtensions,
+      allowMultiple: false,
+    );
+
+    if (result == null || result.files.isEmpty) return;
+
+    final pickedFile = result.files.first;
+    if (pickedFile.path == null) return;
+
+    final file = File(pickedFile.path!);
+    final sizeBytes = pickedFile.size;
+
+    // Client-side size validation (mirrors backend REQ-CMP-002)
+    if (sizeBytes > _maxFileSizeBytes) {
+      setState(() {
+        _selectedFile = null;
+        _selectedFileName = null;
+        _selectedFileSizeBytes = null;
+        _fileError = 'El archivo supera el límite de 10 MB.';
+      });
+      return;
+    }
+
+    setState(() {
+      _selectedFile = file;
+      _selectedFileName = pickedFile.name;
+      _selectedFileSizeBytes = sizeBytes;
+      _fileError = null;
+    });
+  }
+
+  // ── Date picker ─────────────────────────────────────────────────────────────
+
+  Future<void> _pickDate() async {
+    final now = DateTime.now();
+    final picked = await showDatePicker(
+      context: context,
+      initialDate: _fechaPago ?? now,
+      firstDate: DateTime(now.year - 1),
+      lastDate: now, // Cannot be a future date (Mexico TZ approximation)
+    );
+    if (picked != null) {
+      setState(() => _fechaPago = picked);
+    }
+  }
+
+  // ── Submit ───────────────────────────────────────────────────────────────────
+
+  Future<void> _submit() async {
+    // Validate file selection
+    if (_selectedFile == null) {
+      setState(() => _fileError = 'Seleccioná un archivo para continuar.');
+      return;
+    }
+
+    // Validate form fields
+    if (!_formKey.currentState!.validate()) return;
+
+    if (_fechaPago == null) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Seleccioná la fecha de pago.')),
+      );
+      return;
+    }
+
+    await ref.read(uploadComprobanteNotifierProvider.notifier).upload(
+          UploadComprobanteArgs(
+            folioOrId: widget.folioOrId,
+            file: _selectedFile!,
+            montoCentavos: _montoCentavos,
+            refBancariaDeclarada: _refController.text.trim(),
+            fechaPago: _fechaPago!,
+          ),
+        );
+  }
+
+  // ── Build ────────────────────────────────────────────────────────────────────
+
+  @override
+  Widget build(BuildContext context) {
+    final uploadState = ref.watch(uploadComprobanteNotifierProvider);
+
+    // React to success
+    ref.listen(uploadComprobanteNotifierProvider, (prev, next) {
+      if (next.result != null && prev?.result == null) {
+        // Invalidate the order detail so it refreshes
+        ref.invalidate(ordenDetailProvider(widget.folioOrId));
+        if (context.mounted) {
+          context.go(RouteNames.materialesOrdenDetail(widget.folioOrId));
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(
+              content: Text(
+                  'Comprobante enviado. El campo local lo validará pronto.'),
+              backgroundColor: AppColors.secondary,
+            ),
+          );
+        }
+      }
+      if (next.errorMessage != null && prev?.errorMessage == null) {
+        if (context.mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: Text(next.errorMessage!),
+              backgroundColor: AppColors.error,
+            ),
+          );
+        }
+      }
+    });
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Subir comprobante')),
+      body: uploadState.isLoading
+          ? _UploadProgress(progress: uploadState.progress)
+          : _FormBody(
+              formKey: _formKey,
+              selectedFileName: _selectedFileName,
+              selectedFileSizeBytes: _selectedFileSizeBytes,
+              fileError: _fileError,
+              fechaPago: _fechaPago,
+              refController: _refController,
+              onPickFile: _pickFile,
+              onPickDate: _pickDate,
+              onMontoChanged: (c) => _montoCentavos = c,
+              onSubmit: _submit,
+            ),
+    );
+  }
+}
+
+// ── Upload progress view ─────────────────────────────────────────────────────
+
+class _UploadProgress extends StatelessWidget {
+  final double progress;
+  const _UploadProgress({required this.progress});
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(32),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            const Icon(Icons.cloud_upload_outlined,
+                size: 56, color: AppColors.primary),
+            const SizedBox(height: 16),
+            Text(
+              'Enviando comprobante…',
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+            const SizedBox(height: 16),
+            LinearProgressIndicator(
+              value: progress > 0 ? progress : null,
+              backgroundColor: AppColors.primarySurface,
+              color: AppColors.primary,
+            ),
+            if (progress > 0) ...[
+              const SizedBox(height: 8),
+              Text(
+                '${(progress * 100).toStringAsFixed(0)}%',
+                style: const TextStyle(color: AppColors.lightTextSecondary),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+// ── Form body ────────────────────────────────────────────────────────────────
+
+class _FormBody extends StatelessWidget {
+  final GlobalKey<FormState> formKey;
+  final String? selectedFileName;
+  final int? selectedFileSizeBytes;
+  final String? fileError;
+  final DateTime? fechaPago;
+  final TextEditingController refController;
+  final VoidCallback onPickFile;
+  final VoidCallback onPickDate;
+  final ValueChanged<int> onMontoChanged;
+  final VoidCallback onSubmit;
+
+  const _FormBody({
+    required this.formKey,
+    required this.selectedFileName,
+    required this.selectedFileSizeBytes,
+    required this.fileError,
+    required this.fechaPago,
+    required this.refController,
+    required this.onPickFile,
+    required this.onPickDate,
+    required this.onMontoChanged,
+    required this.onSubmit,
+  });
+
+  String _formatFileSize(int bytes) {
+    if (bytes < 1024) return '${bytes}B';
+    if (bytes < 1024 * 1024) return '${(bytes / 1024).toStringAsFixed(1)}KB';
+    return '${(bytes / (1024 * 1024)).toStringAsFixed(1)}MB';
+  }
+
+  String _formatDate(DateTime dt) =>
+      '${dt.day.toString().padLeft(2, '0')}/${dt.month.toString().padLeft(2, '0')}/${dt.year}';
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Form(
+      key: formKey,
+      child: ListView(
+        padding: const EdgeInsets.fromLTRB(16, 16, 16, 32),
+        children: [
+          // ── File picker area ─────────────────────────────────────────────────
+          _SectionLabel(label: 'Archivo del comprobante'),
+          const SizedBox(height: 8),
+          if (selectedFileName == null)
+            OutlinedButton.icon(
+              style: OutlinedButton.styleFrom(
+                padding: const EdgeInsets.symmetric(vertical: 16),
+                side: BorderSide(
+                  color:
+                      fileError != null ? AppColors.error : AppColors.primary,
+                ),
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(12),
+                ),
+              ),
+              icon: const Icon(Icons.attach_file),
+              label: const Text('Seleccionar archivo (PDF, JPG, PNG)'),
+              onPressed: onPickFile,
+            )
+          else
+            _FilePreview(
+              fileName: selectedFileName!,
+              fileSize: _formatFileSize(selectedFileSizeBytes ?? 0),
+              onReplace: onPickFile,
+            ),
+          if (fileError != null) ...[
+            const SizedBox(height: 4),
+            Text(
+              fileError!,
+              style: theme.textTheme.bodySmall
+                  ?.copyWith(color: AppColors.error),
+            ),
+          ],
+
+          const SizedBox(height: 20),
+
+          // ── Monto pagado ─────────────────────────────────────────────────────
+          _SectionLabel(label: 'Monto pagado'),
+          const SizedBox(height: 8),
+          PriceInput(
+            label: 'Monto pagado',
+            hint: '0.00',
+            onChanged: onMontoChanged,
+          ),
+
+          const SizedBox(height: 20),
+
+          // ── Referencia bancaria ──────────────────────────────────────────────
+          _SectionLabel(label: 'Referencia / Concepto que escribiste'),
+          const SizedBox(height: 8),
+          TextFormField(
+            controller: refController,
+            decoration: const InputDecoration(
+              labelText: 'Concepto de la transferencia',
+              hintText: 'Ej: SOL20260001',
+              border: OutlineInputBorder(),
+            ),
+            validator: (value) {
+              if (value == null || value.trim().isEmpty) {
+                return 'Ingresá la referencia que usaste.';
+              }
+              return null;
+            },
+          ),
+
+          const SizedBox(height: 20),
+
+          // ── Fecha de pago ─────────────────────────────────────────────────────
+          _SectionLabel(label: 'Fecha de pago'),
+          const SizedBox(height: 8),
+          GestureDetector(
+            onTap: onPickDate,
+            child: Container(
+              padding:
+                  const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
+              decoration: BoxDecoration(
+                border: Border.all(color: AppColors.lightBorder),
+                borderRadius: BorderRadius.circular(4),
+              ),
+              child: Row(
+                children: [
+                  const Icon(Icons.calendar_today_outlined,
+                      size: 18, color: AppColors.primary),
+                  const SizedBox(width: 12),
+                  Expanded(
+                    child: Text(
+                      fechaPago != null
+                          ? _formatDate(fechaPago!)
+                          : 'Seleccionar fecha',
+                      style: theme.textTheme.bodyMedium?.copyWith(
+                        color: fechaPago != null
+                            ? AppColors.lightText
+                            : AppColors.lightTextSecondary,
+                      ),
+                    ),
+                  ),
+                  const Icon(Icons.chevron_right,
+                      color: AppColors.lightTextSecondary),
+                ],
+              ),
+            ),
+          ),
+
+          const SizedBox(height: 32),
+
+          // ── Submit ────────────────────────────────────────────────────────────
+          FilledButton.icon(
+            style: FilledButton.styleFrom(
+              backgroundColor: AppColors.primary,
+              padding: const EdgeInsets.symmetric(vertical: 14),
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(12),
+              ),
+            ),
+            icon: const Icon(Icons.send_outlined),
+            label: const Text('Enviar comprobante'),
+            onPressed: onSubmit,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+// ── File preview card ─────────────────────────────────────────────────────────
+
+class _FilePreview extends StatelessWidget {
+  final String fileName;
+  final String fileSize;
+  final VoidCallback onReplace;
+
+  const _FilePreview({
+    required this.fileName,
+    required this.fileSize,
+    required this.onReplace,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Container(
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: AppColors.primarySurface,
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: AppColors.primary.withValues(alpha: 0.3)),
+      ),
+      child: Row(
+        children: [
+          Container(
+            padding: const EdgeInsets.all(8),
+            decoration: BoxDecoration(
+              color: AppColors.primary.withValues(alpha: 0.1),
+              borderRadius: BorderRadius.circular(8),
+            ),
+            child: const Icon(Icons.insert_drive_file_outlined,
+                color: AppColors.primary, size: 24),
+          ),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  fileName,
+                  style: theme.textTheme.bodyMedium?.copyWith(
+                    fontWeight: FontWeight.w600,
+                  ),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
+                Text(
+                  fileSize,
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: AppColors.lightTextSecondary,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          TextButton(
+            onPressed: onReplace,
+            child: const Text('Cambiar'),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+// ── Shared label ──────────────────────────────────────────────────────────────
+
+class _SectionLabel extends StatelessWidget {
+  final String label;
+  const _SectionLabel({required this.label});
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(
+      label,
+      style: Theme.of(context).textTheme.titleSmall?.copyWith(
+            fontWeight: FontWeight.w700,
+            color: AppColors.lightText,
+          ),
+    );
+  }
+}

--- a/lib/features/materiales/presentation/screens/subir_comprobante_screen.dart
+++ b/lib/features/materiales/presentation/screens/subir_comprobante_screen.dart
@@ -300,8 +300,8 @@ class _FormBody extends StatelessWidget {
             const SizedBox(height: 4),
             Text(
               fileError!,
-              style: theme.textTheme.bodySmall
-                  ?.copyWith(color: AppColors.error),
+              style:
+                  theme.textTheme.bodySmall?.copyWith(color: AppColors.error),
             ),
           ],
 
@@ -344,8 +344,7 @@ class _FormBody extends StatelessWidget {
           GestureDetector(
             onTap: onPickDate,
             child: Container(
-              padding:
-                  const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
               decoration: BoxDecoration(
                 border: Border.all(color: AppColors.lightBorder),
                 borderRadius: BorderRadius.circular(4),

--- a/lib/features/materiales/presentation/utils/money_format.dart
+++ b/lib/features/materiales/presentation/utils/money_format.dart
@@ -1,0 +1,11 @@
+/// Convierte un valor en centavos enteros a texto formateado en MXN.
+///
+/// Ejemplos:
+///   formatMxn(1000) → "$10.00"
+///   formatMxn(9999) → "$99.99"
+///   formatMxn(0)    → "$0.00"
+String formatMxn(int centavos) {
+  final pesos = centavos ~/ 100;
+  final cents = centavos.remainder(100).abs();
+  return '\$$pesos.${cents.toString().padLeft(2, '0')}';
+}

--- a/lib/features/materiales/presentation/widgets/material_estado_badge.dart
+++ b/lib/features/materiales/presentation/widgets/material_estado_badge.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/material.dart';
+
+import '../../../../core/theme/app_colors.dart';
+import '../../domain/entities/material_estado.dart';
+
+/// Badge visual para el estado de una orden de materiales.
+///
+/// Paleta alineada con el admin panel (AppColors únicamente):
+/// - en_revision → muted (ink400 bg / ink600 text)
+/// - aprobada    → warning (accentLight bg / accentDark text)
+/// - pagada      → success (secondaryLight bg / secondaryDark text)
+/// - entregada   → success (mismo que pagada)
+/// - cancelada   → destructive (errorLight bg / errorDark text)
+class MaterialEstadoBadge extends StatelessWidget {
+  final MaterialEstado estado;
+
+  const MaterialEstadoBadge({super.key, required this.estado});
+
+  @override
+  Widget build(BuildContext context) {
+    final (bg, fg, label) = _resolve(estado);
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+      decoration: BoxDecoration(
+        color: bg,
+        borderRadius: BorderRadius.circular(100),
+      ),
+      child: Text(
+        label,
+        style: TextStyle(
+          fontSize: 12,
+          fontWeight: FontWeight.w600,
+          color: fg,
+          letterSpacing: 0.2,
+        ),
+      ),
+    );
+  }
+
+  static (Color bg, Color fg, String label) _resolve(MaterialEstado estado) {
+    switch (estado) {
+      case MaterialEstado.enRevision:
+        return (AppColors.ink100, AppColors.ink600, 'En revisión');
+      case MaterialEstado.aprobada:
+        return (AppColors.accentLight, AppColors.accentDark, 'Aprobada');
+      case MaterialEstado.pagada:
+        return (AppColors.secondaryLight, AppColors.secondaryDark, 'Pagada');
+      case MaterialEstado.entregada:
+        return (AppColors.secondaryLight, AppColors.secondaryDark, 'Entregada');
+      case MaterialEstado.cancelada:
+        return (AppColors.errorLight, AppColors.errorDark, 'Cancelada');
+    }
+  }
+}

--- a/lib/features/materiales/presentation/widgets/orden_card.dart
+++ b/lib/features/materiales/presentation/widgets/orden_card.dart
@@ -1,0 +1,95 @@
+import 'package:flutter/material.dart';
+
+import '../../../../core/theme/app_colors.dart';
+import '../../domain/entities/orden.dart';
+import '../utils/money_format.dart';
+import 'material_estado_badge.dart';
+
+/// Card de resumen de una orden en el historial.
+///
+/// Muestra folio (o "Sin folio"), fecha, estado y total.
+/// Al tocar navega a la pantalla de detalle.
+class OrdenCard extends StatelessWidget {
+  final Orden orden;
+  final VoidCallback onTap;
+
+  const OrdenCard({super.key, required this.orden, required this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final folio = orden.folioReferencia ?? 'Sin folio';
+
+    return Card(
+      elevation: 0,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(12),
+        side: const BorderSide(color: AppColors.lightBorder),
+      ),
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(12),
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              // ── Header ────────────────────────────────────────────────────
+              Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  Text(
+                    folio,
+                    style: theme.textTheme.titleSmall?.copyWith(
+                      fontWeight: FontWeight.w700,
+                      fontFamily: folio == 'Sin folio' ? null : 'monospace',
+                      color: folio == 'Sin folio'
+                          ? AppColors.lightTextTertiary
+                          : AppColors.lightText,
+                    ),
+                  ),
+                  MaterialEstadoBadge(estado: orden.estado),
+                ],
+              ),
+              const SizedBox(height: 6),
+
+              // ── Fecha ─────────────────────────────────────────────────────
+              Text(
+                _formatDate(orden.createdAt),
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: AppColors.lightTextSecondary,
+                ),
+              ),
+              const SizedBox(height: 12),
+
+              // ── Total + arrow ─────────────────────────────────────────────
+              Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  Text(
+                    formatMxn(orden.totalCentavos),
+                    style: theme.textTheme.bodyMedium?.copyWith(
+                      fontWeight: FontWeight.bold,
+                      color: AppColors.primary,
+                    ),
+                  ),
+                  const Icon(
+                    Icons.chevron_right,
+                    size: 20,
+                    color: AppColors.lightTextTertiary,
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  String _formatDate(DateTime dt) {
+    return '${dt.day.toString().padLeft(2, '0')}/'
+        '${dt.month.toString().padLeft(2, '0')}/'
+        '${dt.year}';
+  }
+}

--- a/lib/features/materiales/presentation/widgets/price_input.dart
+++ b/lib/features/materiales/presentation/widgets/price_input.dart
@@ -1,0 +1,125 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+/// Widget de entrada de precio en MXN.
+///
+/// Internamente almacena centavos (enteros) pero muestra pesos con dos
+/// decimales: "$XX.XX". El valor de centavos se expone vía [onChanged].
+///
+/// Ejemplo de uso:
+/// ```dart
+/// PriceInput(
+///   label: 'Monto pagado',
+///   onChanged: (centavos) => setState(() => _monto = centavos),
+/// )
+/// ```
+class PriceInput extends StatefulWidget {
+  final String label;
+  final String? hint;
+  final int? initialCentavos;
+  final ValueChanged<int>? onChanged;
+  final FormFieldValidator<String>? validator;
+  final TextEditingController? controller;
+
+  const PriceInput({
+    super.key,
+    required this.label,
+    this.hint,
+    this.initialCentavos,
+    this.onChanged,
+    this.validator,
+    this.controller,
+  });
+
+  @override
+  State<PriceInput> createState() => _PriceInputState();
+}
+
+class _PriceInputState extends State<PriceInput> {
+  late final TextEditingController _controller;
+  bool _isExternal = false;
+
+  @override
+  void initState() {
+    super.initState();
+    if (widget.controller != null) {
+      _controller = widget.controller!;
+      _isExternal = true;
+    } else {
+      _controller = TextEditingController();
+    }
+    if (widget.initialCentavos != null && widget.initialCentavos! > 0) {
+      final pesos = widget.initialCentavos! ~/ 100;
+      final cents = widget.initialCentavos!.remainder(100).abs();
+      _controller.text = '$pesos.${cents.toString().padLeft(2, '0')}';
+    }
+  }
+
+  @override
+  void dispose() {
+    if (!_isExternal) _controller.dispose();
+    super.dispose();
+  }
+
+  /// Parsea el texto ingresado como pesos decimales y devuelve centavos.
+  int _parseAsCentavos(String text) {
+    final clean = text.replaceAll(RegExp(r'[^\d.]'), '');
+    if (clean.isEmpty) return 0;
+    final amount = double.tryParse(clean) ?? 0.0;
+    return (amount * 100).round();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return TextFormField(
+      controller: _controller,
+      decoration: InputDecoration(
+        labelText: widget.label,
+        hintText: widget.hint ?? '0.00',
+        prefixText: '\$ ',
+        border: const OutlineInputBorder(),
+      ),
+      keyboardType: const TextInputType.numberWithOptions(decimal: true),
+      inputFormatters: [
+        // Allow digits and at most one decimal point
+        FilteringTextInputFormatter.allow(RegExp(r'[\d.]')),
+        // Max two decimal places — enforced by custom formatter
+        _TwoDecimalInputFormatter(),
+      ],
+      validator: widget.validator ??
+          (value) {
+            final centavos = _parseAsCentavos(value ?? '');
+            if (centavos <= 0) return 'Ingresá un monto mayor a \$0.00';
+            return null;
+          },
+      onChanged: (value) {
+        final centavos = _parseAsCentavos(value);
+        widget.onChanged?.call(centavos);
+      },
+    );
+  }
+}
+
+/// Formateador que limita la entrada a dos decimales.
+class _TwoDecimalInputFormatter extends TextInputFormatter {
+  @override
+  TextEditingValue formatEditUpdate(
+    TextEditingValue oldValue,
+    TextEditingValue newValue,
+  ) {
+    final text = newValue.text;
+
+    // Allow backspace/delete through
+    if (text.isEmpty) return newValue;
+
+    // Block multiple decimal points
+    final dotCount = text.split('.').length - 1;
+    if (dotCount > 1) return oldValue;
+
+    // Limit to 2 decimal places
+    final parts = text.split('.');
+    if (parts.length == 2 && parts[1].length > 2) return oldValue;
+
+    return newValue;
+  }
+}

--- a/lib/features/materiales/presentation/widgets/product_card.dart
+++ b/lib/features/materiales/presentation/widgets/product_card.dart
@@ -50,9 +50,7 @@ class ProductCard extends StatelessWidget {
                 ),
                 alignment: Alignment.center,
                 child: Text(
-                  item.title.isNotEmpty
-                      ? item.title[0].toUpperCase()
-                      : '?',
+                  item.title.isNotEmpty ? item.title[0].toUpperCase() : '?',
                   style: TextStyle(
                     fontSize: 36,
                     fontWeight: FontWeight.bold,
@@ -64,8 +62,7 @@ class ProductCard extends StatelessWidget {
 
             // Info section
             Padding(
-              padding:
-                  const EdgeInsets.symmetric(horizontal: 10, vertical: 8),
+              padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 8),
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [

--- a/lib/features/materiales/presentation/widgets/product_card.dart
+++ b/lib/features/materiales/presentation/widgets/product_card.dart
@@ -1,0 +1,139 @@
+import 'package:flutter/material.dart';
+
+import '../../../../core/theme/app_colors.dart';
+import '../../domain/entities/material_item.dart';
+import '../utils/money_format.dart';
+
+/// Tarjeta cuadrada para mostrar un producto del catálogo.
+class ProductCard extends StatelessWidget {
+  final MaterialItem item;
+  final VoidCallback onTap;
+
+  const ProductCard({
+    super.key,
+    required this.item,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final hasStock = item.stock > 0;
+
+    return GestureDetector(
+      onTap: onTap,
+      child: Container(
+        decoration: BoxDecoration(
+          color: Colors.white,
+          borderRadius: BorderRadius.circular(12),
+          border: Border.all(color: AppColors.lightBorder),
+          boxShadow: const [
+            BoxShadow(
+              color: Color(0x0A000000),
+              blurRadius: 4,
+              offset: Offset(0, 2),
+            ),
+          ],
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // Image placeholder
+            Expanded(
+              child: Container(
+                width: double.infinity,
+                decoration: BoxDecoration(
+                  color: AppColors.primarySurface,
+                  borderRadius: const BorderRadius.vertical(
+                    top: Radius.circular(12),
+                  ),
+                ),
+                alignment: Alignment.center,
+                child: Text(
+                  item.title.isNotEmpty
+                      ? item.title[0].toUpperCase()
+                      : '?',
+                  style: TextStyle(
+                    fontSize: 36,
+                    fontWeight: FontWeight.bold,
+                    color: AppColors.primary,
+                  ),
+                ),
+              ),
+            ),
+
+            // Info section
+            Padding(
+              padding:
+                  const EdgeInsets.symmetric(horizontal: 10, vertical: 8),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    item.title,
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      fontWeight: FontWeight.w600,
+                      color: AppColors.lightText,
+                    ),
+                    maxLines: 2,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                  const SizedBox(height: 4),
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    children: [
+                      Text(
+                        formatMxn(item.priceCentavos),
+                        style: theme.textTheme.bodySmall?.copyWith(
+                          color: AppColors.primary,
+                          fontWeight: FontWeight.w700,
+                        ),
+                      ),
+                      _StockIndicator(hasStock: hasStock, stock: item.stock),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _StockIndicator extends StatelessWidget {
+  final bool hasStock;
+  final int stock;
+
+  const _StockIndicator({required this.hasStock, required this.stock});
+
+  @override
+  Widget build(BuildContext context) {
+    if (!hasStock) {
+      return _badge('Agotado', AppColors.error, AppColors.errorLight);
+    }
+    if (stock <= 5) {
+      return _badge('Poco stock', AppColors.warning, AppColors.accentLight);
+    }
+    return _badge('Disponible', AppColors.secondary, AppColors.secondaryLight);
+  }
+
+  Widget _badge(String label, Color color, Color bg) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+      decoration: BoxDecoration(
+        color: bg,
+        borderRadius: BorderRadius.circular(4),
+      ),
+      child: Text(
+        label,
+        style: TextStyle(
+          fontSize: 9,
+          color: color,
+          fontWeight: FontWeight.w600,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/materiales/presentation/widgets/qty_stepper.dart
+++ b/lib/features/materiales/presentation/widgets/qty_stepper.dart
@@ -1,0 +1,86 @@
+import 'package:flutter/material.dart';
+
+import '../../../../core/theme/app_colors.dart';
+
+/// Stepper de cantidad − / qty / + con límites [min] y [max].
+class QtyStepper extends StatelessWidget {
+  final int value;
+  final int min;
+  final int max;
+  final ValueChanged<int> onChanged;
+
+  const QtyStepper({
+    super.key,
+    required this.value,
+    this.min = 1,
+    required this.max,
+    required this.onChanged,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final canDecrement = value > min;
+    final canIncrement = value < max;
+
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        _StepButton(
+          icon: Icons.remove,
+          enabled: canDecrement,
+          onTap: canDecrement ? () => onChanged(value - 1) : null,
+        ),
+        SizedBox(
+          width: 40,
+          child: Center(
+            child: Text(
+              '$value',
+              style: const TextStyle(
+                fontSize: 16,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          ),
+        ),
+        _StepButton(
+          icon: Icons.add,
+          enabled: canIncrement,
+          onTap: canIncrement ? () => onChanged(value + 1) : null,
+        ),
+      ],
+    );
+  }
+}
+
+class _StepButton extends StatelessWidget {
+  final IconData icon;
+  final bool enabled;
+  final VoidCallback? onTap;
+
+  const _StepButton({
+    required this.icon,
+    required this.enabled,
+    this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final color = enabled ? AppColors.primary : AppColors.lightTextTertiary;
+
+    return GestureDetector(
+      onTap: onTap,
+      child: Container(
+        width: 32,
+        height: 32,
+        decoration: BoxDecoration(
+          color: enabled
+              ? AppColors.primaryLight
+              : AppColors.lightBorder,
+          borderRadius: BorderRadius.circular(8),
+        ),
+        alignment: Alignment.center,
+        child: Icon(icon, size: 18, color: color),
+      ),
+    );
+  }
+}

--- a/lib/features/materiales/presentation/widgets/qty_stepper.dart
+++ b/lib/features/materiales/presentation/widgets/qty_stepper.dart
@@ -73,9 +73,7 @@ class _StepButton extends StatelessWidget {
         width: 32,
         height: 32,
         decoration: BoxDecoration(
-          color: enabled
-              ? AppColors.primaryLight
-              : AppColors.lightBorder,
+          color: enabled ? AppColors.primaryLight : AppColors.lightBorder,
           borderRadius: BorderRadius.circular(8),
         ),
         alignment: Alignment.center,


### PR DESCRIPTION
## Summary
- New `lib/features/materiales/` Clean Architecture feature (data / domain / presentation)
- Dashboard tile "Pedidos" gated by `materiales:create` (HugeIconData typed)
- 7 screens: catalogo, detalle producto, carrito, resumen, orden review, historial, datos pago, subir comprobante
- Riverpod providers: catalog, product detail, cart (in-memory), historial, orden detail, comprobantes, config
- Multipart upload via Dio + file_picker (PDF/JPG/PNG ≤10MB enforced client-side)
- Money formatted with `formatMxn(centavos)`; theme uses existing AppColors (design's tokens.dart discarded)

Companion PRs:
- sacdia-backend#131
- sacdia-admin#TBD

## Verification
- SDD verify: 0 CRITICAL findings
- `flutter analyze` reports 0 issues on the materiales feature
- Routes registered in GoRouter shell branch 18

## Known limitations (tracked as v1 warnings)
- `club_section_id` falls back to 0 if no active club context — TODO marker before integration
- Comprobante list reused inline in OrdenReview (no separate estado_final screen)
- Persistence: cart is in-memory (no SharedPreferences/sqlite in v1)

## Test plan
- [ ] Dashboard tile "Pedidos" hidden for users without materiales:create
- [ ] Catalogo: search debounces, filters by programa + categoría, load-more works
- [ ] Detalle producto: variant selector respects per-option stock; qty stepper clamped to qty_disponible
- [ ] Carrito: add/update/remove lines, subtotal updates, "Continuar" goes to resumen
- [ ] Resumen: confirm posts order, clears cart, navigates to orden review
- [ ] Orden review: shows folio + bank snapshot once aprobada; cancel from en_revision works
- [ ] Datos pago: CLABE + folio_referencia copyable; total formatted MXN
- [ ] Subir comprobante: file_picker accepts pdf/jpg/png only; >10MB rejected before upload; submit shows progress
- [ ] Historial: pull-to-refresh; orders sorted desc; tap navigates to detail