### PR TITLE
ci: notify sacdia-docs on source-affecting changes

### DIFF
--- a/.github/workflows/notify-docs.yml
+++ b/.github/workflows/notify-docs.yml
@@ -1,0 +1,23 @@
+name: Notify sacdia-docs of source changes
+
+# Triggers sacdia-docs sync workflow when app changes that affect
+# generated artifacts (pubspec versions) land on main.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'pubspec.yaml'
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger sacdia-docs repository_dispatch
+        run: |
+          curl --fail -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.SACDIA_REPO_TOKEN }}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/abn-r/sacdia-docs/dispatches \
+            -d '{"event_type":"sacdia-source-changed","client_payload":{"source":"sacdia-app","sha":"${{ github.sha }}"}}'


### PR DESCRIPTION
## Summary
- Add `.github/workflows/notify-docs.yml` that fires `repository_dispatch` (event_type: `sacdia-source-changed`) on push to `main` when `pubspec.yaml` changes.
- Drives `sacdia-docs` to regenerate `_generated-versions.mdx` with current Flutter deps.

## Prerequisite
Repo secret `SACDIA_REPO_TOKEN` (fine-grained PAT, `contents: read` here + `contents: read` + `pull-requests: write` on `sacdia-docs`) must be configured before merge.

## Test plan
- [ ] Confirm `SACDIA_REPO_TOKEN` secret is set in this repo before merge
- [ ] After merge, bump a dep in `pubspec.yaml` and verify `sacdia-docs/sync-docs.yml` triggers