### PR TITLE
fix(profile): hero overflows + migrate profile to HugeIcons

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -188,6 +188,8 @@ PODS:
   - TOCropViewController (2.7.4)
   - url_launcher_ios (0.0.1):
     - Flutter
+  - wakelock_plus (0.0.1):
+    - Flutter
 
 DEPENDENCIES:
   - connectivity_plus (from `.symlinks/plugins/connectivity_plus/ios`)
@@ -219,6 +221,7 @@ DEPENDENCIES:
   - shared_preferences_foundation (from `.symlinks/plugins/shared_preferences_foundation/darwin`)
   - sqflite_darwin (from `.symlinks/plugins/sqflite_darwin/darwin`)
   - url_launcher_ios (from `.symlinks/plugins/url_launcher_ios/ios`)
+  - wakelock_plus (from `.symlinks/plugins/wakelock_plus/ios`)
 
 SPEC REPOS:
   trunk:
@@ -302,6 +305,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/sqflite_darwin/darwin"
   url_launcher_ios:
     :path: ".symlinks/plugins/url_launcher_ios/ios"
+  wakelock_plus:
+    :path: ".symlinks/plugins/wakelock_plus/ios"
 
 SPEC CHECKSUMS:
   AppCheckCore: cc8fd0a3a230ddd401f326489c99990b013f0c4f
@@ -353,6 +358,7 @@ SPEC CHECKSUMS:
   SwiftyGif: 706c60cf65fa2bc5ee0313beece843c8eb8194d4
   TOCropViewController: 80b8985ad794298fb69d3341de183f33d1853654
   url_launcher_ios: 7a95fa5b60cc718a708b8f2966718e93db0cef1b
+  wakelock_plus: e29112ab3ef0b318e58cfa5c32326458be66b556
 
 PODFILE CHECKSUM: 1959d098c91d8a792531a723c4a9d7e9f6a01e38
 

--- a/lib/features/materials/data/datasources/materials_remote_data_source.dart
+++ b/lib/features/materials/data/datasources/materials_remote_data_source.dart
@@ -384,8 +384,7 @@ class MaterialsRemoteDataSourceImpl implements MaterialsRemoteDataSource {
         final body = response.data as Map<String, dynamic>;
         final rawData = _extractData(body) as List<dynamic>;
         return rawData
-            .map((item) =>
-                ReceiptModel.fromJson(item as Map<String, dynamic>))
+            .map((item) => ReceiptModel.fromJson(item as Map<String, dynamic>))
             .toList();
       }
 

