### PR TITLE
feat(certificate-imports): add mobile OCR import flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,6 @@ dist/
 node_modules/
 
 sentry.properties
+
+# Local Codex worktrees
+.worktrees/

--- a/lib/core/config/route_names.dart
+++ b/lib/core/config/route_names.dart
@@ -66,6 +66,17 @@ class RouteNames {
   static const String investitureHistory =
       '/investiture/enrollment/:enrollmentId/history';
 
+  // Carga masiva por comprobante/certificado OCR
+  static const String certificateImportUpload = '/certificate-import';
+  static const String certificateImportProcessing =
+      '/certificate-import/:batchId/processing';
+  static const String certificateImportReview =
+      '/certificate-import/:batchId/review';
+  static const String certificateImportStatus =
+      '/certificate-import/:batchId/status';
+  static const String certificateImportProof =
+      '/certificate-import/item/:itemId/proof';
+
   // Helpers para paths con parámetros
   static String clubDetailPath(String clubId) => '/club/$clubId';
   static String classDetailPath(String classId) => '/class/$classId';
@@ -77,6 +88,14 @@ class RouteNames {
       '/certification/$certificationId/progress/$enrollmentId';
   static String investitureHistoryPath(String enrollmentId) =>
       '/investiture/enrollment/$enrollmentId/history';
+  static String certificateImportProcessingPath(String batchId) =>
+      '/certificate-import/$batchId/processing';
+  static String certificateImportReviewPath(String batchId) =>
+      '/certificate-import/$batchId/review';
+  static String certificateImportStatusPath(String batchId) =>
+      '/certificate-import/$batchId/status';
+  static String certificateImportProofPath(String itemId) =>
+      '/certificate-import/item/$itemId/proof';
 
   // Camporees helpers
   static String camporeeDetailPath(String camporeeId) =>

--- a/lib/core/config/router.dart
+++ b/lib/core/config/router.dart
@@ -11,6 +11,12 @@ import 'package:sacdia_app/features/activities/presentation/views/activities_lis
 import 'package:sacdia_app/features/certifications/presentation/views/certifications_list_view.dart';
 import 'package:sacdia_app/features/certifications/presentation/views/certification_detail_view.dart';
 import 'package:sacdia_app/features/certifications/presentation/views/certification_progress_view.dart';
+import 'package:sacdia_app/features/certificate_import/domain/entities/certificate_import_item.dart';
+import 'package:sacdia_app/features/certificate_import/presentation/views/certificate_import_processing_view.dart';
+import 'package:sacdia_app/features/certificate_import/presentation/views/certificate_import_review_view.dart';
+import 'package:sacdia_app/features/certificate_import/presentation/views/certificate_import_status_view.dart';
+import 'package:sacdia_app/features/certificate_import/presentation/views/certificate_import_upload_view.dart';
+import 'package:sacdia_app/features/certificate_import/presentation/widgets/certificate_import_proof_card.dart';
 import 'package:sacdia_app/features/investiture/presentation/views/investiture_pending_list_view.dart';
 import 'package:sacdia_app/features/investiture/presentation/views/investiture_history_view.dart';
 import 'package:sacdia_app/features/evidence_folder/presentation/views/evidence_folder_view.dart';
@@ -720,6 +726,77 @@ final routerProvider = Provider<GoRouter>((ref) {
             context,
             state,
             InvestitureHistoryView(enrollmentId: enrollmentId),
+          );
+        },
+      ),
+
+      // Carga masiva por certificado OCR (member flow).
+      //
+      // TODO(certificate-import-entrypoint): conectar el acceso visible desde
+      // el módulo de evidencias/progreso cuando producto defina el punto exacto.
+      // Por ahora dejamos rutas profundas estables sin tocar la navegación
+      // principal ni romper el shell existente.
+      GoRoute(
+        path: RouteNames.certificateImportUpload,
+        pageBuilder: (context, state) => _sharedAxisBuild(
+          context,
+          state,
+          const CertificateImportUploadRouteView(),
+        ),
+      ),
+      GoRoute(
+        path: RouteNames.certificateImportProcessing,
+        pageBuilder: (context, state) {
+          final batchId = state.pathParameters['batchId']!;
+          return _sharedAxisBuild(
+            context,
+            state,
+            CertificateImportProcessingRouteView(batchId: batchId),
+          );
+        },
+      ),
+      GoRoute(
+        path: RouteNames.certificateImportReview,
+        pageBuilder: (context, state) {
+          final batchId = state.pathParameters['batchId']!;
+          return _sharedAxisBuild(
+            context,
+            state,
+            CertificateImportReviewRouteView(batchId: batchId),
+          );
+        },
+      ),
+      GoRoute(
+        path: RouteNames.certificateImportStatus,
+        pageBuilder: (context, state) {
+          final batchId = state.pathParameters['batchId']!;
+          return _sharedAxisBuild(
+            context,
+            state,
+            CertificateImportStatusRouteView(batchId: batchId),
+          );
+        },
+      ),
+      GoRoute(
+        path: RouteNames.certificateImportProof,
+        pageBuilder: (context, state) {
+          final item = state.extra is CertificateImportItem
+              ? state.extra as CertificateImportItem
+              : null;
+          return _sharedAxisBuild(
+            context,
+            state,
+            Scaffold(
+              appBar: AppBar(title: const Text('Registro importado')),
+              body: Padding(
+                padding: const EdgeInsets.all(16),
+                child: item == null
+                    ? const Text(
+                        'Detalle no disponible. Abrilo desde un registro importado.',
+                      )
+                    : CertificateImportProofCard(item: item),
+              ),
+            ),
           );
         },
       ),

--- a/lib/core/constants/api_endpoints.dart
+++ b/lib/core/constants/api_endpoints.dart
@@ -95,6 +95,9 @@ class ApiEndpoints {
   // ── Evidence Review ────────────────────────────────────────────────────────
   static const String evidenceReview = '/evidence-review';
 
+  // ── Certificate Bulk Imports ─────────────────────────────────────────────
+  static const String certificateBulkImports = '/certificate-bulk-imports';
+
   // ── Admin Analytics ───────────────────────────────────────────────────────
   static const String adminAnalytics = '/admin/analytics';
 

--- a/lib/features/certificate_import/data/datasources/certificate_import_remote_data_source.dart
+++ b/lib/features/certificate_import/data/datasources/certificate_import_remote_data_source.dart
@@ -1,0 +1,175 @@
+import 'package:dio/dio.dart';
+import '../../../../core/constants/api_endpoints.dart';
+import '../../../../core/errors/exceptions.dart';
+import '../models/certificate_import_batch_model.dart';
+import '../models/certificate_import_item_model.dart';
+
+class CertificateImportFilePayload {
+  final String url;
+  final String name;
+  final String type;
+  final String? ocrRawText;
+
+  const CertificateImportFilePayload({
+    required this.url,
+    required this.name,
+    required this.type,
+    this.ocrRawText,
+  });
+
+  Map<String, dynamic> toJson() => {
+        'file_url': url,
+        'file_name': name,
+        'file_type': type,
+        if (ocrRawText != null) 'ocr_raw_text': ocrRawText,
+      };
+}
+
+class CertificateImportItemUpdatePayload {
+  final String itemType;
+  final int? honorId;
+  final int? classId;
+  final String? detectedName;
+  final String? detectedDate;
+  final String? completedAt;
+  final double? ocrConfidence;
+  final Map<String, dynamic>? fieldConfidence;
+  final bool markAsReady;
+
+  const CertificateImportItemUpdatePayload({
+    required this.itemType,
+    this.honorId,
+    this.classId,
+    this.detectedName,
+    this.detectedDate,
+    this.completedAt,
+    this.ocrConfidence,
+    this.fieldConfidence,
+    this.markAsReady = false,
+  });
+
+  Map<String, dynamic> toJson() => {
+        'item_type': itemType,
+        if (honorId != null) 'honor_id': honorId,
+        if (classId != null) 'class_id': classId,
+        if (detectedName != null) 'detected_name': detectedName,
+        if (detectedDate != null) 'detected_date': detectedDate,
+        if (completedAt != null) 'completed_at': completedAt,
+        if (ocrConfidence != null) 'ocr_confidence': ocrConfidence,
+        if (fieldConfidence != null) 'field_confidence': fieldConfidence,
+        'mark_as_ready': markAsReady,
+      };
+}
+
+abstract class CertificateImportRemoteDataSource {
+  Future<CertificateImportBatchModel> createBatch({
+    required List<CertificateImportFilePayload> files,
+  });
+
+  Future<CertificateImportBatchModel> processOcr(String batchId);
+
+  Future<CertificateImportBatchModel> getBatch(String batchId);
+
+  Future<CertificateImportItemModel> updateItem({
+    required String batchId,
+    required String itemId,
+    required CertificateImportItemUpdatePayload payload,
+  });
+
+  Future<CertificateImportBatchModel> submitBatch(String batchId);
+
+  Future<CertificateImportItemModel> resubmitItem({
+    required String batchId,
+    required String itemId,
+    required CertificateImportItemUpdatePayload payload,
+  });
+}
+
+class CertificateImportRemoteDataSourceImpl
+    implements CertificateImportRemoteDataSource {
+  final Dio _dio;
+  final String _baseUrl;
+
+  CertificateImportRemoteDataSourceImpl({
+    required Dio dio,
+    required String baseUrl,
+  })  : _dio = dio,
+        _baseUrl = baseUrl;
+
+  String get _endpoint => '$_baseUrl${ApiEndpoints.certificateBulkImports}';
+
+  @override
+  Future<CertificateImportBatchModel> createBatch({
+    required List<CertificateImportFilePayload> files,
+  }) async {
+    final response = await _dio.post(
+      _endpoint,
+      data: {'files': files.map((file) => file.toJson()).toList()},
+    );
+    return CertificateImportBatchModel.fromJson(_data(response));
+  }
+
+  @override
+  Future<CertificateImportBatchModel> processOcr(String batchId) async {
+    final response = await _dio.post('$_endpoint/$batchId/process-ocr');
+    return CertificateImportBatchModel.fromJson(_data(response));
+  }
+
+  @override
+  Future<CertificateImportBatchModel> getBatch(String batchId) async {
+    final response = await _dio.get('$_endpoint/$batchId');
+    return CertificateImportBatchModel.fromJson(_data(response));
+  }
+
+  @override
+  Future<CertificateImportItemModel> updateItem({
+    required String batchId,
+    required String itemId,
+    required CertificateImportItemUpdatePayload payload,
+  }) async {
+    final response = await _dio.patch(
+      '$_endpoint/$batchId/items/$itemId',
+      data: payload.toJson(),
+    );
+    return CertificateImportItemModel.fromJson(_data(response));
+  }
+
+  @override
+  Future<CertificateImportBatchModel> submitBatch(String batchId) async {
+    final response = await _dio.post('$_endpoint/$batchId/submit');
+    return CertificateImportBatchModel.fromJson(_data(response));
+  }
+
+  @override
+  Future<CertificateImportItemModel> resubmitItem({
+    required String batchId,
+    required String itemId,
+    required CertificateImportItemUpdatePayload payload,
+  }) async {
+    final response = await _dio.post(
+      '$_endpoint/$batchId/items/$itemId/resubmit',
+      data: payload.toJson(),
+    );
+    return CertificateImportItemModel.fromJson(_data(response));
+  }
+
+  Map<String, dynamic> _data(Response<dynamic> response) {
+    if (response.statusCode != 200 && response.statusCode != 201) {
+      throw ServerException(
+        message: 'Error al comunicarse con carga por certificado',
+        code: response.statusCode,
+      );
+    }
+
+    final body = response.data;
+    if (body is Map<String, dynamic>) {
+      final data = body['data'];
+      if (data is Map<String, dynamic>) {
+        return data;
+      }
+    }
+
+    throw ServerException(
+        message: 'Respuesta inválida de carga por certificado');
+  }
+}

--- a/lib/features/certificate_import/data/models/certificate_import_batch_model.dart
+++ b/lib/features/certificate_import/data/models/certificate_import_batch_model.dart
@@ -1,0 +1,105 @@
+export '../../domain/entities/certificate_import_item.dart';
+
+import 'package:equatable/equatable.dart';
+import '../../../../core/utils/json_helpers.dart';
+import '../../domain/entities/certificate_import_batch.dart';
+import 'certificate_import_file_model.dart';
+import 'certificate_import_item_model.dart';
+
+class CertificateImportBatchModel extends Equatable {
+  final String id;
+  final String status;
+  final int? localFieldId;
+  final List<CertificateImportFileModel> files;
+  final List<CertificateImportItemModel> items;
+  final DateTime? submittedAt;
+  final DateTime? reviewedAt;
+  final DateTime? createdAt;
+  final DateTime? modifiedAt;
+
+  const CertificateImportBatchModel({
+    required this.id,
+    required this.status,
+    this.localFieldId,
+    this.files = const [],
+    this.items = const [],
+    this.submittedAt,
+    this.reviewedAt,
+    this.createdAt,
+    this.modifiedAt,
+  });
+
+  factory CertificateImportBatchModel.fromJson(Map<String, dynamic> json) {
+    final rawFiles = json['files'];
+    final rawItems = json['items'];
+    return CertificateImportBatchModel(
+      id: safeString(json['batch_id'] ?? json['id']),
+      status: safeString(json['status'], 'DRAFT'),
+      localFieldId: safeIntOrNull(json['local_field_id']),
+      files: rawFiles is List
+          ? rawFiles
+              .whereType<Map<String, dynamic>>()
+              .map(CertificateImportFileModel.fromJson)
+              .toList()
+          : const [],
+      items: rawItems is List
+          ? rawItems
+              .whereType<Map<String, dynamic>>()
+              .map(CertificateImportItemModel.fromJson)
+              .toList()
+          : const [],
+      submittedAt: _parseDate(json['submitted_at']),
+      reviewedAt: _parseDate(json['reviewed_at']),
+      createdAt: _parseDate(json['created_at']),
+      modifiedAt: _parseDate(json['modified_at']),
+    );
+  }
+
+  int get readyCount => items.where((item) => item.toEntity().isReady).length;
+  int get needsReviewCount =>
+      items.where((item) => item.toEntity().needsReview).length;
+  int get rejectedCount =>
+      items.where((item) => item.toEntity().isRejected).length;
+
+  Map<String, dynamic> toJson() => {
+        'batch_id': id,
+        'status': status,
+        'local_field_id': localFieldId,
+        'files': files.map((file) => file.toJson()).toList(),
+        'items': items.map((item) => item.toJson()).toList(),
+        'submitted_at': submittedAt?.toIso8601String(),
+        'reviewed_at': reviewedAt?.toIso8601String(),
+        'created_at': createdAt?.toIso8601String(),
+        'modified_at': modifiedAt?.toIso8601String(),
+      };
+
+  CertificateImportBatch toEntity() => CertificateImportBatch(
+        id: id,
+        status: status,
+        localFieldId: localFieldId,
+        files: files.map((file) => file.toEntity()).toList(),
+        items: items.map((item) => item.toEntity()).toList(),
+        submittedAt: submittedAt,
+        reviewedAt: reviewedAt,
+        createdAt: createdAt,
+        modifiedAt: modifiedAt,
+      );
+
+  static DateTime? _parseDate(dynamic value) {
+    final raw = safeStringOrNull(value);
+    return raw == null ? null : DateTime.tryParse(raw);
+  }
+
+  @override
+  List<Object?> get props => [
+        id,
+        status,
+        localFieldId,
+        files,
+        items,
+        submittedAt,
+        reviewedAt,
+        createdAt,
+        modifiedAt,
+      ];
+}

--- a/lib/features/certificate_import/data/models/certificate_import_file_model.dart
+++ b/lib/features/certificate_import/data/models/certificate_import_file_model.dart
@@ -1,0 +1,48 @@
+import 'package:equatable/equatable.dart';
+import '../../../../core/utils/json_helpers.dart';
+import '../../domain/entities/certificate_import_file.dart';
+
+class CertificateImportFileModel extends Equatable {
+  final String id;
+  final String url;
+  final String name;
+  final String type;
+  final DateTime? uploadedAt;
+
+  const CertificateImportFileModel({
+    required this.id,
+    required this.url,
+    required this.name,
+    required this.type,
+    this.uploadedAt,
+  });
+
+  factory CertificateImportFileModel.fromJson(Map<String, dynamic> json) {
+    return CertificateImportFileModel(
+      id: safeString(json['file_id'] ?? json['id']),
+      url: safeString(json['file_url'] ?? json['url']),
+      name: safeString(json['file_name'] ?? json['name']),
+      type: safeString(json['file_type'] ?? json['type']),
+      uploadedAt: DateTime.tryParse(safeString(json['uploaded_at'])),
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'file_id': id,
+        'file_url': url,
+        'file_name': name,
+        'file_type': type,
+        'uploaded_at': uploadedAt?.toIso8601String(),
+      };
+
+  CertificateImportFile toEntity() => CertificateImportFile(
+        id: id,
+        url: url,
+        name: name,
+        type: type,
+        uploadedAt: uploadedAt,
+      );
+
+  @override
+  List<Object?> get props => [id, url, name, type, uploadedAt];
+}

--- a/lib/features/certificate_import/data/models/certificate_import_item_model.dart
+++ b/lib/features/certificate_import/data/models/certificate_import_item_model.dart
@@ -1,3 +1,5 @@
+export '../../domain/entities/certificate_import_item.dart';
+
 import 'package:equatable/equatable.dart';
 import '../../../../core/utils/json_helpers.dart';
 import '../../domain/entities/certificate_import_item.dart';

--- a/lib/features/certificate_import/data/models/certificate_import_item_model.dart
+++ b/lib/features/certificate_import/data/models/certificate_import_item_model.dart
@@ -1,0 +1,162 @@
+import 'package:equatable/equatable.dart';
+import '../../../../core/utils/json_helpers.dart';
+import '../../domain/entities/certificate_import_item.dart';
+
+class CertificateImportItemModel extends Equatable {
+  final String id;
+  final String? batchId;
+  final CertificateImportItemType type;
+  final int? honorId;
+  final int? classId;
+  final String? detectedName;
+  final DateTime? detectedDate;
+  final DateTime? completedAt;
+  final double? ocrConfidence;
+  final Map<String, dynamic>? fieldConfidence;
+  final CertificateImportItemStatus status;
+  final String? rejectionReason;
+  final String? appliedEntityType;
+  final int? appliedEntityId;
+
+  const CertificateImportItemModel({
+    required this.id,
+    this.batchId,
+    required this.type,
+    this.honorId,
+    this.classId,
+    this.detectedName,
+    this.detectedDate,
+    this.completedAt,
+    this.ocrConfidence,
+    this.fieldConfidence,
+    required this.status,
+    this.rejectionReason,
+    this.appliedEntityType,
+    this.appliedEntityId,
+  });
+
+  factory CertificateImportItemModel.fromJson(Map<String, dynamic> json) {
+    final rawFieldConfidence = json['field_confidence'];
+    return CertificateImportItemModel(
+      id: safeString(json['item_id'] ?? json['id']),
+      batchId: safeStringOrNull(json['batch_id']),
+      type: parseItemType(safeString(json['item_type'] ?? json['type'])),
+      honorId: safeIntOrNull(json['honor_id']),
+      classId: safeIntOrNull(json['class_id']),
+      detectedName: safeStringOrNull(json['detected_name']),
+      detectedDate: _parseDate(json['detected_date']),
+      completedAt: _parseDate(json['completed_at']),
+      ocrConfidence: safeDouble(json['ocr_confidence'], double.nan).isNaN
+          ? null
+          : safeDouble(json['ocr_confidence']),
+      fieldConfidence: rawFieldConfidence is Map<String, dynamic>
+          ? rawFieldConfidence
+          : null,
+      status: parseItemStatus(safeString(json['status'])),
+      rejectionReason: safeStringOrNull(json['rejection_reason']),
+      appliedEntityType: safeStringOrNull(json['applied_entity_type']),
+      appliedEntityId: safeIntOrNull(json['applied_entity_id']),
+    );
+  }
+
+  static CertificateImportItemType parseItemType(String value) {
+    switch (value.toUpperCase()) {
+      case 'HONOR':
+        return CertificateImportItemType.honor;
+      case 'CLASS':
+        return CertificateImportItemType.clazz;
+      default:
+        return CertificateImportItemType.unknown;
+    }
+  }
+
+  static CertificateImportItemStatus parseItemStatus(String value) {
+    switch (value.toUpperCase()) {
+      case 'NEEDS_REVIEW':
+        return CertificateImportItemStatus.needsReview;
+      case 'READY':
+        return CertificateImportItemStatus.ready;
+      case 'SUBMITTED':
+        return CertificateImportItemStatus.submitted;
+      case 'APPROVED':
+        return CertificateImportItemStatus.approved;
+      case 'REJECTED':
+        return CertificateImportItemStatus.rejected;
+      case 'RESUBMITTED':
+        return CertificateImportItemStatus.resubmitted;
+      default:
+        return CertificateImportItemStatus.unknown;
+    }
+  }
+
+  Map<String, dynamic> toJson() => {
+        'item_id': id,
+        'batch_id': batchId,
+        'item_type': switch (type) {
+          CertificateImportItemType.honor => 'HONOR',
+          CertificateImportItemType.clazz => 'CLASS',
+          CertificateImportItemType.unknown => 'UNKNOWN',
+        },
+        'honor_id': honorId,
+        'class_id': classId,
+        'detected_name': detectedName,
+        'detected_date': _formatDate(detectedDate),
+        'completed_at': _formatDate(completedAt),
+        'ocr_confidence': ocrConfidence,
+        'field_confidence': fieldConfidence,
+        'status': switch (status) {
+          CertificateImportItemStatus.needsReview => 'NEEDS_REVIEW',
+          CertificateImportItemStatus.ready => 'READY',
+          CertificateImportItemStatus.submitted => 'SUBMITTED',
+          CertificateImportItemStatus.approved => 'APPROVED',
+          CertificateImportItemStatus.rejected => 'REJECTED',
+          CertificateImportItemStatus.resubmitted => 'RESUBMITTED',
+          CertificateImportItemStatus.unknown => 'UNKNOWN',
+        },
+        'rejection_reason': rejectionReason,
+        'applied_entity_type': appliedEntityType,
+        'applied_entity_id': appliedEntityId,
+      };
+
+  CertificateImportItem toEntity() => CertificateImportItem(
+        id: id,
+        batchId: batchId,
+        type: type,
+        honorId: honorId,
+        classId: classId,
+        detectedName: detectedName,
+        detectedDate: detectedDate,
+        completedAt: completedAt,
+        ocrConfidence: ocrConfidence,
+        fieldConfidence: fieldConfidence,
+        status: status,
+        rejectionReason: rejectionReason,
+        appliedEntityType: appliedEntityType,
+        appliedEntityId: appliedEntityId,
+      );
+
+  static DateTime? _parseDate(dynamic value) {
+    final raw = safeStringOrNull(value);
+    return raw == null ? null : DateTime.tryParse(raw);
+  }
+
+  static String? _formatDate(DateTime? value) => value?.toIso8601String();
+
+  @override
+  List<Object?> get props => [
+        id,
+        batchId,
+        type,
+        honorId,
+        classId,
+        detectedName,
+        detectedDate,
+        completedAt,
+        ocrConfidence,
+        fieldConfidence,
+        status,
+        rejectionReason,
+        appliedEntityType,
+        appliedEntityId,
+      ];
+}

--- a/lib/features/certificate_import/data/repositories/certificate_import_repository_impl.dart
+++ b/lib/features/certificate_import/data/repositories/certificate_import_repository_impl.dart
@@ -1,0 +1,116 @@
+import 'package:dartz/dartz.dart';
+import 'package:dio/dio.dart';
+import '../../../../core/errors/exceptions.dart';
+import '../../../../core/errors/failures.dart';
+import '../../../../core/network/network_info.dart';
+import '../../domain/entities/certificate_import_batch.dart';
+import '../../domain/entities/certificate_import_item.dart';
+import '../../domain/repositories/certificate_import_repository.dart';
+import '../datasources/certificate_import_remote_data_source.dart';
+
+class CertificateImportRepositoryImpl implements CertificateImportRepository {
+  final CertificateImportRemoteDataSource remoteDataSource;
+  final NetworkInfo networkInfo;
+
+  CertificateImportRepositoryImpl({
+    required this.remoteDataSource,
+    required this.networkInfo,
+  });
+
+  @override
+  Future<Either<Failure, CertificateImportBatch>> createBatch({
+    required List<CertificateImportFilePayload> files,
+  }) async {
+    return _batch(() => remoteDataSource.createBatch(files: files));
+  }
+
+  @override
+  Future<Either<Failure, CertificateImportBatch>> processOcr(String batchId) {
+    return _batch(() => remoteDataSource.processOcr(batchId));
+  }
+
+  @override
+  Future<Either<Failure, CertificateImportBatch>> getBatch(
+    String batchId, {
+    CancelToken? cancelToken,
+  }) {
+    return _batch(() => remoteDataSource.getBatch(batchId));
+  }
+
+  @override
+  Future<Either<Failure, CertificateImportItem>> updateItem({
+    required String batchId,
+    required String itemId,
+    required CertificateImportItemUpdatePayload payload,
+  }) {
+    return _item(
+      () => remoteDataSource.updateItem(
+        batchId: batchId,
+        itemId: itemId,
+        payload: payload,
+      ),
+    );
+  }
+
+  @override
+  Future<Either<Failure, CertificateImportBatch>> submitBatch(String batchId) {
+    return _batch(() => remoteDataSource.submitBatch(batchId));
+  }
+
+  @override
+  Future<Either<Failure, CertificateImportItem>> resubmitItem({
+    required String batchId,
+    required String itemId,
+    required CertificateImportItemUpdatePayload payload,
+  }) {
+    return _item(
+      () => remoteDataSource.resubmitItem(
+        batchId: batchId,
+        itemId: itemId,
+        payload: payload,
+      ),
+    );
+  }
+
+  Future<Either<Failure, CertificateImportBatch>> _batch(
+    Future<dynamic> Function() action,
+  ) async {
+    try {
+      final model = await action();
+      return Right(model.toEntity() as CertificateImportBatch);
+    } on ServerException catch (error) {
+      return Left(ServerFailure(message: error.message, code: error.code));
+    } on AuthException catch (error) {
+      return Left(AuthFailure(message: error.message, code: error.code));
+    } on DioException catch (error) {
+      return Left(
+        ServerFailure(
+            message: error.message ?? 'Error de red',
+            code: error.response?.statusCode),
+      );
+    } catch (error) {
+      return Left(UnexpectedFailure(message: error.toString()));
+    }
+  }
+
+  Future<Either<Failure, CertificateImportItem>> _item(
+    Future<dynamic> Function() action,
+  ) async {
+    try {
+      final model = await action();
+      return Right(model.toEntity() as CertificateImportItem);
+    } on ServerException catch (error) {
+      return Left(ServerFailure(message: error.message, code: error.code));
+    } on AuthException catch (error) {
+      return Left(AuthFailure(message: error.message, code: error.code));
+    } on DioException catch (error) {
+      return Left(
+        ServerFailure(
+            message: error.message ?? 'Error de red',
+            code: error.response?.statusCode),
+      );
+    } catch (error) {
+      return Left(UnexpectedFailure(message: error.toString()));
+    }
+  }
+}

--- a/lib/features/certificate_import/domain/entities/certificate_import_batch.dart
+++ b/lib/features/certificate_import/domain/entities/certificate_import_batch.dart
@@ -1,0 +1,44 @@
+import 'package:equatable/equatable.dart';
+import 'certificate_import_file.dart';
+import 'certificate_import_item.dart';
+
+class CertificateImportBatch extends Equatable {
+  final String id;
+  final String status;
+  final int? localFieldId;
+  final List<CertificateImportFile> files;
+  final List<CertificateImportItem> items;
+  final DateTime? submittedAt;
+  final DateTime? reviewedAt;
+  final DateTime? createdAt;
+  final DateTime? modifiedAt;
+
+  const CertificateImportBatch({
+    required this.id,
+    required this.status,
+    this.localFieldId,
+    this.files = const [],
+    this.items = const [],
+    this.submittedAt,
+    this.reviewedAt,
+    this.createdAt,
+    this.modifiedAt,
+  });
+
+  int get readyCount => items.where((item) => item.isReady).length;
+  int get needsReviewCount => items.where((item) => item.needsReview).length;
+  int get rejectedCount => items.where((item) => item.isRejected).length;
+
+  @override
+  List<Object?> get props => [
+        id,
+        status,
+        localFieldId,
+        files,
+        items,
+        submittedAt,
+        reviewedAt,
+        createdAt,
+        modifiedAt,
+      ];
+}

--- a/lib/features/certificate_import/domain/entities/certificate_import_file.dart
+++ b/lib/features/certificate_import/domain/entities/certificate_import_file.dart
@@ -1,0 +1,20 @@
+import 'package:equatable/equatable.dart';
+
+class CertificateImportFile extends Equatable {
+  final String id;
+  final String url;
+  final String name;
+  final String type;
+  final DateTime? uploadedAt;
+
+  const CertificateImportFile({
+    required this.id,
+    required this.url,
+    required this.name,
+    required this.type,
+    this.uploadedAt,
+  });
+
+  @override
+  List<Object?> get props => [id, url, name, type, uploadedAt];
+}

--- a/lib/features/certificate_import/domain/entities/certificate_import_item.dart
+++ b/lib/features/certificate_import/domain/entities/certificate_import_item.dart
@@ -1,0 +1,75 @@
+import 'package:equatable/equatable.dart';
+
+enum CertificateImportItemType { honor, clazz, unknown }
+
+enum CertificateImportItemStatus {
+  needsReview,
+  ready,
+  submitted,
+  approved,
+  rejected,
+  resubmitted,
+  unknown,
+}
+
+class CertificateImportItem extends Equatable {
+  final String id;
+  final String? batchId;
+  final CertificateImportItemType type;
+  final int? honorId;
+  final int? classId;
+  final String? detectedName;
+  final DateTime? detectedDate;
+  final DateTime? completedAt;
+  final double? ocrConfidence;
+  final Map<String, dynamic>? fieldConfidence;
+  final CertificateImportItemStatus status;
+  final String? rejectionReason;
+  final String? appliedEntityType;
+  final int? appliedEntityId;
+
+  const CertificateImportItem({
+    required this.id,
+    this.batchId,
+    required this.type,
+    this.honorId,
+    this.classId,
+    this.detectedName,
+    this.detectedDate,
+    this.completedAt,
+    this.ocrConfidence,
+    this.fieldConfidence,
+    required this.status,
+    this.rejectionReason,
+    this.appliedEntityType,
+    this.appliedEntityId,
+  });
+
+  bool get isReady =>
+      status == CertificateImportItemStatus.ready ||
+      status == CertificateImportItemStatus.submitted ||
+      status == CertificateImportItemStatus.resubmitted ||
+      status == CertificateImportItemStatus.approved;
+
+  bool get needsReview => status == CertificateImportItemStatus.needsReview;
+
+  bool get isRejected => status == CertificateImportItemStatus.rejected;
+
+  @override
+  List<Object?> get props => [
+        id,
+        batchId,
+        type,
+        honorId,
+        classId,
+        detectedName,
+        detectedDate,
+        completedAt,
+        ocrConfidence,
+        fieldConfidence,
+        status,
+        rejectionReason,
+        appliedEntityType,
+        appliedEntityId,
+      ];
+}

--- a/lib/features/certificate_import/domain/repositories/certificate_import_repository.dart
+++ b/lib/features/certificate_import/domain/repositories/certificate_import_repository.dart
@@ -1,0 +1,33 @@
+import 'package:dartz/dartz.dart';
+import 'package:dio/dio.dart';
+import '../../../../core/errors/failures.dart';
+import '../../data/datasources/certificate_import_remote_data_source.dart';
+import '../entities/certificate_import_batch.dart';
+import '../entities/certificate_import_item.dart';
+
+abstract class CertificateImportRepository {
+  Future<Either<Failure, CertificateImportBatch>> createBatch({
+    required List<CertificateImportFilePayload> files,
+  });
+
+  Future<Either<Failure, CertificateImportBatch>> processOcr(String batchId);
+
+  Future<Either<Failure, CertificateImportBatch>> getBatch(
+    String batchId, {
+    CancelToken? cancelToken,
+  });
+
+  Future<Either<Failure, CertificateImportItem>> updateItem({
+    required String batchId,
+    required String itemId,
+    required CertificateImportItemUpdatePayload payload,
+  });
+
+  Future<Either<Failure, CertificateImportBatch>> submitBatch(String batchId);
+
+  Future<Either<Failure, CertificateImportItem>> resubmitItem({
+    required String batchId,
+    required String itemId,
+    required CertificateImportItemUpdatePayload payload,
+  });
+}

--- a/lib/features/certificate_import/domain/usecases/create_certificate_import_batch.dart
+++ b/lib/features/certificate_import/domain/usecases/create_certificate_import_batch.dart
@@ -1,0 +1,23 @@
+import 'package:dartz/dartz.dart';
+import '../../../../core/errors/failures.dart';
+import '../../data/datasources/certificate_import_remote_data_source.dart';
+import '../entities/certificate_import_batch.dart';
+import '../repositories/certificate_import_repository.dart';
+
+class CreateCertificateImportBatch {
+  final CertificateImportRepository repository;
+
+  CreateCertificateImportBatch(this.repository);
+
+  Future<Either<Failure, CertificateImportBatch>> call(
+    CreateCertificateImportBatchParams params,
+  ) {
+    return repository.createBatch(files: params.files);
+  }
+}
+
+class CreateCertificateImportBatchParams {
+  final List<CertificateImportFilePayload> files;
+
+  const CreateCertificateImportBatchParams({required this.files});
+}

--- a/lib/features/certificate_import/domain/usecases/get_certificate_import_batch.dart
+++ b/lib/features/certificate_import/domain/usecases/get_certificate_import_batch.dart
@@ -1,0 +1,18 @@
+import 'package:dartz/dartz.dart';
+import 'package:dio/dio.dart';
+import '../../../../core/errors/failures.dart';
+import '../entities/certificate_import_batch.dart';
+import '../repositories/certificate_import_repository.dart';
+
+class GetCertificateImportBatch {
+  final CertificateImportRepository repository;
+
+  GetCertificateImportBatch(this.repository);
+
+  Future<Either<Failure, CertificateImportBatch>> call(
+    String batchId, {
+    CancelToken? cancelToken,
+  }) {
+    return repository.getBatch(batchId, cancelToken: cancelToken);
+  }
+}

--- a/lib/features/certificate_import/domain/usecases/process_certificate_import_ocr.dart
+++ b/lib/features/certificate_import/domain/usecases/process_certificate_import_ocr.dart
@@ -1,0 +1,14 @@
+import 'package:dartz/dartz.dart';
+import '../../../../core/errors/failures.dart';
+import '../entities/certificate_import_batch.dart';
+import '../repositories/certificate_import_repository.dart';
+
+class ProcessCertificateImportOcr {
+  final CertificateImportRepository repository;
+
+  ProcessCertificateImportOcr(this.repository);
+
+  Future<Either<Failure, CertificateImportBatch>> call(String batchId) {
+    return repository.processOcr(batchId);
+  }
+}

--- a/lib/features/certificate_import/domain/usecases/resubmit_certificate_import_item.dart
+++ b/lib/features/certificate_import/domain/usecases/resubmit_certificate_import_item.dart
@@ -1,0 +1,33 @@
+import 'package:dartz/dartz.dart';
+import '../../../../core/errors/failures.dart';
+import '../../data/datasources/certificate_import_remote_data_source.dart';
+import '../entities/certificate_import_item.dart';
+import '../repositories/certificate_import_repository.dart';
+
+class ResubmitCertificateImportItem {
+  final CertificateImportRepository repository;
+
+  ResubmitCertificateImportItem(this.repository);
+
+  Future<Either<Failure, CertificateImportItem>> call(
+    ResubmitCertificateImportItemParams params,
+  ) {
+    return repository.resubmitItem(
+      batchId: params.batchId,
+      itemId: params.itemId,
+      payload: params.payload,
+    );
+  }
+}
+
+class ResubmitCertificateImportItemParams {
+  final String batchId;
+  final String itemId;
+  final CertificateImportItemUpdatePayload payload;
+
+  const ResubmitCertificateImportItemParams({
+    required this.batchId,
+    required this.itemId,
+    required this.payload,
+  });
+}

--- a/lib/features/certificate_import/domain/usecases/submit_certificate_import_batch.dart
+++ b/lib/features/certificate_import/domain/usecases/submit_certificate_import_batch.dart
@@ -1,0 +1,14 @@
+import 'package:dartz/dartz.dart';
+import '../../../../core/errors/failures.dart';
+import '../entities/certificate_import_batch.dart';
+import '../repositories/certificate_import_repository.dart';
+
+class SubmitCertificateImportBatch {
+  final CertificateImportRepository repository;
+
+  SubmitCertificateImportBatch(this.repository);
+
+  Future<Either<Failure, CertificateImportBatch>> call(String batchId) {
+    return repository.submitBatch(batchId);
+  }
+}

--- a/lib/features/certificate_import/domain/usecases/update_certificate_import_item.dart
+++ b/lib/features/certificate_import/domain/usecases/update_certificate_import_item.dart
@@ -1,0 +1,33 @@
+import 'package:dartz/dartz.dart';
+import '../../../../core/errors/failures.dart';
+import '../../data/datasources/certificate_import_remote_data_source.dart';
+import '../entities/certificate_import_item.dart';
+import '../repositories/certificate_import_repository.dart';
+
+class UpdateCertificateImportItem {
+  final CertificateImportRepository repository;
+
+  UpdateCertificateImportItem(this.repository);
+
+  Future<Either<Failure, CertificateImportItem>> call(
+    UpdateCertificateImportItemParams params,
+  ) {
+    return repository.updateItem(
+      batchId: params.batchId,
+      itemId: params.itemId,
+      payload: params.payload,
+    );
+  }
+}
+
+class UpdateCertificateImportItemParams {
+  final String batchId;
+  final String itemId;
+  final CertificateImportItemUpdatePayload payload;
+
+  const UpdateCertificateImportItemParams({
+    required this.batchId,
+    required this.itemId,
+    required this.payload,
+  });
+}

--- a/lib/features/certificate_import/presentation/providers/certificate_import_providers.dart
+++ b/lib/features/certificate_import/presentation/providers/certificate_import_providers.dart
@@ -1,0 +1,81 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../../../providers/dio_provider.dart';
+import '../../../auth/presentation/providers/auth_providers.dart';
+import '../../data/datasources/certificate_import_remote_data_source.dart';
+import '../../data/repositories/certificate_import_repository_impl.dart';
+import '../../domain/entities/certificate_import_batch.dart';
+import '../../domain/repositories/certificate_import_repository.dart';
+import '../../domain/usecases/create_certificate_import_batch.dart';
+import '../../domain/usecases/get_certificate_import_batch.dart';
+import '../../domain/usecases/process_certificate_import_ocr.dart';
+import '../../domain/usecases/resubmit_certificate_import_item.dart';
+import '../../domain/usecases/submit_certificate_import_batch.dart';
+import '../../domain/usecases/update_certificate_import_item.dart';
+
+final certificateImportRemoteDataSourceProvider =
+    Provider<CertificateImportRemoteDataSource>((ref) {
+  return CertificateImportRemoteDataSourceImpl(
+    dio: ref.read(dioProvider),
+    baseUrl: ref.read(apiBaseUrlProvider),
+  );
+});
+
+final certificateImportRepositoryProvider =
+    Provider<CertificateImportRepository>((ref) {
+  return CertificateImportRepositoryImpl(
+    remoteDataSource: ref.read(certificateImportRemoteDataSourceProvider),
+    networkInfo: ref.read(networkInfoProvider),
+  );
+});
+
+final createCertificateImportBatchProvider =
+    Provider<CreateCertificateImportBatch>((ref) {
+  return CreateCertificateImportBatch(
+      ref.read(certificateImportRepositoryProvider));
+});
+
+final processCertificateImportOcrProvider =
+    Provider<ProcessCertificateImportOcr>((ref) {
+  return ProcessCertificateImportOcr(
+      ref.read(certificateImportRepositoryProvider));
+});
+
+final getCertificateImportBatchProvider =
+    Provider<GetCertificateImportBatch>((ref) {
+  return GetCertificateImportBatch(
+      ref.read(certificateImportRepositoryProvider));
+});
+
+final updateCertificateImportItemProvider =
+    Provider<UpdateCertificateImportItem>((ref) {
+  return UpdateCertificateImportItem(
+      ref.read(certificateImportRepositoryProvider));
+});
+
+final submitCertificateImportBatchProvider =
+    Provider<SubmitCertificateImportBatch>((ref) {
+  return SubmitCertificateImportBatch(
+      ref.read(certificateImportRepositoryProvider));
+});
+
+final resubmitCertificateImportItemProvider =
+    Provider<ResubmitCertificateImportItem>((ref) {
+  return ResubmitCertificateImportItem(
+      ref.read(certificateImportRepositoryProvider));
+});
+
+final certificateImportBatchProvider = FutureProvider.autoDispose
+    .family<CertificateImportBatch, String>((ref, batchId) async {
+  final cancelToken = CancelToken();
+  ref.onDispose(() => cancelToken.cancel());
+
+  final result = await ref
+      .read(getCertificateImportBatchProvider)
+      .call(batchId, cancelToken: cancelToken);
+
+  return result.fold(
+    (failure) => throw Exception(failure.message),
+    (batch) => batch,
+  );
+});

--- a/lib/features/certificate_import/presentation/views/certificate_import_processing_view.dart
+++ b/lib/features/certificate_import/presentation/views/certificate_import_processing_view.dart
@@ -1,0 +1,180 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:sacdia_app/core/config/route_names.dart';
+import 'package:sacdia_app/core/theme/sac_colors.dart';
+import 'package:sacdia_app/core/widgets/sac_button.dart';
+import 'package:sacdia_app/core/widgets/sac_card.dart';
+
+import '../providers/certificate_import_providers.dart';
+
+class CertificateImportProcessingRouteView extends ConsumerWidget {
+  const CertificateImportProcessingRouteView(
+      {super.key, required this.batchId});
+
+  final String batchId;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return CertificateImportProcessingView(
+      batchId: batchId,
+      onStartOcr: () async {
+        final result =
+            await ref.read(processCertificateImportOcrProvider).call(batchId);
+        result.fold(
+          (failure) => throw Exception(failure.message),
+          (_) => context.go(RouteNames.certificateImportReviewPath(batchId)),
+        );
+      },
+      onManualFallback: () =>
+          context.go(RouteNames.certificateImportReviewPath(batchId)),
+    );
+  }
+}
+
+class CertificateImportProcessingView extends StatefulWidget {
+  const CertificateImportProcessingView({
+    super.key,
+    required this.batchId,
+    this.autoStart = true,
+    this.onStartOcr,
+    this.onManualFallback,
+  });
+
+  final String batchId;
+  final bool autoStart;
+  final Future<void> Function()? onStartOcr;
+  final VoidCallback? onManualFallback;
+
+  @override
+  State<CertificateImportProcessingView> createState() =>
+      _CertificateImportProcessingViewState();
+}
+
+class _CertificateImportProcessingViewState
+    extends State<CertificateImportProcessingView> {
+  bool _running = false;
+  String? _error;
+
+  @override
+  void initState() {
+    super.initState();
+    if (widget.autoStart) {
+      WidgetsBinding.instance.addPostFrameCallback((_) => _start());
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final c = context.sac;
+    return Scaffold(
+      backgroundColor: c.background,
+      appBar: AppBar(title: const Text('Leyendo comprobante')),
+      body: ListView(
+        padding: const EdgeInsets.fromLTRB(20, 16, 20, 28),
+        children: [
+          SacCard(
+            child: Column(
+              children: [
+                Icon(Icons.document_scanner_rounded, size: 72, color: c.info),
+                const SizedBox(height: 16),
+                Text(
+                  _error == null
+                      ? 'Estamos leyendo tu comprobante'
+                      : 'No pudimos leer todo',
+                  textAlign: TextAlign.center,
+                  style: Theme.of(context).textTheme.headlineSmall?.copyWith(
+                        color: c.text,
+                        fontWeight: FontWeight.w700,
+                      ),
+                ),
+                const SizedBox(height: 8),
+                Text(
+                  _error == null
+                      ? 'Extraemos honores, clases y fechas para que confirmes los datos.'
+                      : 'Podés reintentar OCR o completar los datos manualmente. No te dejamos en un callejón sin salida.',
+                  textAlign: TextAlign.center,
+                  style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                        color: c.textSecondary,
+                      ),
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(height: 16),
+          _Step(label: 'Subiendo archivo', done: true),
+          _Step(label: 'Leyendo texto', active: _running && _error == null),
+          _Step(
+              label: 'Preparando resultados',
+              active: _running && _error == null),
+          if (_error != null) ...[
+            const SizedBox(height: 12),
+            Text(_error!, style: TextStyle(color: c.error)),
+          ],
+          const SizedBox(height: 22),
+          SacButton.outline(
+            text: 'Completar manualmente',
+            icon: Icons.edit_note_rounded,
+            onPressed: widget.onManualFallback,
+          ),
+          const SizedBox(height: 10),
+          SacButton.ghost(
+            text: 'Reintentar lectura',
+            onPressed: _running ? null : _start,
+          ),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _start() async {
+    if (widget.onStartOcr == null) return;
+    setState(() {
+      _running = true;
+      _error = null;
+    });
+    try {
+      await widget.onStartOcr!();
+    } catch (error) {
+      if (mounted) setState(() => _error = error.toString());
+    } finally {
+      if (mounted) setState(() => _running = false);
+    }
+  }
+}
+
+class _Step extends StatelessWidget {
+  const _Step({required this.label, this.done = false, this.active = false});
+
+  final String label;
+  final bool done;
+  final bool active;
+
+  @override
+  Widget build(BuildContext context) {
+    final c = context.sac;
+    final color = done
+        ? c.success
+        : active
+            ? c.warning
+            : c.border;
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 7),
+      child: Row(
+        children: [
+          Icon(done ? Icons.check_circle_rounded : Icons.radio_button_unchecked,
+              color: color),
+          const SizedBox(width: 12),
+          Expanded(child: Text(label)),
+          if (active)
+            SizedBox(
+              width: 18,
+              height: 18,
+              child:
+                  CircularProgressIndicator(strokeWidth: 2, color: c.warning),
+            ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/certificate_import/presentation/views/certificate_import_review_view.dart
+++ b/lib/features/certificate_import/presentation/views/certificate_import_review_view.dart
@@ -1,0 +1,304 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:sacdia_app/core/config/route_names.dart';
+import 'package:sacdia_app/core/theme/sac_colors.dart';
+import 'package:sacdia_app/core/widgets/sac_badge.dart';
+import 'package:sacdia_app/core/widgets/sac_button.dart';
+import 'package:sacdia_app/core/widgets/sac_card.dart';
+
+import '../../data/datasources/certificate_import_remote_data_source.dart';
+import '../../domain/entities/certificate_import_batch.dart';
+import '../../domain/entities/certificate_import_item.dart';
+import '../../domain/usecases/update_certificate_import_item.dart';
+import '../providers/certificate_import_providers.dart';
+import '../widgets/certificate_import_item_card.dart';
+import '../widgets/certificate_import_item_editor_sheet.dart';
+
+class CertificateImportReviewRouteView extends ConsumerWidget {
+  const CertificateImportReviewRouteView({super.key, required this.batchId});
+
+  final String batchId;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final batchAsync = ref.watch(certificateImportBatchProvider(batchId));
+    return batchAsync.when(
+      loading: () =>
+          const Scaffold(body: Center(child: CircularProgressIndicator())),
+      error: (error, _) => Scaffold(
+        appBar: AppBar(title: const Text('Revisá los datos')),
+        body: Center(child: Text('No pudimos cargar el lote: $error')),
+      ),
+      data: (batch) => CertificateImportReviewView(
+        initialBatch: batch,
+        onUpdateItem: (item) async {
+          final payload = CertificateImportItemUpdatePayload(
+            itemType: item.type == CertificateImportItemType.honor
+                ? 'HONOR'
+                : 'CLASS',
+            honorId: item.honorId,
+            classId: item.classId,
+            detectedName: item.detectedName,
+            completedAt: _apiDate(item.completedAt),
+            markAsReady: item.status == CertificateImportItemStatus.ready,
+          );
+          final result =
+              await ref.read(updateCertificateImportItemProvider).call(
+                    UpdateCertificateImportItemParams(
+                      batchId: batch.id,
+                      itemId: item.id,
+                      payload: payload,
+                    ),
+                  );
+          result.fold((failure) => throw Exception(failure.message), (_) {});
+        },
+        onSubmitBatch: () async {
+          final result = await ref
+              .read(submitCertificateImportBatchProvider)
+              .call(batch.id);
+          result.fold(
+            (failure) => throw Exception(failure.message),
+            (_) => context.go(RouteNames.certificateImportStatusPath(batch.id)),
+          );
+        },
+      ),
+    );
+  }
+
+  static String? _apiDate(DateTime? date) {
+    if (date == null) return null;
+    return '${date.year.toString().padLeft(4, '0')}-${date.month.toString().padLeft(2, '0')}-${date.day.toString().padLeft(2, '0')}';
+  }
+}
+
+class CertificateImportReviewView extends StatefulWidget {
+  const CertificateImportReviewView({
+    super.key,
+    required this.initialBatch,
+    this.onUpdateItem,
+    this.onSubmitBatch,
+  });
+
+  final CertificateImportBatch initialBatch;
+  final Future<void> Function(CertificateImportItem item)? onUpdateItem;
+  final Future<void> Function()? onSubmitBatch;
+
+  @override
+  State<CertificateImportReviewView> createState() =>
+      _CertificateImportReviewViewState();
+}
+
+class _CertificateImportReviewViewState
+    extends State<CertificateImportReviewView> {
+  late List<CertificateImportItem> _items;
+  bool _submitting = false;
+  String _filter = 'all';
+
+  @override
+  void initState() {
+    super.initState();
+    _items = List.of(widget.initialBatch.items);
+  }
+
+  bool get _canSubmit => _items.isNotEmpty && _items.every(_isComplete);
+
+  int get _honorCount => _items
+      .where((item) => item.type == CertificateImportItemType.honor)
+      .length;
+  int get _classCount => _items
+      .where((item) => item.type == CertificateImportItemType.clazz)
+      .length;
+  int get _readyCount => _items.where(_isComplete).length;
+  int get _missingCount => _items.length - _readyCount;
+
+  @override
+  Widget build(BuildContext context) {
+    final c = context.sac;
+    final visibleItems = _items.where((item) {
+      if (_filter == 'ready') return _isComplete(item);
+      if (_filter == 'missing') return !_isComplete(item);
+      return true;
+    }).toList(growable: false);
+
+    return Scaffold(
+      backgroundColor: c.background,
+      appBar: AppBar(title: const Text('Revisá los datos')),
+      body: Stack(
+        children: [
+          CustomScrollView(
+            slivers: [
+              SliverToBoxAdapter(
+                child: Padding(
+                  padding: const EdgeInsets.fromLTRB(16, 4, 16, 14),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text('Encontramos',
+                          style: TextStyle(color: c.textSecondary)),
+                      const SizedBox(height: 2),
+                      Text(
+                        '$_honorCount ${_honorCount == 1 ? 'especialidad' : 'especialidades'} y $_classCount ${_classCount == 1 ? 'clase' : 'clases'}',
+                        style:
+                            Theme.of(context).textTheme.displaySmall?.copyWith(
+                                  color: c.text,
+                                  fontWeight: FontWeight.w700,
+                                ),
+                      ),
+                      const SizedBox(height: 12),
+                      Wrap(
+                        spacing: 8,
+                        runSpacing: 8,
+                        children: [
+                          _FilterButton(
+                            label: 'Todas ${_items.length}',
+                            selected: _filter == 'all',
+                            onPressed: () => setState(() => _filter = 'all'),
+                          ),
+                          _FilterButton(
+                            label: 'Listas $_readyCount',
+                            selected: _filter == 'ready',
+                            onPressed: () => setState(() => _filter = 'ready'),
+                          ),
+                          _FilterButton(
+                            label: 'Falta dato $_missingCount',
+                            selected: _filter == 'missing',
+                            onPressed: () =>
+                                setState(() => _filter = 'missing'),
+                          ),
+                        ],
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+              if (visibleItems.isEmpty)
+                SliverToBoxAdapter(
+                  child: Padding(
+                    padding: const EdgeInsets.all(16),
+                    child: SacCard(
+                      child: Text('No hay filas para este filtro.',
+                          style: TextStyle(color: c.textSecondary)),
+                    ),
+                  ),
+                )
+              else
+                SliverPadding(
+                  padding: const EdgeInsets.fromLTRB(16, 0, 16, 150),
+                  sliver: SliverList.separated(
+                    itemCount: visibleItems.length,
+                    separatorBuilder: (_, __) => const SizedBox(height: 12),
+                    itemBuilder: (context, index) {
+                      final item = visibleItems[index];
+                      return CertificateImportItemCard(
+                        item: item,
+                        onEdit: () => _openEditor(item),
+                      );
+                    },
+                  ),
+                ),
+            ],
+          ),
+          Positioned(
+            left: 0,
+            right: 0,
+            bottom: 0,
+            child: DecoratedBox(
+              decoration: BoxDecoration(
+                color: c.background,
+                border: Border(top: BorderSide(color: c.border)),
+              ),
+              child: SafeArea(
+                top: false,
+                child: Padding(
+                  padding: const EdgeInsets.fromLTRB(16, 12, 16, 16),
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Row(
+                        children: [
+                          SacBadge.success(label: '$_readyCount listas'),
+                          const SizedBox(width: 8),
+                          SacBadge.warning(
+                              label: '$_missingCount con datos faltantes'),
+                        ],
+                      ),
+                      const SizedBox(height: 10),
+                      SacButton.primary(
+                        text: 'Enviar a revisión',
+                        isEnabled: _canSubmit,
+                        isLoading: _submitting,
+                        onPressed: _canSubmit ? _submit : null,
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _openEditor(CertificateImportItem item) async {
+    await showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      useSafeArea: true,
+      builder: (context) => CertificateImportItemEditorSheet(
+        item: item,
+        onSave: (updated) async {
+          await widget.onUpdateItem?.call(updated);
+          setState(() {
+            _items = _items
+                .map((current) => current.id == updated.id ? updated : current)
+                .toList(growable: false);
+          });
+        },
+      ),
+    );
+  }
+
+  Future<void> _submit() async {
+    setState(() => _submitting = true);
+    try {
+      await widget.onSubmitBatch?.call();
+    } finally {
+      if (mounted) setState(() => _submitting = false);
+    }
+  }
+
+  bool _isComplete(CertificateImportItem item) {
+    final hasCatalog = item.type == CertificateImportItemType.honor
+        ? item.honorId != null
+        : item.classId != null;
+    return item.type != CertificateImportItemType.unknown &&
+        (item.detectedName?.trim().isNotEmpty ?? false) &&
+        item.completedAt != null &&
+        hasCatalog;
+  }
+}
+
+class _FilterButton extends StatelessWidget {
+  const _FilterButton({
+    required this.label,
+    required this.selected,
+    required this.onPressed,
+  });
+
+  final String label;
+  final bool selected;
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return SacButton(
+      text: label,
+      size: SacButtonSize.small,
+      fullWidth: false,
+      variant: selected ? SacButtonVariant.primary : SacButtonVariant.outline,
+      onPressed: onPressed,
+    );
+  }
+}

--- a/lib/features/certificate_import/presentation/views/certificate_import_status_view.dart
+++ b/lib/features/certificate_import/presentation/views/certificate_import_status_view.dart
@@ -1,0 +1,134 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:sacdia_app/core/theme/sac_colors.dart';
+import 'package:sacdia_app/core/widgets/sac_badge.dart';
+import 'package:sacdia_app/core/widgets/sac_card.dart';
+
+import '../../data/datasources/certificate_import_remote_data_source.dart';
+import '../../domain/entities/certificate_import_batch.dart';
+import '../../domain/entities/certificate_import_item.dart';
+import '../../domain/usecases/resubmit_certificate_import_item.dart';
+import '../providers/certificate_import_providers.dart';
+import '../widgets/certificate_import_item_card.dart';
+
+class CertificateImportStatusRouteView extends ConsumerWidget {
+  const CertificateImportStatusRouteView({super.key, required this.batchId});
+
+  final String batchId;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final batchAsync = ref.watch(certificateImportBatchProvider(batchId));
+    return batchAsync.when(
+      loading: () =>
+          const Scaffold(body: Center(child: CircularProgressIndicator())),
+      error: (error, _) => Scaffold(
+          body: Center(child: Text('No pudimos cargar el estado: $error'))),
+      data: (batch) => CertificateImportStatusView(
+        batch: batch,
+        onResubmitItem: (item) async {
+          final result =
+              await ref.read(resubmitCertificateImportItemProvider).call(
+                    ResubmitCertificateImportItemParams(
+                      batchId: batch.id,
+                      itemId: item.id,
+                      payload: CertificateImportItemUpdatePayload(
+                        itemType: item.type == CertificateImportItemType.honor
+                            ? 'HONOR'
+                            : 'CLASS',
+                        honorId: item.honorId,
+                        classId: item.classId,
+                        detectedName: item.detectedName,
+                        completedAt: _apiDate(item.completedAt),
+                        markAsReady: true,
+                      ),
+                    ),
+                  );
+          result.fold((failure) => throw Exception(failure.message), (_) {});
+        },
+      ),
+    );
+  }
+
+  static String? _apiDate(DateTime? date) {
+    if (date == null) return null;
+    return '${date.year.toString().padLeft(4, '0')}-${date.month.toString().padLeft(2, '0')}-${date.day.toString().padLeft(2, '0')}';
+  }
+}
+
+class CertificateImportStatusView extends StatelessWidget {
+  const CertificateImportStatusView({
+    super.key,
+    required this.batch,
+    this.onResubmitItem,
+  });
+
+  final CertificateImportBatch batch;
+  final Future<void> Function(CertificateImportItem item)? onResubmitItem;
+
+  @override
+  Widget build(BuildContext context) {
+    final c = context.sac;
+    final rejected = batch.items
+        .where((item) => item.isRejected || item.rejectionReason != null)
+        .toList();
+    final pending = batch.items
+        .where((item) =>
+            !item.isRejected && item.rejectionReason == null && !item.isReady)
+        .length;
+    final approved = batch.items
+        .where((item) => item.status == CertificateImportItemStatus.approved)
+        .length;
+
+    return Scaffold(
+      backgroundColor: c.background,
+      appBar: AppBar(title: const Text('Estado del envío')),
+      body: ListView(
+        padding: const EdgeInsets.fromLTRB(16, 8, 16, 28),
+        children: [
+          SacCard(
+            accentColor: rejected.isNotEmpty ? c.error : c.warning,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                SacBadge(
+                  label: rejected.isNotEmpty
+                      ? 'Correcciones pendientes'
+                      : 'En revisión',
+                  variant: rejected.isNotEmpty
+                      ? SacBadgeVariant.error
+                      : SacBadgeVariant.accent,
+                ),
+                const SizedBox(height: 12),
+                Text(
+                  rejected.isNotEmpty
+                      ? 'Hay correcciones pendientes'
+                      : 'Tu Campo Local está revisando este envío.',
+                  style: Theme.of(context).textTheme.headlineSmall?.copyWith(
+                        color: c.text,
+                        fontWeight: FontWeight.w700,
+                      ),
+                ),
+                const SizedBox(height: 8),
+                Text(
+                  'Aprobadas: $approved · Rechazadas: ${rejected.length} · Pendientes: $pending',
+                  style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                        color: c.textSecondary,
+                      ),
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(height: 14),
+          for (final item in rejected) ...[
+            CertificateImportItemCard(
+              item: item,
+              onResubmit: () => onResubmitItem?.call(item),
+            ),
+            const SizedBox(height: 12),
+          ],
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/certificate_import/presentation/views/certificate_import_upload_view.dart
+++ b/lib/features/certificate_import/presentation/views/certificate_import_upload_view.dart
@@ -1,0 +1,277 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:sacdia_app/core/config/route_names.dart';
+import 'package:sacdia_app/core/theme/sac_colors.dart';
+import 'package:sacdia_app/core/widgets/sac_button.dart';
+import 'package:sacdia_app/core/widgets/sac_card.dart';
+
+import '../../data/datasources/certificate_import_remote_data_source.dart';
+import '../../domain/usecases/create_certificate_import_batch.dart';
+import '../providers/certificate_import_providers.dart';
+
+class CertificateImportUploadRouteView extends ConsumerWidget {
+  const CertificateImportUploadRouteView({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return CertificateImportUploadView(
+      onCreateMockUpload: () async {
+        final result =
+            await ref.read(createCertificateImportBatchProvider).call(
+                  const CreateCertificateImportBatchParams(
+                    files: [
+                      CertificateImportFilePayload(
+                        url: 'mock://certificate-import/pending-uploader.jpg',
+                        name: 'comprobante-pendiente.jpg',
+                        type: 'image/jpeg',
+                      ),
+                    ],
+                  ),
+                );
+        result.fold(
+          (failure) => throw Exception(failure.message),
+          (batch) => context.push(
+            RouteNames.certificateImportProcessingPath(batch.id),
+          ),
+        );
+      },
+    );
+  }
+}
+
+class CertificateImportUploadView extends StatefulWidget {
+  const CertificateImportUploadView({
+    super.key,
+    this.onCreateMockUpload,
+    this.onPickCamera,
+    this.onPickFile,
+  });
+
+  final Future<void> Function()? onCreateMockUpload;
+  final VoidCallback? onPickCamera;
+  final VoidCallback? onPickFile;
+
+  @override
+  State<CertificateImportUploadView> createState() =>
+      _CertificateImportUploadViewState();
+}
+
+class _CertificateImportUploadViewState
+    extends State<CertificateImportUploadView> {
+  bool _loading = false;
+  String? _error;
+
+  @override
+  Widget build(BuildContext context) {
+    final c = context.sac;
+    return Scaffold(
+      backgroundColor: c.background,
+      appBar: AppBar(title: const Text('Carga por certificado')),
+      body: Stack(
+        children: [
+          ListView(
+            padding: const EdgeInsets.fromLTRB(18, 8, 18, 190),
+            children: [
+              _UploadHero(),
+              const SizedBox(height: 14),
+              SacCard(
+                child: Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Icon(Icons.check_circle_rounded, color: c.success),
+                    const SizedBox(width: 12),
+                    Expanded(
+                      child: Text(
+                        'Podés mezclar especialidades y clases. SACDIA detecta candidatos, pero vos confirmás antes de enviar.',
+                        style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                              color: c.textSecondary,
+                            ),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              if (_error != null) ...[
+                const SizedBox(height: 12),
+                Text(
+                  _error!,
+                  style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                        color: c.error,
+                        fontWeight: FontWeight.w600,
+                      ),
+                ),
+              ],
+            ],
+          ),
+          Positioned(
+            left: 0,
+            right: 0,
+            bottom: 0,
+            child: DecoratedBox(
+              decoration: BoxDecoration(
+                color: c.background,
+                border: Border(top: BorderSide(color: c.border)),
+              ),
+              child: SafeArea(
+                top: false,
+                child: Padding(
+                  padding: const EdgeInsets.fromLTRB(16, 12, 16, 16),
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      SacButton.primary(
+                        text: 'Subir comprobante',
+                        icon: Icons.upload_rounded,
+                        isLoading: _loading,
+                        onPressed: _loading ? null : _createMockUpload,
+                      ),
+                      const SizedBox(height: 8),
+                      Row(
+                        children: [
+                          Expanded(
+                            child: SacButton.outline(
+                              text: 'Tomar foto',
+                              icon: Icons.camera_alt_outlined,
+                              onPressed:
+                                  widget.onPickCamera ?? _createMockUpload,
+                            ),
+                          ),
+                          const SizedBox(width: 8),
+                          Expanded(
+                            child: SacButton.outline(
+                              text: 'Elegir archivo',
+                              icon: Icons.folder_outlined,
+                              onPressed: widget.onPickFile ?? _createMockUpload,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _createMockUpload() async {
+    if (widget.onCreateMockUpload == null) {
+      setState(() => _error =
+          'Uploader real pendiente: seam preparado para metadata del archivo.');
+      return;
+    }
+    setState(() {
+      _loading = true;
+      _error = null;
+    });
+    try {
+      await widget.onCreateMockUpload!();
+    } catch (error) {
+      setState(() => _error = error.toString());
+    } finally {
+      if (mounted) setState(() => _loading = false);
+    }
+  }
+}
+
+class _UploadHero extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    final c = context.sac;
+    return SacCard(
+      backgroundColor: c.surfaceVariant,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Center(
+            child: SizedBox(
+              height: 150,
+              child: Stack(
+                alignment: Alignment.center,
+                children: [
+                  Transform.rotate(
+                    angle: -0.12,
+                    child: const _ReceiptThumb(label: 'CMP-01'),
+                  ),
+                  Positioned(
+                    left: 100,
+                    child: Transform.rotate(
+                      angle: 0.08,
+                      child:
+                          const _ReceiptThumb(label: 'CMP-02', compact: true),
+                    ),
+                  ),
+                  Positioned(
+                    top: 12,
+                    right: 42,
+                    child: Icon(Icons.auto_awesome_rounded, color: c.warning),
+                  ),
+                ],
+              ),
+            ),
+          ),
+          const SizedBox(height: 16),
+          Text(
+            'Subí tus comprobantes y los leemos por vos',
+            style: Theme.of(context).textTheme.displaySmall?.copyWith(
+                  color: c.text,
+                  fontWeight: FontWeight.w700,
+                ),
+          ),
+          const SizedBox(height: 8),
+          Text(
+            'OCR asistido para honores y clases. Menos tipeo, misma responsabilidad: revisar antes de enviar.',
+            style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                  color: c.textSecondary,
+                ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ReceiptThumb extends StatelessWidget {
+  const _ReceiptThumb({required this.label, this.compact = false});
+
+  final String label;
+  final bool compact;
+
+  @override
+  Widget build(BuildContext context) {
+    final c = context.sac;
+    return Container(
+      width: compact ? 88 : 110,
+      height: compact ? 118 : 140,
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: c.surface,
+        borderRadius: BorderRadius.circular(18),
+        border: Border.all(color: c.border),
+        boxShadow: [BoxShadow(color: c.shadow, blurRadius: 10)],
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(label, style: Theme.of(context).textTheme.labelMedium),
+          const SizedBox(height: 14),
+          for (var i = 0; i < (compact ? 3 : 5); i++) ...[
+            Container(
+              height: compact ? 3 : 4,
+              width: i.isEven ? 64 : 44,
+              decoration: BoxDecoration(
+                color: c.border,
+                borderRadius: BorderRadius.circular(99),
+              ),
+            ),
+            SizedBox(height: compact ? 6 : 8),
+          ],
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/certificate_import/presentation/widgets/certificate_import_item_card.dart
+++ b/lib/features/certificate_import/presentation/widgets/certificate_import_item_card.dart
@@ -1,0 +1,131 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'package:sacdia_app/core/theme/sac_colors.dart';
+import 'package:sacdia_app/core/widgets/sac_badge.dart';
+import 'package:sacdia_app/core/widgets/sac_button.dart';
+import 'package:sacdia_app/core/widgets/sac_card.dart';
+
+import '../../domain/entities/certificate_import_item.dart';
+
+class CertificateImportItemCard extends StatelessWidget {
+  const CertificateImportItemCard({
+    super.key,
+    required this.item,
+    this.onEdit,
+    this.onResubmit,
+  });
+
+  final CertificateImportItem item;
+  final VoidCallback? onEdit;
+  final VoidCallback? onResubmit;
+
+  bool get _isComplete {
+    final hasCatalog = item.type == CertificateImportItemType.honor
+        ? item.honorId != null
+        : item.classId != null;
+    return item.type != CertificateImportItemType.unknown &&
+        (item.detectedName?.trim().isNotEmpty ?? false) &&
+        item.completedAt != null &&
+        hasCatalog;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final c = context.sac;
+    final isHonor = item.type == CertificateImportItemType.honor;
+    final confidence = item.ocrConfidence == null
+        ? null
+        : '${(item.ocrConfidence! * 100).round()}% OCR';
+    final isRejected = item.isRejected || item.rejectionReason != null;
+    final statusLabel = isRejected
+        ? 'RECHAZADO'
+        : _isComplete
+            ? 'LISTO'
+            : 'FALTA DATO';
+
+    return SacCard(
+      accentColor: isHonor ? c.warning : c.info,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              SacBadge(
+                label: isHonor ? 'HONOR' : 'CLASE',
+                variant:
+                    isHonor ? SacBadgeVariant.accent : SacBadgeVariant.primary,
+              ),
+              const SizedBox(width: 8),
+              SacBadge(
+                label: statusLabel,
+                variant: isRejected
+                    ? SacBadgeVariant.error
+                    : _isComplete
+                        ? SacBadgeVariant.secondary
+                        : SacBadgeVariant.accent,
+              ),
+              const Spacer(),
+              if (confidence != null)
+                Text(
+                  confidence,
+                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                        color: c.textTertiary,
+                      ),
+                ),
+            ],
+          ),
+          const SizedBox(height: 12),
+          Text(
+            item.detectedName ?? 'Sin nombre detectado',
+            style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                  color: c.text,
+                  fontWeight: FontWeight.w700,
+                ),
+          ),
+          const SizedBox(height: 6),
+          Text(
+            _subtitle(),
+            style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                  color: c.textSecondary,
+                ),
+          ),
+          if (item.rejectionReason != null) ...[
+            const SizedBox(height: 10),
+            Text(
+              item.rejectionReason!,
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                    color: c.error,
+                    fontWeight: FontWeight.w600,
+                  ),
+            ),
+          ],
+          const SizedBox(height: 14),
+          if (onResubmit != null && isRejected)
+            SacButton.outline(
+              text: 'Corregir y reenviar',
+              onPressed: onResubmit,
+            )
+          else
+            Align(
+              alignment: Alignment.centerRight,
+              child: SacButton.ghost(
+                text: 'Corregir',
+                onPressed: onEdit,
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+
+  String _subtitle() {
+    final date = item.completedAt ?? item.detectedDate;
+    final formattedDate = date == null
+        ? 'fecha pendiente'
+        : DateFormat('dd/MM/yyyy').format(date);
+    final catalogId = item.type == CertificateImportItemType.honor
+        ? item.honorId
+        : item.classId;
+    return 'Catálogo: ${catalogId ?? 'pendiente'} · $formattedDate';
+  }
+}

--- a/lib/features/certificate_import/presentation/widgets/certificate_import_item_editor_sheet.dart
+++ b/lib/features/certificate_import/presentation/widgets/certificate_import_item_editor_sheet.dart
@@ -1,0 +1,217 @@
+import 'package:flutter/material.dart';
+import 'package:sacdia_app/core/theme/sac_colors.dart';
+import 'package:sacdia_app/core/widgets/sac_button.dart';
+
+import '../../domain/entities/certificate_import_item.dart';
+
+class CertificateImportItemEditorSheet extends StatefulWidget {
+  const CertificateImportItemEditorSheet({
+    super.key,
+    required this.item,
+    required this.onSave,
+  });
+
+  final CertificateImportItem item;
+  final Future<void> Function(CertificateImportItem item) onSave;
+
+  @override
+  State<CertificateImportItemEditorSheet> createState() =>
+      _CertificateImportItemEditorSheetState();
+}
+
+class _CertificateImportItemEditorSheetState
+    extends State<CertificateImportItemEditorSheet> {
+  late CertificateImportItemType _type;
+  late final TextEditingController _nameController;
+  late final TextEditingController _catalogController;
+  late final TextEditingController _dateController;
+  bool _saving = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _type = widget.item.type == CertificateImportItemType.unknown
+        ? CertificateImportItemType.honor
+        : widget.item.type;
+    _nameController =
+        TextEditingController(text: widget.item.detectedName ?? '');
+    _catalogController = TextEditingController(
+      text: '${widget.item.honorId ?? widget.item.classId ?? ''}',
+    );
+    final date = widget.item.completedAt ?? widget.item.detectedDate;
+    _dateController = TextEditingController(
+      text: date == null
+          ? ''
+          : '${date.year.toString().padLeft(4, '0')}-${date.month.toString().padLeft(2, '0')}-${date.day.toString().padLeft(2, '0')}',
+    );
+  }
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    _catalogController.dispose();
+    _dateController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final c = context.sac;
+    return SafeArea(
+      child: Padding(
+        padding: EdgeInsets.only(
+          left: 18,
+          right: 18,
+          top: 18,
+          bottom: MediaQuery.of(context).viewInsets.bottom + 18,
+        ),
+        child: SingleChildScrollView(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Text(
+                'Corregir fila',
+                style: Theme.of(context).textTheme.headlineSmall?.copyWith(
+                      color: c.text,
+                      fontWeight: FontWeight.w700,
+                    ),
+              ),
+              const SizedBox(height: 14),
+              Row(
+                children: [
+                  Expanded(
+                    child: SacButton(
+                      text: 'Honor',
+                      variant: _type == CertificateImportItemType.honor
+                          ? SacButtonVariant.primary
+                          : SacButtonVariant.outline,
+                      onPressed: () => setState(
+                          () => _type = CertificateImportItemType.honor),
+                    ),
+                  ),
+                  const SizedBox(width: 10),
+                  Expanded(
+                    child: SacButton(
+                      text: 'Clase',
+                      variant: _type == CertificateImportItemType.clazz
+                          ? SacButtonVariant.primary
+                          : SacButtonVariant.outline,
+                      onPressed: () => setState(
+                          () => _type = CertificateImportItemType.clazz),
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 12),
+              _Field(
+                label: 'Nombre detectado',
+                controller: _nameController,
+                textInputAction: TextInputAction.next,
+              ),
+              const SizedBox(height: 12),
+              _Field(
+                label: 'ID catálogo',
+                controller: _catalogController,
+                keyboardType: TextInputType.number,
+                textInputAction: TextInputAction.next,
+              ),
+              const SizedBox(height: 12),
+              _Field(
+                label: 'Fecha completada',
+                controller: _dateController,
+                keyboardType: TextInputType.datetime,
+                hint: 'AAAA-MM-DD',
+              ),
+              const SizedBox(height: 18),
+              SacButton.primary(
+                text: 'Guardar corrección',
+                isLoading: _saving,
+                onPressed: _saving ? null : _save,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Future<void> _save() async {
+    final catalogId = int.tryParse(_catalogController.text.trim());
+    final completedAt = DateTime.tryParse(_dateController.text.trim());
+    final updated = CertificateImportItem(
+      id: widget.item.id,
+      batchId: widget.item.batchId,
+      type: _type,
+      honorId: _type == CertificateImportItemType.honor ? catalogId : null,
+      classId: _type == CertificateImportItemType.clazz ? catalogId : null,
+      detectedName: _nameController.text.trim(),
+      detectedDate: widget.item.detectedDate,
+      completedAt: completedAt,
+      ocrConfidence: widget.item.ocrConfidence,
+      fieldConfidence: widget.item.fieldConfidence,
+      status: _isComplete(_type, catalogId, completedAt, _nameController.text)
+          ? CertificateImportItemStatus.ready
+          : CertificateImportItemStatus.needsReview,
+      rejectionReason: widget.item.rejectionReason,
+      appliedEntityType: widget.item.appliedEntityType,
+      appliedEntityId: widget.item.appliedEntityId,
+    );
+
+    setState(() => _saving = true);
+    await widget.onSave(updated);
+    if (mounted) Navigator.of(context).pop();
+  }
+
+  bool _isComplete(
+    CertificateImportItemType type,
+    int? catalogId,
+    DateTime? completedAt,
+    String name,
+  ) {
+    return type != CertificateImportItemType.unknown &&
+        catalogId != null &&
+        completedAt != null &&
+        name.trim().isNotEmpty;
+  }
+}
+
+class _Field extends StatelessWidget {
+  const _Field({
+    required this.label,
+    required this.controller,
+    this.keyboardType,
+    this.textInputAction,
+    this.hint,
+  });
+
+  final String label;
+  final TextEditingController controller;
+  final TextInputType? keyboardType;
+  final TextInputAction? textInputAction;
+  final String? hint;
+
+  @override
+  Widget build(BuildContext context) {
+    final c = context.sac;
+    return TextFormField(
+      controller: controller,
+      keyboardType: keyboardType,
+      textInputAction: textInputAction,
+      decoration: InputDecoration(
+        labelText: label,
+        hintText: hint,
+        filled: true,
+        fillColor: c.surface,
+        border: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(12),
+          borderSide: BorderSide(color: c.border),
+        ),
+        enabledBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(12),
+          borderSide: BorderSide(color: c.border),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/certificate_import/presentation/widgets/certificate_import_proof_card.dart
+++ b/lib/features/certificate_import/presentation/widgets/certificate_import_proof_card.dart
@@ -1,0 +1,69 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'package:sacdia_app/core/theme/sac_colors.dart';
+import 'package:sacdia_app/core/widgets/sac_badge.dart';
+import 'package:sacdia_app/core/widgets/sac_card.dart';
+
+import '../../domain/entities/certificate_import_item.dart';
+
+class CertificateImportProofCard extends StatelessWidget {
+  const CertificateImportProofCard({super.key, required this.item});
+
+  final CertificateImportItem item;
+
+  @override
+  Widget build(BuildContext context) {
+    final c = context.sac;
+    final title = item.detectedName ?? 'Registro sin nombre';
+    final date = item.completedAt ?? item.detectedDate;
+
+    return SacCard(
+      accentColor:
+          item.type == CertificateImportItemType.honor ? c.warning : c.info,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              const SacBadge.success(label: 'Registro importado'),
+              const Spacer(),
+              SacBadge(
+                label: item.type == CertificateImportItemType.honor
+                    ? 'HONOR'
+                    : 'CLASE',
+                variant: SacBadgeVariant.neutral,
+              ),
+            ],
+          ),
+          const SizedBox(height: 14),
+          Text(
+            title,
+            style: Theme.of(context).textTheme.headlineSmall?.copyWith(
+                  color: c.text,
+                  fontWeight: FontWeight.w700,
+                ),
+          ),
+          const SizedBox(height: 6),
+          Text(
+            date == null
+                ? 'Fecha pendiente'
+                : DateFormat('dd/MM/yyyy').format(date),
+            style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                  color: c.textSecondary,
+                ),
+          ),
+          if (item.appliedEntityType != null ||
+              item.appliedEntityId != null) ...[
+            const SizedBox(height: 10),
+            Text(
+              'Aplicado en ${item.appliedEntityType ?? 'SACDIA'} #${item.appliedEntityId ?? '-'}',
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                    color: c.textTertiary,
+                  ),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}

--- a/test/features/certificate_import/data/datasources/certificate_import_remote_data_source_test.dart
+++ b/test/features/certificate_import/data/datasources/certificate_import_remote_data_source_test.dart
@@ -1,0 +1,121 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sacdia_app/features/certificate_import/data/datasources/certificate_import_remote_data_source.dart';
+
+class _FakeAdapter implements HttpClientAdapter {
+  _FakeAdapter(this._body);
+
+  final ResponseBody _body;
+  RequestOptions? lastOptions;
+  String? lastBody;
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    lastOptions = options;
+    if (requestStream != null) {
+      lastBody =
+          utf8.decode(await requestStream.expand((chunk) => chunk).toList());
+    }
+    return _body;
+  }
+
+  @override
+  void close({bool force = false}) {}
+}
+
+({Dio dio, _FakeAdapter adapter}) _dioWith(Map<String, dynamic> bodyJson) {
+  final adapter = _FakeAdapter(
+    ResponseBody.fromString(
+      jsonEncode(bodyJson),
+      200,
+      headers: {
+        Headers.contentTypeHeader: ['application/json'],
+      },
+    ),
+  );
+  final dio = Dio(BaseOptions(responseType: ResponseType.json));
+  dio.httpClientAdapter = adapter;
+  return (dio: dio, adapter: adapter);
+}
+
+Map<String, dynamic> _batchJson() => {
+      'batch_id': 'batch-1',
+      'status': 'DRAFT',
+      'files': [],
+      'items': [],
+    };
+
+void main() {
+  const baseUrl = 'http://localhost:3000/api/v1';
+
+  test('creates a certificate import batch with uploaded file metadata',
+      () async {
+    final (:dio, :adapter) = _dioWith({
+      'status': 'success',
+      'data': _batchJson(),
+    });
+    final dataSource = CertificateImportRemoteDataSourceImpl(
+      dio: dio,
+      baseUrl: baseUrl,
+    );
+
+    final result = await dataSource.createBatch(
+      files: const [
+        CertificateImportFilePayload(
+          url: 'https://cdn.sacdia.app/cert.jpg',
+          name: 'cert.jpg',
+          type: 'image/jpeg',
+        ),
+      ],
+    );
+
+    expect(result.id, 'batch-1');
+    expect(adapter.lastOptions!.method, 'POST');
+    expect(adapter.lastOptions!.path, '$baseUrl/certificate-bulk-imports');
+    expect(adapter.lastBody, contains('cert.jpg'));
+  });
+
+  test('updates an item using the backend snake_case contract', () async {
+    final (:dio, :adapter) = _dioWith({
+      'status': 'success',
+      'data': {
+        'item_id': 'item-1',
+        'item_type': 'HONOR',
+        'honor_id': 10,
+        'completed_at': '2026-04-12',
+        'status': 'READY',
+      },
+    });
+    final dataSource = CertificateImportRemoteDataSourceImpl(
+      dio: dio,
+      baseUrl: baseUrl,
+    );
+
+    final item = await dataSource.updateItem(
+      batchId: 'batch-1',
+      itemId: 'item-1',
+      payload: const CertificateImportItemUpdatePayload(
+        itemType: 'HONOR',
+        honorId: 10,
+        completedAt: '2026-04-12',
+        markAsReady: true,
+      ),
+    );
+
+    expect(item.id, 'item-1');
+    expect(adapter.lastOptions!.method, 'PATCH');
+    expect(
+      adapter.lastOptions!.path,
+      '$baseUrl/certificate-bulk-imports/batch-1/items/item-1',
+    );
+    expect(adapter.lastBody, contains('"item_type":"HONOR"'));
+    expect(adapter.lastBody, contains('"mark_as_ready":true'));
+  });
+}

--- a/test/features/certificate_import/data/models/certificate_import_model_test.dart
+++ b/test/features/certificate_import/data/models/certificate_import_model_test.dart
@@ -1,0 +1,50 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sacdia_app/features/certificate_import/data/models/certificate_import_batch_model.dart';
+
+void main() {
+  group('CertificateImportBatchModel', () {
+    test('parses a batch with mixed honor and class rows', () {
+      final model = CertificateImportBatchModel.fromJson({
+        'batch_id': 'batch-1',
+        'status': 'SUBMITTED',
+        'local_field_id': 7,
+        'files': [
+          {
+            'file_id': 'file-1',
+            'file_url': 'https://cdn.sacdia.app/cert.jpg',
+            'file_name': 'cert.jpg',
+            'file_type': 'image/jpeg',
+            'uploaded_at': '2026-04-12T12:00:00.000Z',
+          },
+        ],
+        'items': [
+          {
+            'item_id': 'item-1',
+            'item_type': 'HONOR',
+            'honor_id': 10,
+            'detected_name': 'Primeros Auxilios',
+            'completed_at': '2026-04-12',
+            'status': 'READY',
+            'ocr_confidence': 0.82,
+          },
+          {
+            'item_id': 'item-2',
+            'item_type': 'CLASS',
+            'class_id': 4,
+            'detected_name': 'Amigo',
+            'completed_at': '2026-04-12',
+            'status': 'NEEDS_REVIEW',
+          },
+        ],
+      });
+
+      expect(model.id, 'batch-1');
+      expect(model.items, hasLength(2));
+      expect(model.items.first.type, CertificateImportItemType.honor);
+      expect(model.items.last.type, CertificateImportItemType.clazz);
+      expect(model.files.single.url, 'https://cdn.sacdia.app/cert.jpg');
+      expect(model.readyCount, 1);
+      expect(model.needsReviewCount, 1);
+    });
+  });
+}

--- a/test/features/certificate_import/data/repositories/certificate_import_repository_impl_test.dart
+++ b/test/features/certificate_import/data/repositories/certificate_import_repository_impl_test.dart
@@ -1,0 +1,107 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sacdia_app/core/errors/exceptions.dart';
+import 'package:sacdia_app/core/errors/failures.dart';
+import 'package:sacdia_app/core/network/network_info.dart';
+import 'package:sacdia_app/features/certificate_import/data/datasources/certificate_import_remote_data_source.dart';
+import 'package:sacdia_app/features/certificate_import/data/models/certificate_import_batch_model.dart';
+import 'package:sacdia_app/features/certificate_import/data/models/certificate_import_item_model.dart';
+import 'package:sacdia_app/features/certificate_import/data/repositories/certificate_import_repository_impl.dart';
+
+class _NetworkInfo implements NetworkInfo {
+  @override
+  Future<bool> get isConnected async => true;
+}
+
+class _RemoteDataSource implements CertificateImportRemoteDataSource {
+  Object? error;
+
+  @override
+  Future<CertificateImportBatchModel> createBatch({
+    required List<CertificateImportFilePayload> files,
+  }) async {
+    if (error != null) throw error!;
+    return const CertificateImportBatchModel(id: 'batch-1', status: 'DRAFT');
+  }
+
+  @override
+  Future<CertificateImportBatchModel> getBatch(String batchId) async =>
+      const CertificateImportBatchModel(id: 'batch-1', status: 'DRAFT');
+
+  @override
+  Future<CertificateImportBatchModel> processOcr(String batchId) async =>
+      const CertificateImportBatchModel(id: 'batch-1', status: 'DRAFT');
+
+  @override
+  Future<CertificateImportItemModel> resubmitItem({
+    required String batchId,
+    required String itemId,
+    required CertificateImportItemUpdatePayload payload,
+  }) async =>
+      const CertificateImportItemModel(
+        id: 'item-1',
+        type: CertificateImportItemType.honor,
+        status: CertificateImportItemStatus.resubmitted,
+      );
+
+  @override
+  Future<CertificateImportBatchModel> submitBatch(String batchId) async =>
+      const CertificateImportBatchModel(id: 'batch-1', status: 'SUBMITTED');
+
+  @override
+  Future<CertificateImportItemModel> updateItem({
+    required String batchId,
+    required String itemId,
+    required CertificateImportItemUpdatePayload payload,
+  }) async =>
+      const CertificateImportItemModel(
+        id: 'item-1',
+        type: CertificateImportItemType.honor,
+        status: CertificateImportItemStatus.ready,
+      );
+}
+
+void main() {
+  test('maps a successful create call to a domain entity', () async {
+    final repository = CertificateImportRepositoryImpl(
+      remoteDataSource: _RemoteDataSource(),
+      networkInfo: _NetworkInfo(),
+    );
+
+    final result = await repository.createBatch(
+      files: const [
+        CertificateImportFilePayload(
+          url: 'https://cdn.sacdia.app/cert.jpg',
+          name: 'cert.jpg',
+          type: 'image/jpeg',
+        ),
+      ],
+    );
+
+    expect(result.isRight(), isTrue);
+    result.fold(
+      (_) => fail('expected right'),
+      (batch) => expect(batch.id, 'batch-1'),
+    );
+  });
+
+  test('maps server exceptions to ServerFailure', () async {
+    final remote = _RemoteDataSource()
+      ..error = ServerException(message: 'Forbidden', code: 403);
+    final repository = CertificateImportRepositoryImpl(
+      remoteDataSource: remote,
+      networkInfo: _NetworkInfo(),
+    );
+
+    final result = await repository.createBatch(files: const []);
+
+    expect(result.isLeft(), isTrue);
+    result.fold(
+      (failure) {
+        expect(failure, isA<ServerFailure>());
+        expect(failure.code, 403);
+      },
+      (_) => fail('expected failure'),
+    );
+  });
+}

--- a/test/features/certificate_import/presentation/views/certificate_import_flow_views_test.dart
+++ b/test/features/certificate_import/presentation/views/certificate_import_flow_views_test.dart
@@ -1,0 +1,193 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sacdia_app/core/config/route_names.dart';
+import 'package:sacdia_app/core/config/router.dart';
+import 'package:sacdia_app/core/theme/app_theme.dart';
+import 'package:sacdia_app/features/certificate_import/domain/entities/certificate_import_batch.dart';
+import 'package:sacdia_app/features/certificate_import/domain/entities/certificate_import_file.dart';
+import 'package:sacdia_app/features/certificate_import/domain/entities/certificate_import_item.dart';
+import 'package:sacdia_app/features/certificate_import/presentation/views/certificate_import_processing_view.dart';
+import 'package:sacdia_app/features/certificate_import/presentation/views/certificate_import_review_view.dart';
+import 'package:sacdia_app/features/certificate_import/presentation/views/certificate_import_status_view.dart';
+import 'package:sacdia_app/features/certificate_import/presentation/views/certificate_import_upload_view.dart';
+import 'package:sacdia_app/features/certificate_import/presentation/widgets/certificate_import_proof_card.dart';
+
+Widget _wrap(Widget child) => MaterialApp(
+      theme: AppTheme.lightTheme,
+      home: child,
+    );
+
+CertificateImportBatch _batch({bool complete = false, bool rejected = false}) {
+  return CertificateImportBatch(
+    id: 'batch-1',
+    status: rejected ? 'REJECTED' : 'DRAFT',
+    files: const [
+      CertificateImportFile(
+        id: 'file-1',
+        url: 'mock://receipt.jpg',
+        name: 'Acampada Sinaí 2026',
+        type: 'image/jpeg',
+      ),
+    ],
+    items: [
+      CertificateImportItem(
+        id: 'honor-1',
+        type: CertificateImportItemType.honor,
+        honorId: complete ? 10 : null,
+        detectedName: 'Primeros Auxilios',
+        completedAt: complete ? DateTime(2026, 4, 12) : null,
+        ocrConfidence: 0.82,
+        status: complete
+            ? CertificateImportItemStatus.ready
+            : CertificateImportItemStatus.needsReview,
+        rejectionReason:
+            rejected ? 'La fecha no coincide con el comprobante' : null,
+      ),
+      CertificateImportItem(
+        id: 'class-1',
+        type: CertificateImportItemType.clazz,
+        classId: 3,
+        detectedName: 'Amigo',
+        completedAt: DateTime(2026, 4, 12),
+        ocrConfidence: 0.91,
+        status: CertificateImportItemStatus.ready,
+      ),
+    ],
+  );
+}
+
+void main() {
+  group('Certificate import routing', () {
+    test(
+        'declares route names for upload, processing, review and imported proof',
+        () {
+      expect(RouteNames.certificateImportUpload, '/certificate-import');
+      expect(RouteNames.certificateImportProcessingPath('batch-1'),
+          '/certificate-import/batch-1/processing');
+      expect(RouteNames.certificateImportReviewPath('batch-1'),
+          '/certificate-import/batch-1/review');
+      expect(RouteNames.certificateImportProofPath('item-1'),
+          '/certificate-import/item/item-1/proof');
+      expect(routerProvider, isNotNull);
+    });
+  });
+
+  group('CertificateImportUploadView', () {
+    testWidgets('shows upload, camera and file actions with accessible labels',
+        (tester) async {
+      var uploadCalls = 0;
+      await tester.pumpWidget(_wrap(CertificateImportUploadView(
+        onCreateMockUpload: () async => uploadCalls++,
+      )));
+
+      expect(find.text('Subir comprobante'), findsOneWidget);
+      expect(find.text('Tomar foto'), findsOneWidget);
+      expect(find.text('Elegir archivo'), findsOneWidget);
+
+      await tester.tap(find.text('Subir comprobante'));
+      await tester.pump();
+
+      expect(uploadCalls, 1);
+    });
+  });
+
+  group('CertificateImportProcessingView', () {
+    testWidgets('shows OCR steps and a manual fallback action', (tester) async {
+      var fallbackCalls = 0;
+      await tester.pumpWidget(_wrap(CertificateImportProcessingView(
+        batchId: 'batch-1',
+        autoStart: false,
+        onManualFallback: () => fallbackCalls++,
+      )));
+
+      expect(find.text('Leyendo comprobante'), findsOneWidget);
+      expect(find.text('Subiendo archivo'), findsOneWidget);
+      expect(find.text('Leyendo texto'), findsOneWidget);
+      expect(find.text('Completar manualmente'), findsOneWidget);
+
+      await tester.tap(find.text('Completar manualmente'));
+      await tester.pump();
+      expect(fallbackCalls, 1);
+    });
+  });
+
+  group('CertificateImportReviewView', () {
+    testWidgets(
+        'renders mixed HONOR/CLASS cards, counters and disabled submit when data is missing',
+        (tester) async {
+      await tester.pumpWidget(_wrap(CertificateImportReviewView(
+        initialBatch: _batch(),
+      )));
+
+      expect(find.text('1 especialidad y 1 clase'), findsOneWidget);
+      expect(find.text('HONOR'), findsOneWidget);
+      expect(find.text('CLASE'), findsOneWidget);
+      expect(find.text('Primeros Auxilios'), findsOneWidget);
+      expect(find.text('Amigo'), findsOneWidget);
+
+      final submit = tester.widget<ElevatedButton>(
+        find.widgetWithText(ElevatedButton, 'Enviar a revisión'),
+      );
+      expect(submit.onPressed, isNull);
+    });
+
+    testWidgets('opens editor and enables submit after item correction',
+        (tester) async {
+      CertificateImportItem? updated;
+      await tester.pumpWidget(_wrap(CertificateImportReviewView(
+        initialBatch: _batch(),
+        onUpdateItem: (item) async => updated = item,
+      )));
+
+      await tester.tap(find.text('Corregir').first);
+      await tester.pumpAndSettle();
+
+      await tester.enterText(find.bySemanticsLabel('ID catálogo'), '10');
+      await tester.enterText(
+          find.bySemanticsLabel('Fecha completada'), '2026-04-12');
+      await tester.tap(find.text('Guardar corrección'));
+      await tester.pumpAndSettle();
+
+      expect(updated?.honorId, 10);
+      expect(updated?.completedAt, DateTime(2026, 4, 12));
+
+      final submit = tester.widget<ElevatedButton>(
+        find.widgetWithText(ElevatedButton, 'Enviar a revisión'),
+      );
+      expect(submit.onPressed, isNotNull);
+    });
+  });
+
+  group('CertificateImportStatusView', () {
+    testWidgets('shows rejected correction and resubmit affordance',
+        (tester) async {
+      var resubmitCalls = 0;
+      await tester.pumpWidget(_wrap(CertificateImportStatusView(
+        batch: _batch(rejected: true),
+        onResubmitItem: (_) async => resubmitCalls++,
+      )));
+
+      expect(find.text('Hay correcciones pendientes'), findsOneWidget);
+      expect(
+          find.text('La fecha no coincide con el comprobante'), findsOneWidget);
+
+      await tester.tap(find.text('Corregir y reenviar').first);
+      await tester.pump();
+      expect(resubmitCalls, 1);
+    });
+  });
+
+  group('CertificateImportProofCard', () {
+    testWidgets('renders simplified imported proof from item props',
+        (tester) async {
+      await tester.pumpWidget(_wrap(Scaffold(
+        body: CertificateImportProofCard(
+            item: _batch(complete: true).items.first),
+      )));
+
+      expect(find.text('Registro importado'), findsOneWidget);
+      expect(find.text('Primeros Auxilios'), findsOneWidget);
+      expect(find.text('12/04/2026'), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Adds Flutter domain/data models, remote datasource, repository, use cases, and Riverpod providers for certificate imports.
- Adds mobile review flow UI for upload, OCR processing, editable mixed HONOR/CLASS rows, review status, and imported proof view.
- Wires deep routes without forcing a main navigation entry yet.

## Test Plan
- [x] `flutter test test/features/certificate_import`
- [ ] Device QA with real upload/signed URL flow

## Notes
- Upload currently uses the feature seam/metadata path; real signed URL integration remains pending.
- Product still needs to decide the visible navigation entrypoint.
