### PR TITLE
fix(materiales): dashboard.quick_access.materiales i18n keys

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -2889,7 +2889,8 @@
       "inventory": "Inventory",
       "resources": "Resources",
       "my_ranking": "My ranking",
-      "section_ranking": "Section ranking"
+      "section_ranking": "Section ranking",
+      "materiales": "Orders"
     },
     "stats": {
       "honors_completed": "Honors completed",

--- a/assets/translations/es.json
+++ b/assets/translations/es.json
@@ -2889,7 +2889,8 @@
       "inventory": "Inventario",
       "resources": "Recursos",
       "my_ranking": "Mi ranking",
-      "section_ranking": "Ranking de sección"
+      "section_ranking": "Ranking de sección",
+      "materiales": "Pedidos"
     },
     "stats": {
       "honors_completed": "Esp. completadas",


### PR DESCRIPTION
## Bug
Pedidos tile in the dashboard QuickAccessGrid was showing the raw key:

```
[🌎 Easy Localization] [WARNING] Localization key [dashboard.quick_access.materiales] not found
```

## Fix
Add the missing key to both translation bundles:
- es.json: `"materiales": "Pedidos"`
- en.json: `"materiales": "Orders"`

## Test plan
- [ ] Restart app → dashboard tile shows "Pedidos" (or "Orders" in EN)
- [ ] No Easy Localization warning in console