--- a/lib/features/materials/data/repositories/materials_repository_impl.dart
+++ b/lib/features/materials/data/repositories/materials_repository_impl.dart
@@ -208,8 +208,7 @@ class MaterialsRepositoryImpl implements MaterialsRepository {
   // ── Receipts ──────────────────────────────────────────────────────────────
 
   @override
-  Future<Either<Failure, List<Receipt>>> listReceipts(
-      String folioOrId) async {
+  Future<Either<Failure, List<Receipt>>> listReceipts(String folioOrId) async {
     try {
       final models = await remoteDataSource.listReceipts(folioOrId);
       return Right(models.map((m) => m.toEntity()).toList());

--- a/lib/features/materials/presentation/providers/receipts_provider.dart
+++ b/lib/features/materials/presentation/providers/receipts_provider.dart
@@ -113,6 +113,6 @@ class UploadReceiptNotifier extends AutoDisposeNotifier<UploadReceiptState> {
   }
 }
 
-final uploadReceiptNotifierProvider = AutoDisposeNotifierProvider<
-    UploadReceiptNotifier,
-    UploadReceiptState>(UploadReceiptNotifier.new);
+final uploadReceiptNotifierProvider =
+    AutoDisposeNotifierProvider<UploadReceiptNotifier, UploadReceiptState>(
+        UploadReceiptNotifier.new);

--- a/lib/features/materials/presentation/views/catalog_view.dart
+++ b/lib/features/materials/presentation/views/catalog_view.dart
@@ -74,7 +74,8 @@ class _CatalogViewState extends ConsumerState<CatalogView> {
             alignment: Alignment.topRight,
             children: [
               IconButton(
-                icon: const HugeIcon(icon: HugeIcons.strokeRoundedShoppingCart01),
+                icon:
+                    const HugeIcon(icon: HugeIcons.strokeRoundedShoppingCart01),
                 onPressed: () => context.push(RouteNames.materialsCart),
               ),
               if (cartState.itemCount > 0)
@@ -113,7 +114,8 @@ class _CatalogViewState extends ConsumerState<CatalogView> {
               onChanged: _onSearchChanged,
               decoration: InputDecoration(
                 hintText: 'Buscar productos...',
-                prefixIcon: const HugeIcon(icon: HugeIcons.strokeRoundedSearch01),
+                prefixIcon:
+                    const HugeIcon(icon: HugeIcons.strokeRoundedSearch01),
                 border: OutlineInputBorder(
                   borderRadius: BorderRadius.circular(12),
                   borderSide: const BorderSide(color: AppColors.lightBorder),

--- a/lib/features/materials/presentation/views/order_history_view.dart
+++ b/lib/features/materials/presentation/views/order_history_view.dart
@@ -103,7 +103,8 @@ class _EmptyHistorial extends StatelessWidget {
                   borderRadius: BorderRadius.circular(12),
                 ),
               ),
-              icon: const HugeIcon(icon: HugeIcons.strokeRoundedStoreManagement01),
+              icon: const HugeIcon(
+                  icon: HugeIcons.strokeRoundedStoreManagement01),
               label: const Text('Ir al catálogo'),
               onPressed: onGoCatalog,
             ),

--- a/lib/features/materials/presentation/views/order_review_view.dart
+++ b/lib/features/materials/presentation/views/order_review_view.dart
@@ -702,8 +702,8 @@ class _ComprobantesSection extends ConsumerWidget {
           children: [
             for (int i = 0; i < receipts.length; i++)
               Padding(
-                padding: EdgeInsets.only(
-                    bottom: i < receipts.length - 1 ? 8 : 0),
+                padding:
+                    EdgeInsets.only(bottom: i < receipts.length - 1 ? 8 : 0),
                 child: _ComprobanteCard(comprobante: receipts[i]),
               ),
           ],

--- a/lib/features/materials/presentation/views/product_detail_view.dart
+++ b/lib/features/materials/presentation/views/product_detail_view.dart
@@ -17,8 +17,7 @@ class ProductDetailView extends ConsumerStatefulWidget {
   const ProductDetailView({super.key, required this.productId});
 
   @override
-  ConsumerState<ProductDetailView> createState() =>
-      _ProductDetailViewState();
+  ConsumerState<ProductDetailView> createState() => _ProductDetailViewState();
 }
 
 class _ProductDetailViewState extends ConsumerState<ProductDetailView> {
@@ -247,7 +246,8 @@ class _ProductDetailViewState extends ConsumerState<ProductDetailView> {
                 SizedBox(
                   width: double.infinity,
                   child: FilledButton.icon(
-                    icon: const HugeIcon(icon: HugeIcons.strokeRoundedShoppingCartAdd01),
+                    icon: const HugeIcon(
+                        icon: HugeIcons.strokeRoundedShoppingCartAdd01),
                     label: const Text('Agregar al carrito'),
                     style: FilledButton.styleFrom(
                       backgroundColor: maxQty > 0

--- a/lib/features/materials/presentation/views/upload_receipt_view.dart
+++ b/lib/features/materials/presentation/views/upload_receipt_view.dart
@@ -28,12 +28,10 @@ class UploadReceiptView extends ConsumerStatefulWidget {
   const UploadReceiptView({super.key, required this.folioOrId});
 
   @override
-  ConsumerState<UploadReceiptView> createState() =>
-      _UploadReceiptViewState();
+  ConsumerState<UploadReceiptView> createState() => _UploadReceiptViewState();
 }
 
-class _UploadReceiptViewState
-    extends ConsumerState<UploadReceiptView> {
+class _UploadReceiptViewState extends ConsumerState<UploadReceiptView> {
   final _formKey = GlobalKey<FormState>();
 
   File? _selectedFile;

--- a/lib/features/profile/presentation/views/medical_info_view.dart
+++ b/lib/features/profile/presentation/views/medical_info_view.dart
@@ -1,6 +1,7 @@
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:hugeicons/hugeicons.dart';
 import 'package:go_router/go_router.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'package:sacdia_app/core/theme/app_colors.dart';
@@ -156,7 +157,7 @@ class MedicalInfoView extends ConsumerWidget {
 
                     // ── Contactos de emergencia ─────────────────────────────
                     MedicoSectionCard(
-                      icon: Icons.contact_phone_outlined,
+                      icon: HugeIcons.strokeRoundedContactBook,
                       iconBg: MedicoTokens.coral100,
                       iconFg: MedicoTokens.coral600,
                       title: 'profile.medical_info.emergency_contacts'.tr(),
@@ -209,7 +210,7 @@ class MedicalInfoView extends ConsumerWidget {
 
                     // ── Alergias ────────────────────────────────────────────
                     MedicoSectionCard(
-                      icon: Icons.medical_services_outlined,
+                      icon: HugeIcons.strokeRoundedFirstAidKit,
                       iconBg: MedicoTokens.rose50,
                       iconFg: MedicoTokens.rose500,
                       title: 'profile.medical_info.allergies'.tr(),
@@ -258,7 +259,7 @@ class MedicalInfoView extends ConsumerWidget {
 
                     // ── Enfermedades ────────────────────────────────────────
                     MedicoSectionCard(
-                      icon: Icons.favorite_border,
+                      icon: HugeIcons.strokeRoundedHealth,
                       iconBg: MedicoTokens.amber50,
                       iconFg: MedicoTokens.amber500,
                       title: 'profile.medical_info.diseases'.tr(),
@@ -307,7 +308,7 @@ class MedicalInfoView extends ConsumerWidget {
 
                     // ── Medicamentos ────────────────────────────────────────
                     MedicoSectionCard(
-                      icon: Icons.medication_outlined,
+                      icon: HugeIcons.strokeRoundedMedicine01,
                       iconBg: MedicoTokens.mint50,
                       iconFg: MedicoTokens.mint500,
                       title: 'profile.medical_info.medicines'.tr(),
@@ -360,7 +361,7 @@ class MedicalInfoView extends ConsumerWidget {
                       data: (isRequired) {
                         if (!isRequired) return const SizedBox.shrink();
                         return MedicoSectionCard(
-                          icon: Icons.shield_outlined,
+                          icon: HugeIcons.strokeRoundedSecurityCheck,
                           iconBg: MedicoTokens.lavender100,
                           iconFg: MedicoTokens.lavender500,
                           title: 'profile.medical_info.legal_rep'.tr(),
@@ -445,7 +446,7 @@ class _MedicoAppBar extends StatelessWidget {
           _circleBtn(
             color: MedicoTokens.ink100,
             iconColor: MedicoTokens.ink800,
-            icon: Icons.chevron_left_rounded,
+            icon: HugeIcons.strokeRoundedArrowLeft01,
             onTap: onBack,
           ),
           Expanded(
@@ -483,7 +484,7 @@ class _MedicoAppBar extends StatelessWidget {
   Widget _circleBtn({
     required Color color,
     required Color iconColor,
-    required IconData icon,
+    required List<List<dynamic>> icon,
     VoidCallback? onTap,
   }) {
     return Material(
@@ -495,7 +496,7 @@ class _MedicoAppBar extends StatelessWidget {
         child: SizedBox(
           width: 38,
           height: 38,
-          child: Icon(icon, color: iconColor, size: 22),
+          child: HugeIcon(icon: icon, color: iconColor, size: 22),
         ),
       ),
     );
@@ -513,8 +514,8 @@ class _MedicoAppBar extends StatelessWidget {
           child: Row(
             mainAxisSize: MainAxisSize.min,
             children: [
-              const Icon(
-                Icons.emergency_outlined,
+              HugeIcon(
+                icon: HugeIcons.strokeRoundedAlert02,
                 color: MedicoTokens.rose500,
                 size: 16,
               ),
@@ -548,8 +549,8 @@ class _SectionError extends StatelessWidget {
   Widget build(BuildContext context) {
     return Row(
       children: [
-        const Icon(
-          Icons.error_outline_rounded,
+        HugeIcon(
+          icon: HugeIcons.strokeRoundedAlert02,
           size: 16,
           color: AppColors.error,
         ),

--- a/lib/features/profile/presentation/views/medical_sos_view.dart
+++ b/lib/features/profile/presentation/views/medical_sos_view.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:hugeicons/hugeicons.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:geolocator/geolocator.dart';
 import 'package:screen_brightness/screen_brightness.dart';
@@ -441,11 +442,11 @@ class _SosAppBarState extends State<_SosAppBar>
               button: true,
               child: GestureDetector(
                 onTap: widget.onClose,
-                child: const SizedBox(
+                child: SizedBox(
                   width: 44,
                   height: 44,
-                  child: Icon(
-                    Icons.close_rounded,
+                  child: HugeIcon(
+                    icon: HugeIcons.strokeRoundedCancel01,
                     color: MedicoTokens.sosInkOnCoral,
                     size: 24,
                   ),
@@ -561,7 +562,7 @@ class _BloodHeroCard extends StatelessWidget {
               .tr(namedArgs: {'blood': blood})
           : 'profile.medical_info.sos.hero.blood_unknown_label'.tr(),
       child: Container(
-        height: 240,
+        constraints: const BoxConstraints(minHeight: 240),
         decoration: BoxDecoration(
           gradient: const LinearGradient(
             begin: Alignment.topLeft,
@@ -592,6 +593,7 @@ class _BloodHeroCard extends StatelessWidget {
               padding: const EdgeInsets.all(24),
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
+                mainAxisSize: MainAxisSize.min,
                 children: [
                   // Blood glyph — monospace, 140pt
                   Text(
@@ -607,7 +609,7 @@ class _BloodHeroCard extends StatelessWidget {
                           : MedicoTokens.ink400,
                     ),
                   ),
-                  const Spacer(),
+                  const SizedBox(height: 12),
 
                   // Name
                   if (name.isNotEmpty)
@@ -813,8 +815,8 @@ class _PrimaryContactCta extends StatelessWidget {
               Row(
                 mainAxisAlignment: MainAxisAlignment.center,
                 children: [
-                  const Icon(
-                    Icons.phone_rounded,
+                  HugeIcon(
+                    icon: HugeIcons.strokeRoundedCall,
                     color: MedicoTokens.sosInkOnCoral,
                     size: 22,
                   ),
@@ -931,13 +933,15 @@ class _GpsCta extends StatelessWidget {
         bg = MedicoTokens.mint50;
         fg = MedicoTokens.mintInk;
         label = 'profile.medical_info.sos.actions.gps_sent'.tr();
-        trailing = Icon(Icons.check_rounded, color: fg, size: 18);
+        trailing =
+            HugeIcon(icon: HugeIcons.strokeRoundedTick02, color: fg, size: 18);
         break;
       case _GpsState.error:
         bg = MedicoTokens.rose500;
         fg = MedicoTokens.paper;
         label = 'profile.medical_info.sos.actions.gps_failed'.tr();
-        trailing = Icon(Icons.refresh_rounded, color: fg, size: 18);
+        trailing =
+            HugeIcon(icon: HugeIcons.strokeRoundedRefresh, color: fg, size: 18);
         break;
       case _GpsState.idle:
         bg = MedicoTokens.mint500;
@@ -963,7 +967,7 @@ class _GpsCta extends StatelessWidget {
           child: Row(
             mainAxisAlignment: MainAxisAlignment.center,
             children: [
-              const Icon(Icons.location_on_rounded, size: 20),
+              HugeIcon(icon: HugeIcons.strokeRoundedLocation01, size: 20),
               const SizedBox(width: 8),
               Flexible(
                 child: Text(
@@ -1040,10 +1044,10 @@ class _ContactsList extends StatelessWidget {
               padding: const EdgeInsets.symmetric(vertical: 8),
               child: Row(
                 children: [
-                  Icon(
-                    showAll
-                        ? Icons.keyboard_arrow_up_rounded
-                        : Icons.keyboard_arrow_down_rounded,
+                  HugeIcon(
+                    icon: showAll
+                        ? HugeIcons.strokeRoundedArrowUp01
+                        : HugeIcons.strokeRoundedArrowDown01,
                     size: 20,
                     color: MedicoTokens.ink500,
                   ),
@@ -1154,8 +1158,8 @@ class _ContactTileRow extends StatelessWidget {
               ),
 
               // Phone icon
-              const Icon(
-                Icons.phone_rounded,
+              HugeIcon(
+                icon: HugeIcons.strokeRoundedCall,
                 color: MedicoTokens.mint500,
                 size: 22,
               ),

--- a/lib/features/profile/presentation/widgets/class_status_circles.dart
+++ b/lib/features/profile/presentation/widgets/class_status_circles.dart
@@ -1,6 +1,7 @@
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:hugeicons/hugeicons.dart';
 import '../../../../core/theme/app_colors.dart';
 import '../../../../core/theme/sac_colors.dart';
 import '../../../classes/domain/entities/progressive_class.dart';
@@ -317,8 +318,8 @@ class _ClassLogo extends StatelessWidget {
       return Image.asset(
         assetPath,
         fit: BoxFit.contain,
-        errorBuilder: (_, __, ___) => Icon(
-          Icons.shield_outlined,
+        errorBuilder: (_, __, ___) => HugeIcon(
+          icon: HugeIcons.strokeRoundedSecurityCheck,
           color: color,
           size: 24,
         ),
@@ -335,8 +336,8 @@ class _ClassLogo extends StatelessWidget {
       child: Image.asset(
         assetPath,
         fit: BoxFit.contain,
-        errorBuilder: (_, __, ___) => Icon(
-          Icons.shield_outlined,
+        errorBuilder: (_, __, ___) => HugeIcon(
+          icon: HugeIcons.strokeRoundedSecurityCheck,
           color: c.textTertiary,
           size: 24,
         ),

--- a/lib/features/profile/presentation/widgets/info_section.dart
+++ b/lib/features/profile/presentation/widgets/info_section.dart
@@ -163,8 +163,8 @@ class _InfoItemWidget extends StatelessWidget {
               ),
             ),
             if (item.onTap != null)
-              Icon(
-                Icons.chevron_right,
+              HugeIcon(
+                icon: HugeIcons.strokeRoundedArrowRight01,
                 color: context.sac.textTertiary,
                 size: 18,
               ),

--- a/lib/features/profile/presentation/widgets/medico/blood_hero_card.dart
+++ b/lib/features/profile/presentation/widgets/medico/blood_hero_card.dart
@@ -1,5 +1,6 @@
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
+import 'package:hugeicons/hugeicons.dart';
 import 'medico_tokens.dart';
 
 /// Tarjeta hero con tipo de sangre + barra de completitud.
@@ -109,25 +110,36 @@ class BloodHeroCard extends StatelessWidget {
         Row(
           crossAxisAlignment: CrossAxisAlignment.end,
           children: [
-            Text(
-              bloodType ?? 'profile.medical_info.hero.empty_blood'.tr(),
-              style: const TextStyle(
-                fontSize: 44,
-                fontWeight: FontWeight.w800,
-                color: Colors.white,
-                height: 1,
-                letterSpacing: -1.3,
+            Flexible(
+              child: FittedBox(
+                fit: BoxFit.scaleDown,
+                alignment: Alignment.bottomLeft,
+                child: Text(
+                  bloodType ?? 'profile.medical_info.hero.empty_blood'.tr(),
+                  maxLines: 1,
+                  style: const TextStyle(
+                    fontSize: 44,
+                    fontWeight: FontWeight.w800,
+                    color: Colors.white,
+                    height: 1,
+                    letterSpacing: -1.3,
+                  ),
+                ),
               ),
             ),
             if (rhLabel != null) ...[
               const SizedBox(width: 8),
-              Padding(
-                padding: const EdgeInsets.only(bottom: 4),
-                child: Text(
-                  rhLabel,
-                  style: const TextStyle(
-                    fontSize: 13,
-                    color: Color(0xD9FFFFFF),
+              Flexible(
+                child: Padding(
+                  padding: const EdgeInsets.only(bottom: 4),
+                  child: Text(
+                    rhLabel,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: const TextStyle(
+                      fontSize: 13,
+                      color: Color(0xD9FFFFFF),
+                    ),
                   ),
                 ),
               ),
@@ -146,8 +158,8 @@ class BloodHeroCard extends StatelessWidget {
         color: const Color(0x2EFFFFFF), // 18% white
         borderRadius: BorderRadius.circular(16),
       ),
-      child: const Icon(
-        Icons.water_drop_outlined,
+      child: HugeIcon(
+        icon: HugeIcons.strokeRoundedBlood,
         color: Colors.white,
         size: 28,
       ),

--- a/lib/features/profile/presentation/widgets/medico/contact_tile.dart
+++ b/lib/features/profile/presentation/widgets/medico/contact_tile.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:hugeicons/hugeicons.dart';
 import 'package:sacdia_app/features/post_registration/data/models/emergency_contact_model.dart';
 import 'medico_tokens.dart';
 
@@ -71,14 +72,14 @@ class ContactTile extends StatelessWidget {
           ),
           const SizedBox(width: 8),
           _quickButton(
-            icon: Icons.phone_outlined,
+            icon: HugeIcons.strokeRoundedCall,
             bg: MedicoTokens.mint50,
             fg: MedicoTokens.mint500,
             onTap: () => onCall?.call(_cleanedPhone),
           ),
           const SizedBox(width: 6),
           _quickButton(
-            icon: Icons.chat_bubble_outline,
+            icon: HugeIcons.strokeRoundedMessage01,
             bg: MedicoTokens.ink100,
             fg: MedicoTokens.ink600,
             onTap: () => onSms?.call(_cleanedPhone),
@@ -109,7 +110,7 @@ class ContactTile extends StatelessWidget {
   }
 
   Widget _quickButton({
-    required IconData icon,
+    required List<List<dynamic>> icon,
     required Color bg,
     required Color fg,
     required VoidCallback onTap,
@@ -123,7 +124,7 @@ class ContactTile extends StatelessWidget {
         child: SizedBox(
           width: 36,
           height: 36,
-          child: Icon(icon, color: fg, size: 16),
+          child: HugeIcon(icon: icon, color: fg, size: 16),
         ),
       ),
     );

--- a/lib/features/profile/presentation/widgets/medico/medico_section_card.dart
+++ b/lib/features/profile/presentation/widgets/medico/medico_section_card.dart
@@ -1,12 +1,13 @@
 import 'package:flutter/material.dart';
+import 'package:hugeicons/hugeicons.dart';
 import 'medico_tokens.dart';
 
 /// Wrapper común para cada sección (Alergias, Enfermedades, etc.).
 ///
 /// Header: icono coloreado + título + acción opcional ("Editar" / "Administrar").
 class MedicoSectionCard extends StatelessWidget {
-  /// Icono Material a mostrar dentro del badge coloreado.
-  final IconData icon;
+  /// Icono HugeIcons a mostrar dentro del badge coloreado.
+  final List<List<dynamic>> icon;
 
   /// Color de fondo del badge.
   final Color iconBg;
@@ -67,7 +68,7 @@ class MedicoSectionCard extends StatelessWidget {
             color: iconBg,
             borderRadius: BorderRadius.circular(MedicoTokens.sectionIconRadius),
           ),
-          child: Icon(icon, color: iconFg, size: 20),
+          child: HugeIcon(icon: icon, color: iconFg, size: 20),
         ),
         const SizedBox(width: 12),
         Expanded(

--- a/lib/features/profile/presentation/widgets/medico/slide_to_confirm_button.dart
+++ b/lib/features/profile/presentation/widgets/medico/slide_to_confirm_button.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:hugeicons/hugeicons.dart';
 
 import 'medico_tokens.dart';
 
@@ -236,8 +237,8 @@ class _SlideToConfirmButtonState extends State<SlideToConfirmButton>
                           ),
                         ],
                       ),
-                      child: Icon(
-                        Icons.chevron_right_rounded,
+                      child: HugeIcon(
+                        icon: HugeIcons.strokeRoundedArrowRight01,
                         color: widget.thumbIconColor,
                         size: 30,
                       ),

--- a/lib/features/profile/presentation/widgets/profile_classes_section.dart
+++ b/lib/features/profile/presentation/widgets/profile_classes_section.dart
@@ -102,8 +102,8 @@ class ProfileClassesSection extends ConsumerWidget {
                         color: AppColors.primary,
                         borderRadius: BorderRadius.circular(8),
                       ),
-                      child: const Icon(
-                        Icons.school,
+                      child: HugeIcon(
+                        icon: HugeIcons.strokeRoundedSchool,
                         color: Colors.white,
                         size: 22,
                       ),
@@ -224,14 +224,14 @@ class _ClassGridItem extends StatelessWidget {
                       ? Image.asset(
                           logoAsset,
                           fit: BoxFit.contain,
-                          errorBuilder: (_, __, ___) => Icon(
-                            Icons.school,
+                          errorBuilder: (_, __, ___) => HugeIcon(
+                            icon: HugeIcons.strokeRoundedSchool,
                             size: 30,
                             color: classColor,
                           ),
                         )
-                      : Icon(
-                          Icons.school,
+                      : HugeIcon(
+                          icon: HugeIcons.strokeRoundedSchool,
                           size: 30,
                           color: classColor,
                         ),
@@ -271,8 +271,8 @@ class _ClassGridItem extends StatelessWidget {
                         color: classColor,
                         shape: BoxShape.circle,
                       ),
-                      child: const Icon(
-                        Icons.check,
+                      child: HugeIcon(
+                        icon: HugeIcons.strokeRoundedTick02,
                         color: Colors.white,
                         size: 12,
                       ),

--- a/lib/features/profile/presentation/widgets/profile_honors_section.dart
+++ b/lib/features/profile/presentation/widgets/profile_honors_section.dart
@@ -12,16 +12,17 @@ import 'package:sacdia_app/core/widgets/sac_button.dart';
 import 'package:sacdia_app/features/honors/domain/entities/user_honor.dart';
 import 'package:sacdia_app/features/honors/presentation/providers/honors_providers.dart';
 
-const Map<String, IconData> _categoryIcons = {
-  'ADRA': Icons.volunteer_activism,
-  'Actividades Agropecuarias': Icons.agriculture,
-  'Ciencias de la Salud': Icons.medical_services,
-  'Artes Domésticas': Icons.home,
-  'Artes y Actividades Manuales': Icons.handyman,
-  'Crecimiento Espiritual, Actividades Misioneras y Herencia': Icons.public,
-  'Estudio de la Naturaleza': Icons.forest,
-  'Actividades Vocacionales': Icons.work,
-  'Actividades Recreativas': Icons.sports_handball,
+const Map<String, List<List<dynamic>>> _categoryIcons = {
+  'ADRA': HugeIcons.strokeRoundedCharity,
+  'Actividades Agropecuarias': HugeIcons.strokeRoundedPlant03,
+  'Ciencias de la Salud': HugeIcons.strokeRoundedFirstAidKit,
+  'Artes Domésticas': HugeIcons.strokeRoundedHome01,
+  'Artes y Actividades Manuales': HugeIcons.strokeRoundedTools,
+  'Crecimiento Espiritual, Actividades Misioneras y Herencia':
+      HugeIcons.strokeRoundedGlobe02,
+  'Estudio de la Naturaleza': HugeIcons.strokeRoundedTree01,
+  'Actividades Vocacionales': HugeIcons.strokeRoundedBriefcase01,
+  'Actividades Recreativas': HugeIcons.strokeRoundedFootball,
 };
 
 /// Section of the profile view that shows the user's earned / in-progress
@@ -148,7 +149,8 @@ class _CategorySection extends StatelessWidget {
       categoryId: categoryId,
       categoryName: categoryName,
     );
-    final categoryIcon = _categoryIcons[categoryName] ?? Icons.star;
+    final categoryIcon =
+        _categoryIcons[categoryName] ?? HugeIcons.strokeRoundedStar;
 
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: 10),
@@ -179,8 +181,8 @@ class _CategorySection extends StatelessWidget {
                     color: categoryColor,
                     borderRadius: BorderRadius.circular(8),
                   ),
-                  child: Icon(
-                    categoryIcon,
+                  child: HugeIcon(
+                    icon: categoryIcon,
                     color: Colors.white,
                     size: 22,
                   ),
@@ -308,8 +310,8 @@ class _HonorGridItem extends StatelessWidget {
                           color: AppColors.secondary,
                           shape: BoxShape.circle,
                         ),
-                        child: const Icon(
-                          Icons.check,
+                        child: HugeIcon(
+                          icon: HugeIcons.strokeRoundedTick02,
                           color: Colors.white,
                           size: 10,
                         ),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1893,10 +1893,10 @@ packages:
     dependency: transitive
     description:
       name: wakelock_plus_platform_interface
-      sha256: "14b2e5b9e35c2631e656913c47adecdd71633ae92896a27a64c8f1fcfabc21cc"
+      sha256: b13f99e992e7ae6a152e16c5559d3c07ff445b13330192662494e614ca3e7d7b
       url: "https://pub.dev"
     source: hosted
-    version: "1.5.0"
+    version: "1.5.1"
   watcher:
     dependency: transitive
     description:
@@ -1978,5 +1978,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.11.0 <4.0.0"
-  flutter: ">=3.41.0"
+  dart: ">=3.10.0 <4.0.0"
+  flutter: ">=3.38.0"


### PR DESCRIPTION
## Summary

Polishes the Información Médica + SOS screens shipped in PR #91 and migrates the entire `lib/features/profile/presentation/` tree from Material `Icons.*` to `HugeIcons.*` for consistency with the rest of the app.

## Fixes

### Hero overflow on Información Médica
`BloodHeroCard` was rendering a 70px horizontal overflow when the backend returned the raw Prisma enum identifier (e.g. `O_POSITIVE`) instead of the display value (`O+`). Backend now formats the display string (separate PR #133 already merged), but the widget hardens against any long blood value:
- Wrap the blood `Text` in `Flexible` + `FittedBox(fit: scaleDown, alignment: bottomLeft)` with `maxLines: 1`.
- Wrap the Rh sub-label in `Flexible` + `maxLines: 1` + `overflow: ellipsis`.

### SOS hero vertical overflow
`MedicalSosView` hero card was overflowing 8px vertically because a fixed `Container(height: 240)` + `Padding(24)` left 192pt for a column whose children summed to 200pt. The `Spacer` collapsed to 0 in the tight constraint.
- Replace `height: 240` with `constraints: BoxConstraints(minHeight: 240)`.
- Drop the `Spacer` (incompatible with `mainAxisSize: min` in scrolling context).
- Use explicit `SizedBox(height: 12)` for rhythm.

## Migrate to HugeIcons

All Material `Icons.*` in `lib/features/profile/presentation/` swapped for HugeIcons equivalents (32 occurrences, 10 files). Examples:

| Material | HugeIcons |
|---|---|
| `Icons.water_drop_outlined` | `HugeIcons.strokeRoundedBlood` |
| `Icons.chat_bubble_outline` | `HugeIcons.strokeRoundedMessage01` |
| `Icons.phone_outlined` / `phone_rounded` | `HugeIcons.strokeRoundedCall` |
| `Icons.location_on_rounded` | `HugeIcons.strokeRoundedLocation01` |
| `Icons.contact_phone_outlined` | `HugeIcons.strokeRoundedContactBook` |
| `Icons.favorite_border` | `HugeIcons.strokeRoundedHealth` |
| `Icons.medication_outlined` | `HugeIcons.strokeRoundedMedicine01` |
| `Icons.shield_outlined` | `HugeIcons.strokeRoundedSecurityCheck` |
| `Icons.agriculture` / `forest` / `handyman` / `work` | `Plant03` / `Tree01` / `Tools` / `Briefcase01` |

### Type ripples
`MedicoSectionCard.icon` type changed from `IconData` to `List<List<dynamic>>` (HugeIcons constant type). Same change for `_quickButton` in `contact_tile.dart`, `_circleBtn` in `medical_info_view.dart`, and `_categoryIcons` map in `profile_honors_section.dart`. Const removed from widget sites converted to `HugeIcon` (not const-constructible).

## Test plan
- [x] `flutter analyze lib/features/profile/presentation/` → 0 issues
- [x] `dart format --set-exit-if-changed lib/features/profile/presentation/` → 0 changes
- [ ] Reviewer: open Información Médica → blood hero shows `O+` (or `—` if unset) with no horizontal overflow
- [ ] Reviewer: open SOS → hero card no vertical overflow, blood + name + age render correctly
- [ ] Reviewer: scan all profile screens (info, sos, edit, settings, data export, active sessions, profile_view) → no Material icons remain visible; all chrome uses HugeIcons strokes

## Pairs with
- Backend PR #133 (already merged) — `formatBloodType` maps `O_POSITIVE` → `O+`