### PR TITLE
feat(app): support expired class trajectory

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -1325,7 +1325,9 @@
       "percent": "{percent}%"
     },
     "class_card": {
-      "current_badge": "Current class"
+      "current_badge": "Current class",
+      "expired_badge": "Expired",
+      "expired_description": "This class remains in your history, but it can no longer be completed for investiture."
     },
     "requirement_card": {
       "files_label": "{count} / {max} files",
@@ -1350,7 +1352,8 @@
       "linked_honor_title": "Required honor",
       "honor_completed": "Completed",
       "honor_pending": "Pending",
-      "semantics_status": "Requirement status: {status}. Tap to view history."
+      "semantics_status": "Requirement status: {status}. Tap to view history.",
+      "expired_banner": "Expired · This class remains in your history, but it can no longer be completed for investiture."
     },
     "section_detail": {
       "title": "Section Detail",
@@ -2288,7 +2291,8 @@
       "field_approved": "Approved by field",
       "approved": "Approved",
       "rejected": "Rejected",
-      "investido": "Invested"
+      "investido": "Invested",
+      "expired": "Expired"
     }
   },
   "annual_folders": {
@@ -2909,7 +2913,9 @@
     "class_card": {
       "label": "My Current Class",
       "no_class": "No class assigned",
-      "completed": "Completed"
+      "completed": "Completed",
+      "expired_label": "Expired class",
+      "expired_badge": "Expired"
     },
     "banner": {
       "pending_title": "Your membership request is pending approval",

--- a/assets/translations/es.json
+++ b/assets/translations/es.json
@@ -1325,7 +1325,9 @@
       "percent": "{percent}%"
     },
     "class_card": {
-      "current_badge": "Clase actual"
+      "current_badge": "Clase actual",
+      "expired_badge": "Vencida",
+      "expired_description": "Esta clase se conserva en tu trayectoria, pero ya no puede completarse para investidura."
     },
     "requirement_card": {
       "files_label": "{count} / {max} archivos",
@@ -1350,7 +1352,8 @@
       "linked_honor_title": "Especialidad requerida",
       "honor_completed": "Completada",
       "honor_pending": "Pendiente",
-      "semantics_status": "Estado del requisito: {status}. Tocar para ver historial."
+      "semantics_status": "Estado del requisito: {status}. Tocar para ver historial.",
+      "expired_banner": "Vencida · Esta clase se conserva en tu trayectoria, pero ya no puede completarse para investidura."
     },
     "section_detail": {
       "title": "Detalle de Sección",
@@ -2288,7 +2291,8 @@
       "field_approved": "Aprobado por campo",
       "approved": "Aprobado",
       "rejected": "Rechazado",
-      "investido": "Investido"
+      "investido": "Investido",
+      "expired": "Vencida"
     }
   },
   "annual_folders": {
@@ -2909,7 +2913,9 @@
     "class_card": {
       "label": "Mi Clase Actual",
       "no_class": "Sin clase asignada",
-      "completed": "Completada"
+      "completed": "Completada",
+      "expired_label": "Clase vencida",
+      "expired_badge": "Vencida"
     },
     "banner": {
       "pending_title": "Tu solicitud de membresía está pendiente de aprobación",

--- a/assets/translations/fr.json
+++ b/assets/translations/fr.json
@@ -1325,7 +1325,9 @@
       "percent": "{percent}%"
     },
     "class_card": {
-      "current_badge": "Classe actuelle"
+      "current_badge": "Classe actuelle",
+      "expired_badge": "Expirée",
+      "expired_description": "Cette classe reste dans votre parcours, mais elle ne peut plus être terminée pour l’investiture."
     },
     "requirement_card": {
       "files_label": "{count} / {max} fichiers",
@@ -1350,7 +1352,8 @@
       "linked_honor_title": "Spécialité requise",
       "honor_completed": "Terminée",
       "honor_pending": "En attente",
-      "semantics_status": "Statut de l'exigence : {status}. Appuyez pour voir l'historique."
+      "semantics_status": "Statut de l'exigence : {status}. Appuyez pour voir l'historique.",
+      "expired_banner": "Expirée · Cette classe reste dans votre parcours, mais elle ne peut plus être terminée pour l’investiture."
     },
     "section_detail": {
       "title": "Détail de la section",
@@ -2288,7 +2291,8 @@
       "field_approved": "Approuvé par le champ",
       "approved": "Approuvé",
       "rejected": "Rejeté",
-      "investido": "Investi"
+      "investido": "Investi",
+      "expired": "Expirée"
     }
   },
   "annual_folders": {
@@ -2909,7 +2913,9 @@
     "class_card": {
       "label": "Ma classe actuelle",
       "no_class": "Aucune classe assignée",
-      "completed": "Terminée"
+      "completed": "Terminée",
+      "expired_label": "Classe expirée",
+      "expired_badge": "Expirée"
     },
     "banner": {
       "pending_title": "Votre demande d'adhésion est en attente d'approbation",

--- a/assets/translations/pt-BR.json
+++ b/assets/translations/pt-BR.json
@@ -1325,7 +1325,9 @@
       "percent": "{percent}%"
     },
     "class_card": {
-      "current_badge": "Classe atual"
+      "current_badge": "Classe atual",
+      "expired_badge": "Expirada",
+      "expired_description": "Esta classe permanece no seu histórico, mas não pode mais ser concluída para investidura."
     },
     "requirement_card": {
       "files_label": "{count} / {max} arquivos",
@@ -1350,7 +1352,8 @@
       "linked_honor_title": "Especialidade requerida",
       "honor_completed": "Concluída",
       "honor_pending": "Pendente",
-      "semantics_status": "Status do requisito: {status}. Toque para ver o histórico."
+      "semantics_status": "Status do requisito: {status}. Toque para ver o histórico.",
+      "expired_banner": "Expirada · Esta classe permanece no seu histórico, mas não pode mais ser concluída para investidura."
     },
     "section_detail": {
       "title": "Detalhe da Seção",
@@ -2288,7 +2291,8 @@
       "field_approved": "Aprovado pelo campo",
       "approved": "Aprovado",
       "rejected": "Rejeitado",
-      "investido": "Investido"
+      "investido": "Investido",
+      "expired": "Expirada"
     }
   },
   "annual_folders": {
@@ -2909,7 +2913,9 @@
     "class_card": {
       "label": "Minha Classe Atual",
       "no_class": "Nenhuma classe atribuída",
-      "completed": "Concluída"
+      "completed": "Concluída",
+      "expired_label": "Classe expirada",
+      "expired_badge": "Expirada"
     },
     "banner": {
       "pending_title": "Sua solicitação de associação está pendente de aprovação",

--- a/lib/features/activities/presentation/views/activities_list_view.dart
+++ b/lib/features/activities/presentation/views/activities_list_view.dart
@@ -633,8 +633,8 @@ class _ActivitiesListViewState extends ConsumerState<ActivitiesListView> {
                                                   _showTodayButton.value =
                                                       false;
                                                   _visibleMonth.value =
-                                                      DateTime(now.year,
-                                                          now.month);
+                                                      DateTime(
+                                                          now.year, now.month);
                                                   _scrollToToday(animate: true);
                                                 },
                                                 child: Center(

--- a/lib/features/classes/data/datasources/classes_remote_data_source.dart
+++ b/lib/features/classes/data/datasources/classes_remote_data_source.dart
@@ -353,6 +353,7 @@ class ClassesRemoteDataSourceImpl implements ClassesRemoteDataSource {
           // Construir JSON combinado
           final combined = {
             ...classJson,
+            ...body,
             'modules': modulesJson,
           };
 

--- a/lib/features/classes/data/models/class_model.dart
+++ b/lib/features/classes/data/models/class_model.dart
@@ -21,6 +21,11 @@ class ClassModel extends Equatable {
   /// Mapeado desde el campo snake_case `asset_code` del backend.
   final String? assetCode;
 
+  final int? availableFromYearId;
+  final int? availableUntilYearId;
+  final int minDurationYears;
+  final int maxDurationYears;
+
   const ClassModel({
     required this.id,
     required this.name,
@@ -30,6 +35,10 @@ class ClassModel extends Equatable {
     this.investitureStatus,
     this.overallProgress,
     this.assetCode,
+    this.availableFromYearId,
+    this.availableUntilYearId,
+    this.minDurationYears = 1,
+    this.maxDurationYears = 1,
   });
 
   /// Crea una instancia desde JSON.
@@ -48,6 +57,14 @@ class ClassModel extends Equatable {
       investitureStatus: safeStringOrNull(json['investiture_status']),
       overallProgress: safeIntOrNull(json['overall_progress']),
       assetCode: safeStringOrNull(json['asset_code']),
+      availableFromYearId: safeIntOrNull(
+          json['available_from_year_id'] ?? json['availableFromYearId']),
+      availableUntilYearId: safeIntOrNull(
+          json['available_until_year_id'] ?? json['availableUntilYearId']),
+      minDurationYears:
+          safeInt(json['min_duration_years'] ?? json['minDurationYears'], 1),
+      maxDurationYears:
+          safeInt(json['max_duration_years'] ?? json['maxDurationYears'], 1),
     );
   }
 
@@ -62,6 +79,10 @@ class ClassModel extends Equatable {
       'investiture_status': investitureStatus,
       'overall_progress': overallProgress,
       'asset_code': assetCode,
+      'available_from_year_id': availableFromYearId,
+      'available_until_year_id': availableUntilYearId,
+      'min_duration_years': minDurationYears,
+      'max_duration_years': maxDurationYears,
     };
   }
 
@@ -76,6 +97,10 @@ class ClassModel extends Equatable {
       investitureStatus: investitureStatus,
       overallProgress: overallProgress,
       assetCode: assetCode,
+      availableFromYearId: availableFromYearId,
+      availableUntilYearId: availableUntilYearId,
+      minDurationYears: minDurationYears,
+      maxDurationYears: maxDurationYears,
     );
   }
 
@@ -89,6 +114,10 @@ class ClassModel extends Equatable {
     String? investitureStatus,
     int? overallProgress,
     String? assetCode,
+    int? availableFromYearId,
+    int? availableUntilYearId,
+    int? minDurationYears,
+    int? maxDurationYears,
   }) {
     return ClassModel(
       id: id ?? this.id,
@@ -99,6 +128,10 @@ class ClassModel extends Equatable {
       investitureStatus: investitureStatus ?? this.investitureStatus,
       overallProgress: overallProgress ?? this.overallProgress,
       assetCode: assetCode ?? this.assetCode,
+      availableFromYearId: availableFromYearId ?? this.availableFromYearId,
+      availableUntilYearId: availableUntilYearId ?? this.availableUntilYearId,
+      minDurationYears: minDurationYears ?? this.minDurationYears,
+      maxDurationYears: maxDurationYears ?? this.maxDurationYears,
     );
   }
 
@@ -112,5 +145,9 @@ class ClassModel extends Equatable {
         investitureStatus,
         overallProgress,
         assetCode,
+        availableFromYearId,
+        availableUntilYearId,
+        minDurationYears,
+        maxDurationYears,
       ];
 }

--- a/lib/features/classes/data/models/class_with_progress_model.dart
+++ b/lib/features/classes/data/models/class_with_progress_model.dart
@@ -10,6 +10,11 @@ class ClassWithProgressModel extends ClassWithProgress {
     super.description,
     required super.clubTypeId,
     super.imageUrl,
+    super.investitureStatus,
+    super.availableFromYearId,
+    super.availableUntilYearId,
+    super.minDurationYears,
+    super.maxDurationYears,
     super.modules,
   });
 
@@ -27,6 +32,16 @@ class ClassWithProgressModel extends ClassWithProgress {
       description: json['description']?.toString(),
       clubTypeId: safeInt(json['club_type_id'] ?? json['clubTypeId']),
       imageUrl: json['image_url']?.toString() ?? json['imageUrl']?.toString(),
+      investitureStatus: json['investiture_status']?.toString() ??
+          json['investitureStatus']?.toString(),
+      availableFromYearId: safeIntOrNull(
+          json['available_from_year_id'] ?? json['availableFromYearId']),
+      availableUntilYearId: safeIntOrNull(
+          json['available_until_year_id'] ?? json['availableUntilYearId']),
+      minDurationYears:
+          safeInt(json['min_duration_years'] ?? json['minDurationYears'], 1),
+      maxDurationYears:
+          safeInt(json['max_duration_years'] ?? json['maxDurationYears'], 1),
       modules: modules,
     );
   }
@@ -37,6 +52,11 @@ class ClassWithProgressModel extends ClassWithProgress {
         description: description,
         clubTypeId: clubTypeId,
         imageUrl: imageUrl,
+        investitureStatus: investitureStatus,
+        availableFromYearId: availableFromYearId,
+        availableUntilYearId: availableUntilYearId,
+        minDurationYears: minDurationYears,
+        maxDurationYears: maxDurationYears,
         modules: modules,
       );
 }

--- a/lib/features/classes/domain/entities/class_requirement.dart
+++ b/lib/features/classes/domain/entities/class_requirement.dart
@@ -184,6 +184,12 @@ class ClassRequirement extends Equatable {
           status == RequirementStatus.observado) &&
       files.isNotEmpty;
 
+  bool canUploadForClass({required bool isClassExpired}) =>
+      !isClassExpired && canUpload;
+
+  bool canSubmitForClass({required bool isClassExpired}) =>
+      !isClassExpired && canSubmit;
+
   @override
   List<Object?> get props => [
         id,

--- a/lib/features/classes/domain/entities/class_with_progress.dart
+++ b/lib/features/classes/domain/entities/class_with_progress.dart
@@ -13,6 +13,11 @@ class ClassWithProgress extends Equatable {
   final String? description;
   final int clubTypeId;
   final String? imageUrl;
+  final String? investitureStatus;
+  final int? availableFromYearId;
+  final int? availableUntilYearId;
+  final int minDurationYears;
+  final int maxDurationYears;
 
   // Progreso del usuario
   final List<ClassModuleDetail> modules;
@@ -23,10 +28,17 @@ class ClassWithProgress extends Equatable {
     this.description,
     required this.clubTypeId,
     this.imageUrl,
+    this.investitureStatus,
+    this.availableFromYearId,
+    this.availableUntilYearId,
+    this.minDurationYears = 1,
+    this.maxDurationYears = 1,
     this.modules = const [],
   });
 
   // Computed helpers
+
+  bool get isExpired => investitureStatus?.toUpperCase() == 'EXPIRED';
 
   /// Total de requerimientos en todos los modulos.
   int get totalRequirements =>
@@ -58,6 +70,17 @@ class ClassWithProgress extends Equatable {
       modules.expand((m) => m.requirements).toList();
 
   @override
-  List<Object?> get props =>
-      [id, name, description, clubTypeId, imageUrl, modules];
+  List<Object?> get props => [
+        id,
+        name,
+        description,
+        clubTypeId,
+        imageUrl,
+        investitureStatus,
+        availableFromYearId,
+        availableUntilYearId,
+        minDurationYears,
+        maxDurationYears,
+        modules,
+      ];
 }

--- a/lib/features/classes/domain/entities/class_with_progress.dart
+++ b/lib/features/classes/domain/entities/class_with_progress.dart
@@ -38,7 +38,7 @@ class ClassWithProgress extends Equatable {
 
   // Computed helpers
 
-  bool get isExpired => investitureStatus?.toUpperCase() == 'EXPIRED';
+  bool get isExpired => investitureStatus?.trim().toUpperCase() == 'EXPIRED';
 
   /// Total de requerimientos en todos los modulos.
   int get totalRequirements =>

--- a/lib/features/classes/domain/entities/progressive_class.dart
+++ b/lib/features/classes/domain/entities/progressive_class.dart
@@ -50,7 +50,7 @@ class ProgressiveClass extends Equatable {
     this.maxDurationYears = 1,
   });
 
-  bool get isExpired => investitureStatus?.toUpperCase() == 'EXPIRED';
+  bool get isExpired => investitureStatus?.trim().toUpperCase() == 'EXPIRED';
 
   @override
   List<Object?> get props => [

--- a/lib/features/classes/domain/entities/progressive_class.dart
+++ b/lib/features/classes/domain/entities/progressive_class.dart
@@ -21,6 +21,20 @@ class ProgressiveClass extends Equatable {
   /// Null hasta que el backend esté desplegado con el campo poblado.
   final String? assetCode;
 
+  /// Año eclesiástico desde el que se puede iniciar la clase.
+  final int? availableFromYearId;
+
+  /// Año eclesiástico hasta el que se puede iniciar la clase.
+  ///
+  /// Null significa que no tiene expiración programada.
+  final int? availableUntilYearId;
+
+  /// Duración mínima requerida, en años eclesiásticos.
+  final int minDurationYears;
+
+  /// Duración máxima permitida, en años eclesiásticos.
+  final int maxDurationYears;
+
   const ProgressiveClass({
     required this.id,
     required this.name,
@@ -30,7 +44,13 @@ class ProgressiveClass extends Equatable {
     this.investitureStatus,
     this.overallProgress,
     this.assetCode,
+    this.availableFromYearId,
+    this.availableUntilYearId,
+    this.minDurationYears = 1,
+    this.maxDurationYears = 1,
   });
+
+  bool get isExpired => investitureStatus?.toUpperCase() == 'EXPIRED';
 
   @override
   List<Object?> get props => [
@@ -42,5 +62,9 @@ class ProgressiveClass extends Equatable {
         investitureStatus,
         overallProgress,
         assetCode,
+        availableFromYearId,
+        availableUntilYearId,
+        minDurationYears,
+        maxDurationYears,
       ];
 }

--- a/lib/features/classes/presentation/roadmap/data/roadmap_data.dart
+++ b/lib/features/classes/presentation/roadmap/data/roadmap_data.dart
@@ -9,7 +9,7 @@
 
 import 'package:flutter/foundation.dart' show visibleForTesting;
 
-enum ClassStatus { done, current, locked }
+enum ClassStatus { done, current, expired, locked }
 
 class ClassItem {
   final String id;

--- a/lib/features/classes/presentation/roadmap/data/roadmap_mapper.dart
+++ b/lib/features/classes/presentation/roadmap/data/roadmap_mapper.dart
@@ -170,10 +170,12 @@ List<TrackData> buildRoadmapTracks({
 
 /// Deriva el [ClassStatus] desde el valor de investitureStatus del backend.
 ///
-/// Valores observados: null, 'PENDIENTE', 'INVESTIDO'.
+/// Valores observados: null, 'PENDIENTE', 'INVESTIDO', 'EXPIRED'.
 /// Cualquier estado activo no-investido se trata como [ClassStatus.current].
 ClassStatus _deriveStatus(String? investitureStatus) {
   if (investitureStatus == null) return ClassStatus.locked;
-  if (investitureStatus.toUpperCase() == 'INVESTIDO') return ClassStatus.done;
+  final normalized = investitureStatus.toUpperCase();
+  if (normalized == 'INVESTIDO') return ClassStatus.done;
+  if (normalized == 'EXPIRED') return ClassStatus.expired;
   return ClassStatus.current;
 }

--- a/lib/features/classes/presentation/roadmap/theme/roadmap_tokens.dart
+++ b/lib/features/classes/presentation/roadmap/theme/roadmap_tokens.dart
@@ -13,6 +13,7 @@ class RoadmapTokens {
   // Estados
   static const Color statusDone = Color(0xFF4FB37C);
   static const Color statusCurrent = Color(0xFFE57460);
+  static const Color statusExpired = Color(0xFFBE123C);
   static const Color statusLocked = Color(0xFFB0B5BF);
 
   // Texto (hardcoded — el roadmap tiene fondo propio con gradiente de cielo

--- a/lib/features/classes/presentation/roadmap/widgets/roadmap_screen.dart
+++ b/lib/features/classes/presentation/roadmap/widgets/roadmap_screen.dart
@@ -175,6 +175,9 @@ class _LegendPills extends StatelessWidget {
                   _Pill(label: 'Actual', color: RoadmapTokens.statusCurrent)),
           Expanded(
               child:
+                  _Pill(label: 'Vencida', color: RoadmapTokens.statusExpired)),
+          Expanded(
+              child:
                   _Pill(label: 'Bloqueada', color: RoadmapTokens.statusLocked)),
         ],
       ),

--- a/lib/features/classes/presentation/roadmap/widgets/va_node.dart
+++ b/lib/features/classes/presentation/roadmap/widgets/va_node.dart
@@ -45,6 +45,7 @@ class _VANodeState extends State<VANode> with SingleTickerProviderStateMixin {
     final isCurrent = item.status == ClassStatus.current;
     final isLocked = item.status == ClassStatus.locked;
     final isDone = item.status == ClassStatus.done;
+    final isExpired = item.status == ClassStatus.expired;
     final isLeft = widget.side == 'left';
 
     return Padding(
@@ -187,7 +188,7 @@ class _VANodeState extends State<VANode> with SingleTickerProviderStateMixin {
                               ),
                             ),
                           // Done check
-                          if (isDone)
+                          if (isDone || isExpired)
                             Positioned(
                               right: 6,
                               bottom: -2,
@@ -195,7 +196,9 @@ class _VANodeState extends State<VANode> with SingleTickerProviderStateMixin {
                                 width: 30,
                                 height: 30,
                                 decoration: BoxDecoration(
-                                  color: RoadmapTokens.statusDone,
+                                  color: isExpired
+                                      ? RoadmapTokens.statusExpired
+                                      : RoadmapTokens.statusDone,
                                   shape: BoxShape.circle,
                                   border:
                                       Border.all(color: Colors.white, width: 3),
@@ -208,8 +211,11 @@ class _VANodeState extends State<VANode> with SingleTickerProviderStateMixin {
                                     ),
                                   ],
                                 ),
-                                child: const Icon(Icons.check,
-                                    size: 14, color: Colors.white),
+                                child: Icon(
+                                  isExpired ? Icons.history : Icons.check,
+                                  size: 14,
+                                  color: Colors.white,
+                                ),
                               ),
                             ),
                         ],
@@ -269,6 +275,27 @@ class _VANodeState extends State<VANode> with SingleTickerProviderStateMixin {
                       child: Text(
                         'ACTUAL · ${item.progress!.toStringAsFixed(0)}%',
                         style: const TextStyle(
+                          fontSize: 10,
+                          fontWeight: FontWeight.w700,
+                          color: Colors.white,
+                          letterSpacing: 0.4,
+                        ),
+                      ),
+                    ),
+                  ),
+                if (isExpired)
+                  Padding(
+                    padding: const EdgeInsets.only(top: 8),
+                    child: Container(
+                      padding: const EdgeInsets.symmetric(
+                          horizontal: 10, vertical: 3),
+                      decoration: BoxDecoration(
+                        color: RoadmapTokens.statusExpired,
+                        borderRadius: BorderRadius.circular(999),
+                      ),
+                      child: const Text(
+                        'VENCIDA',
+                        style: TextStyle(
                           fontSize: 10,
                           fontWeight: FontWeight.w700,
                           color: Colors.white,

--- a/lib/features/classes/presentation/views/class_detail_with_progress_view.dart
+++ b/lib/features/classes/presentation/views/class_detail_with_progress_view.dart
@@ -138,6 +138,7 @@ class _ClassBodyState extends State<_ClassBody> {
         builder: (_) => RequirementDetailView(
           requirement: requirement,
           classId: widget.classId,
+          isClassExpired: widget.classWithProgress.isExpired,
         ),
       ),
     );
@@ -168,6 +169,7 @@ class _ClassBodyState extends State<_ClassBody> {
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
                   _HeroCard(classData: classData),
+                  if (classData.isExpired) const _ExpiredTrajectoryBanner(),
                   _PillsRow(classData: classData),
                   _SearchBar(
                     controller: _searchController,
@@ -217,6 +219,33 @@ class _ClassBodyState extends State<_ClassBody> {
               ),
             ),
         ],
+      ),
+    );
+  }
+}
+
+class _ExpiredTrajectoryBanner extends StatelessWidget {
+  const _ExpiredTrajectoryBanner();
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: double.infinity,
+      margin: const EdgeInsets.only(bottom: 12),
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: const Color(0xFFFFF1F2),
+        borderRadius: BorderRadius.circular(14),
+        border: Border.all(color: AppColors.error.withValues(alpha: 0.35)),
+      ),
+      child: const Text(
+        'Vencida · Esta clase se conserva en tu trayectoria, pero ya no puede completarse para investidura.',
+        style: TextStyle(
+          fontSize: 12.5,
+          fontWeight: FontWeight.w600,
+          color: AppColors.errorDark,
+          height: 1.35,
+        ),
       ),
     );
   }

--- a/lib/features/classes/presentation/views/class_detail_with_progress_view.dart
+++ b/lib/features/classes/presentation/views/class_detail_with_progress_view.dart
@@ -238,9 +238,9 @@ class _ExpiredTrajectoryBanner extends StatelessWidget {
         borderRadius: BorderRadius.circular(14),
         border: Border.all(color: AppColors.error.withValues(alpha: 0.35)),
       ),
-      child: const Text(
-        'Vencida · Esta clase se conserva en tu trayectoria, pero ya no puede completarse para investidura.',
-        style: TextStyle(
+      child: Text(
+        'classes.requirement_detail.expired_banner'.tr(),
+        style: const TextStyle(
           fontSize: 12.5,
           fontWeight: FontWeight.w600,
           color: AppColors.errorDark,

--- a/lib/features/classes/presentation/views/classes_list_view.dart
+++ b/lib/features/classes/presentation/views/classes_list_view.dart
@@ -125,10 +125,14 @@ class ClassesListViewBody extends ConsumerWidget {
           );
         }
 
-        // Split: current class (index 0) vs others
-        final currentClass = classes.first;
-        final otherClasses =
-            classes.length > 1 ? classes.sublist(1) : <dynamic>[];
+        final activeClasses = classes.where((c) => !c.isExpired).toList();
+        final expiredClasses = classes.where((c) => c.isExpired).toList();
+        final currentClass =
+            activeClasses.isNotEmpty ? activeClasses.first : null;
+        final otherClasses = [
+          if (activeClasses.length > 1) ...activeClasses.sublist(1),
+          ...expiredClasses,
+        ];
 
         return RefreshIndicator(
           color: AppColors.primary,
@@ -142,49 +146,51 @@ class ClassesListViewBody extends ConsumerWidget {
               _RoadmapChip(hPad: hPad),
               const SizedBox(height: 20),
 
-              // ── Section: Clase actual ──────────────────────────────────────
-              Text(
-                'classes.list.section_current'.tr(),
-                style: theme.textTheme.titleSmall?.copyWith(
-                  fontWeight: FontWeight.w700,
-                  color: c.textSecondary,
+              if (currentClass != null) ...[
+                // ── Section: Clase actual ────────────────────────────────────
+                Text(
+                  'classes.list.section_current'.tr(),
+                  style: theme.textTheme.titleSmall?.copyWith(
+                    fontWeight: FontWeight.w700,
+                    color: c.textSecondary,
+                  ),
                 ),
-              ),
-              const SizedBox(height: 8),
-              StaggeredListItem(
-                index: 0,
-                initialDelay: const Duration(milliseconds: 80),
-                staggerDelay: const Duration(milliseconds: 65),
-                child: Consumer(
-                  builder: (context, progressRef, _) {
-                    final progressAsync = progressRef
-                        .watch(classWithProgressProvider(currentClass.id));
-                    final progress = progressAsync.whenOrNull(
-                          data: (cwp) => cwp.completionRatio,
-                        ) ??
-                        0.0;
-                    return ClassCard(
-                      progressiveClass: currentClass,
-                      progress: progress,
-                      isCurrent: true,
-                      onTap: () {
-                        Navigator.push(
-                          context,
-                          MaterialPageRoute(
-                            builder: (context) => ClassDetailWithProgressView(
-                              classId: currentClass.id,
+                const SizedBox(height: 8),
+                StaggeredListItem(
+                  index: 0,
+                  initialDelay: const Duration(milliseconds: 80),
+                  staggerDelay: const Duration(milliseconds: 65),
+                  child: Consumer(
+                    builder: (context, progressRef, _) {
+                      final progressAsync = progressRef
+                          .watch(classWithProgressProvider(currentClass.id));
+                      final progress = progressAsync.whenOrNull(
+                            data: (cwp) => cwp.completionRatio,
+                          ) ??
+                          0.0;
+                      return ClassCard(
+                        progressiveClass: currentClass,
+                        progress: progress,
+                        isCurrent: true,
+                        onTap: () {
+                          Navigator.push(
+                            context,
+                            MaterialPageRoute(
+                              builder: (context) => ClassDetailWithProgressView(
+                                classId: currentClass.id,
+                              ),
                             ),
-                          ),
-                        );
-                      },
-                    );
-                  },
+                          );
+                        },
+                      );
+                    },
+                  ),
                 ),
-              ),
+              ],
 
               // ── Section: Otras clases ──────────────────────────────────────
               if (otherClasses.isNotEmpty) ...[
-                const SizedBox(height: 16),
+                SizedBox(height: currentClass == null ? 0 : 16),
                 Text(
                   'classes.list.section_others'.tr(),
                   style: theme.textTheme.titleSmall?.copyWith(

--- a/lib/features/classes/presentation/views/requirement_detail_view.dart
+++ b/lib/features/classes/presentation/views/requirement_detail_view.dart
@@ -129,7 +129,8 @@ class _RequirementDetailViewState extends ConsumerState<RequirementDetailView> {
     final requirement = _liveRequirement(classAsync);
     final isClassExpired =
         widget.isClassExpired || (classAsync.valueOrNull?.isExpired ?? false);
-    final canModify = !isClassExpired && requirement.canUpload;
+    final canModify =
+        requirement.canUploadForClass(isClassExpired: isClassExpired);
     final isLoading = notifierState.isLoading;
 
     // Find module index for eyebrow "X / Y"
@@ -336,6 +337,11 @@ class _RequirementDetailViewState extends ConsumerState<RequirementDetailView> {
                                 maxFiles: requirement.maxFiles,
                                 isLoading: notifierState.isLoading,
                                 onUpload: (xFile, mimeType, onProgress) async {
+                                  if (isClassExpired) {
+                                    throw StateError(
+                                      'Cannot upload evidence for an expired class',
+                                    );
+                                  }
                                   final success = await ref
                                       .read(requirementNotifierProvider(
                                               widget.classId)
@@ -353,6 +359,7 @@ class _RequirementDetailViewState extends ConsumerState<RequirementDetailView> {
                                   }
                                 },
                                 onDeleteRemote: (fileId) async {
+                                  if (isClassExpired) return;
                                   await ref
                                       .read(requirementNotifierProvider(
                                               widget.classId)
@@ -363,6 +370,7 @@ class _RequirementDetailViewState extends ConsumerState<RequirementDetailView> {
                                       );
                                 },
                                 onSubmit: () async {
+                                  if (isClassExpired) return;
                                   final success = await ref
                                       .read(requirementNotifierProvider(
                                               widget.classId)
@@ -472,6 +480,11 @@ class _RequirementDetailViewState extends ConsumerState<RequirementDetailView> {
   }
 
   Future<void> _handleSubmit(ClassRequirement req) async {
+    final classAsync = ref.read(classWithProgressProvider(widget.classId));
+    final isClassExpired =
+        widget.isClassExpired || (classAsync.valueOrNull?.isExpired ?? false);
+    if (!req.canSubmitForClass(isClassExpired: isClassExpired)) return;
+
     final success = await ref
         .read(requirementNotifierProvider(widget.classId).notifier)
         .submit(req.id);
@@ -514,8 +527,8 @@ class _ExpiredRequirementBanner extends StatelessWidget {
         borderRadius: BorderRadius.circular(14),
         border: Border.all(color: AppColors.error.withValues(alpha: 0.35)),
       ),
-      child: const Text(
-        'Vencida · Esta clase se conserva en tu trayectoria, pero ya no puede completarse para investidura.',
+      child: Text(
+        'classes.requirement_detail.expired_banner'.tr(),
         style: TextStyle(
           fontSize: 12.5,
           fontWeight: FontWeight.w600,

--- a/lib/features/classes/presentation/views/requirement_detail_view.dart
+++ b/lib/features/classes/presentation/views/requirement_detail_view.dart
@@ -30,11 +30,13 @@ import '../sheets/requirement_status_history_sheet.dart';
 class RequirementDetailView extends ConsumerStatefulWidget {
   final ClassRequirement requirement;
   final int classId;
+  final bool isClassExpired;
 
   const RequirementDetailView({
     super.key,
     required this.requirement,
     required this.classId,
+    this.isClassExpired = false,
   });
 
   @override
@@ -125,7 +127,9 @@ class _RequirementDetailViewState extends ConsumerState<RequirementDetailView> {
         ref.watch(requirementNotifierProvider(widget.classId));
     final classAsync = ref.watch(classWithProgressProvider(widget.classId));
     final requirement = _liveRequirement(classAsync);
-    final canModify = requirement.canUpload;
+    final isClassExpired =
+        widget.isClassExpired || (classAsync.valueOrNull?.isExpired ?? false);
+    final canModify = !isClassExpired && requirement.canUpload;
     final isLoading = notifierState.isLoading;
 
     // Find module index for eyebrow "X / Y"
@@ -218,6 +222,9 @@ class _RequirementDetailViewState extends ConsumerState<RequirementDetailView> {
                             ),
 
                             const SizedBox(height: 16),
+
+                            if (isClassExpired)
+                              const _ExpiredRequirementBanner(),
 
                             // Status banner (observed / rejected only)
                             if (requirement.status ==
@@ -490,6 +497,33 @@ class _RequirementDetailViewState extends ConsumerState<RequirementDetailView> {
       // ignore: use_build_context_synchronously
       Navigator.pop(context);
     }
+  }
+}
+
+class _ExpiredRequirementBanner extends StatelessWidget {
+  const _ExpiredRequirementBanner();
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: double.infinity,
+      margin: const EdgeInsets.only(bottom: 16),
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: const Color(0xFFFFF1F2),
+        borderRadius: BorderRadius.circular(14),
+        border: Border.all(color: AppColors.error.withValues(alpha: 0.35)),
+      ),
+      child: const Text(
+        'Vencida · Esta clase se conserva en tu trayectoria, pero ya no puede completarse para investidura.',
+        style: TextStyle(
+          fontSize: 12.5,
+          fontWeight: FontWeight.w600,
+          color: AppColors.errorDark,
+          height: 1.35,
+        ),
+      ),
+    );
   }
 }
 

--- a/lib/features/classes/presentation/widgets/class_card.dart
+++ b/lib/features/classes/presentation/widgets/class_card.dart
@@ -1,4 +1,5 @@
 import 'package:cached_network_image/cached_network_image.dart';
+import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:hugeicons/hugeicons.dart';
 import 'package:sacdia_app/core/theme/app_colors.dart';
@@ -12,7 +13,7 @@ import '../../domain/entities/progressive_class.dart';
 /// Card de clase progresiva - Estilo "Scout Vibrante"
 ///
 /// SacCard con barra de acento lateral (color de clase),
-/// progress bar lineal indigo→emerald, badge "Clase actual".
+/// progress bar lineal indigo→emerald y badge de estado.
 class ClassCard extends StatelessWidget {
   final ProgressiveClass progressiveClass;
   final double progress;
@@ -117,15 +118,19 @@ class ClassCard extends StatelessWidget {
                           ),
                         ),
                         if (isExpired)
-                          const SacBadge(label: 'Vencida')
+                          SacBadge(
+                            label: 'classes.class_card.expired_badge'.tr(),
+                          )
                         else if (isCurrent)
-                          const SacBadge(label: 'Clase actual'),
+                          SacBadge(
+                            label: 'classes.class_card.current_badge'.tr(),
+                          ),
                       ],
                     ),
                     if (isExpired) ...[
                       const SizedBox(height: 4),
-                      const Text(
-                        'Esta clase se conserva en tu trayectoria, pero ya no puede completarse para investidura.',
+                      Text(
+                        'classes.class_card.expired_description'.tr(),
                         style: TextStyle(
                           fontSize: 12,
                           color: AppColors.errorDark,

--- a/lib/features/classes/presentation/widgets/class_card.dart
+++ b/lib/features/classes/presentation/widgets/class_card.dart
@@ -32,11 +32,16 @@ class ClassCard extends StatelessWidget {
     final progressPercent = (progress * 100).toInt();
     final classColor = AppColors.classColor(progressiveClass.name);
     final logoAsset = AppColors.classLogoAsset(progressiveClass.name);
+    final isExpired = progressiveClass.isExpired;
 
     return SacCard(
       onTap: onTap,
       accentColor: classColor,
-      borderColor: isCurrent ? classColor : null,
+      borderColor: isExpired
+          ? AppColors.error.withValues(alpha: 0.45)
+          : isCurrent
+              ? classColor
+              : null,
       margin: const EdgeInsets.only(bottom: 12),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
@@ -111,9 +116,25 @@ class ClassCard extends StatelessWidget {
                             overflow: TextOverflow.ellipsis,
                           ),
                         ),
-                        if (isCurrent) const SacBadge(label: 'Clase actual'),
+                        if (isExpired)
+                          const SacBadge(label: 'Vencida')
+                        else if (isCurrent)
+                          const SacBadge(label: 'Clase actual'),
                       ],
                     ),
+                    if (isExpired) ...[
+                      const SizedBox(height: 4),
+                      const Text(
+                        'Esta clase se conserva en tu trayectoria, pero ya no puede completarse para investidura.',
+                        style: TextStyle(
+                          fontSize: 12,
+                          color: AppColors.errorDark,
+                          height: 1.25,
+                        ),
+                        maxLines: 2,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ],
                     if (progressiveClass.description != null) ...[
                       const SizedBox(height: 2),
                       Text(

--- a/lib/features/coordinator/presentation/views/evidence_review_list_view.dart
+++ b/lib/features/coordinator/presentation/views/evidence_review_list_view.dart
@@ -258,9 +258,9 @@ class _FilterChips extends ConsumerWidget {
           return FilterChip(
             label: Text(filter.label),
             selected: isSelected,
-            onSelected: (_) =>
-                ref.read(evidenceTypeFilterProvider.notifier).state =
-                    filter.value,
+            onSelected: (_) => ref
+                .read(evidenceTypeFilterProvider.notifier)
+                .state = filter.value,
             selectedColor: AppColors.primaryLight,
             checkmarkColor: AppColors.primary,
             labelStyle: TextStyle(

--- a/lib/features/dashboard/data/models/dashboard_summary_model.dart
+++ b/lib/features/dashboard/data/models/dashboard_summary_model.dart
@@ -73,6 +73,7 @@ class DashboardSummaryModel extends DashboardSummary {
     super.clubType,
     super.userRole,
     super.currentClassName,
+    super.currentClassInvestitureStatus,
     super.currentClassId,
     required super.classProgress,
     required super.honorsCompleted,
@@ -95,6 +96,10 @@ class DashboardSummaryModel extends DashboardSummary {
       clubType: json['club_type'] as String?,
       userRole: json['user_role'] as String?,
       currentClassName: json['current_class_name'] as String?,
+      currentClassInvestitureStatus: (json['investiture_status'] ??
+              json['current_class_investiture_status'] ??
+              json['current_class_status'])
+          ?.toString(),
       currentClassId: json['current_class_id'] as int?,
       // Backend sends class_progress as an integer percentage (0–100).
       // The domain entity and all widgets expect a fraction (0.0–1.0),
@@ -116,6 +121,7 @@ class DashboardSummaryModel extends DashboardSummary {
       'club_type': clubType,
       'user_role': userRole,
       'current_class_name': currentClassName,
+      'investiture_status': currentClassInvestitureStatus,
       'current_class_id': currentClassId,
       // Serialize back to the API contract format (integer percentage 0–100)
       'class_progress': (classProgress * 100).round(),
@@ -142,6 +148,7 @@ class DashboardSummaryModel extends DashboardSummary {
     String? clubType,
     String? userRole,
     String? currentClassName,
+    String? currentClassInvestitureStatus,
     int? currentClassId,
     double? classProgress,
     int? honorsCompleted,
@@ -155,6 +162,8 @@ class DashboardSummaryModel extends DashboardSummary {
       clubType: clubType ?? this.clubType,
       userRole: userRole ?? this.userRole,
       currentClassName: currentClassName ?? this.currentClassName,
+      currentClassInvestitureStatus:
+          currentClassInvestitureStatus ?? this.currentClassInvestitureStatus,
       currentClassId: currentClassId ?? this.currentClassId,
       classProgress: classProgress ?? this.classProgress,
       honorsCompleted: honorsCompleted ?? this.honorsCompleted,

--- a/lib/features/dashboard/domain/entities/dashboard_summary.dart
+++ b/lib/features/dashboard/domain/entities/dashboard_summary.dart
@@ -33,6 +33,7 @@ class DashboardSummary extends Equatable {
   final String? clubType;
   final String? userRole;
   final String? currentClassName;
+  final String? currentClassInvestitureStatus;
 
   /// ID de la clase actual del usuario, usado para obtener el progreso
   /// detallado desde [classWithProgressProvider].
@@ -49,12 +50,16 @@ class DashboardSummary extends Equatable {
     this.clubType,
     this.userRole,
     this.currentClassName,
+    this.currentClassInvestitureStatus,
     this.currentClassId,
     required this.classProgress,
     required this.honorsCompleted,
     required this.honorsInProgress,
     required this.upcomingActivities,
   });
+
+  bool get isCurrentClassExpired =>
+      currentClassInvestitureStatus?.trim().toUpperCase() == 'EXPIRED';
 
   @override
   List<Object?> get props => [
@@ -64,6 +69,7 @@ class DashboardSummary extends Equatable {
         clubType,
         userRole,
         currentClassName,
+        currentClassInvestitureStatus,
         currentClassId,
         classProgress,
         honorsCompleted,

--- a/lib/features/dashboard/presentation/views/dashboard_view.dart
+++ b/lib/features/dashboard/presentation/views/dashboard_view.dart
@@ -126,6 +126,7 @@ class DashboardView extends ConsumerWidget {
                           CurrentClassCard(
                             currentClassName: dashboard.currentClassName,
                             currentClassId: dashboard.currentClassId,
+                            initialIsExpired: dashboard.isCurrentClassExpired,
                             fallbackProgress: dashboard.classProgress,
                           ),
                           const SizedBox(height: 16),

--- a/lib/features/dashboard/presentation/widgets/current_class_card.dart
+++ b/lib/features/dashboard/presentation/widgets/current_class_card.dart
@@ -86,6 +86,7 @@ class CurrentClassCard extends ConsumerWidget {
 
     final int progressPercentage = (progress * 100).toInt();
     final bool isComplete = progress >= 1.0;
+    final bool isExpired = classState?.valueOrNull?.isExpired ?? false;
 
     return SacCard(
       child: Row(
@@ -125,7 +126,9 @@ class CurrentClassCard extends ConsumerWidget {
           const SizedBox(width: 12),
 
           // Small progress ring + percentage, OR "Completada" badge
-          if (isComplete)
+          if (isExpired)
+            const _ExpiredBadge()
+          else if (isComplete)
             const _CompletadaBadge()
           else
             SacProgressRing(
@@ -202,6 +205,41 @@ class CurrentClassCard extends ConsumerWidget {
                     size: 20,
                   ),
                 ),
+    );
+  }
+}
+
+class _ExpiredBadge extends StatelessWidget {
+  const _ExpiredBadge();
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+      decoration: BoxDecoration(
+        color: const Color(0xFFFFF1F2),
+        borderRadius: BorderRadius.circular(20),
+        border: Border.all(color: AppColors.error.withValues(alpha: 0.35)),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          HugeIcon(
+            icon: HugeIcons.strokeRoundedClock04,
+            size: 14,
+            color: AppColors.errorDark,
+          ),
+          const SizedBox(width: 4),
+          const Text(
+            'Vencida',
+            style: TextStyle(
+              fontSize: 12,
+              fontWeight: FontWeight.w500,
+              color: AppColors.errorDark,
+            ),
+          ),
+        ],
+      ),
     );
   }
 }

--- a/lib/features/dashboard/presentation/widgets/current_class_card.dart
+++ b/lib/features/dashboard/presentation/widgets/current_class_card.dart
@@ -11,7 +11,7 @@ import 'package:sacdia_app/features/classes/presentation/providers/classes_provi
 
 /// Card de clase actual con SacProgressRing - Estilo "Scout Vibrante"
 ///
-/// Fixed compact header row showing the school icon, "Mi Clase" label,
+/// Fixed compact header row showing the school icon, localized status label,
 /// the class name below, a small progress ring with the percentage, and
 /// the "Completada" badge when progress reaches 100%.
 ///
@@ -31,12 +31,14 @@ class CurrentClassCard extends ConsumerWidget {
   /// Se muestra mientras [classWithProgressProvider] carga o cuando
   /// [currentClassId] es null.
   final double fallbackProgress;
+  final bool initialIsExpired;
 
   const CurrentClassCard({
     super.key,
     this.currentClassName,
     this.currentClassId,
     this.fallbackProgress = 0.0,
+    this.initialIsExpired = false,
   });
 
   // ─── Build ────────────────────────────────────────────────────────────────
@@ -86,7 +88,8 @@ class CurrentClassCard extends ConsumerWidget {
 
     final int progressPercentage = (progress * 100).toInt();
     final bool isComplete = progress >= 1.0;
-    final bool isExpired = classState?.valueOrNull?.isExpired ?? false;
+    final bool isExpired =
+        initialIsExpired || (classState?.valueOrNull?.isExpired ?? false);
 
     return SacCard(
       child: Row(
@@ -103,7 +106,9 @@ class CurrentClassCard extends ConsumerWidget {
               mainAxisSize: MainAxisSize.min,
               children: [
                 Text(
-                  tr('dashboard.class_card.label'),
+                  tr(isExpired
+                      ? 'dashboard.class_card.expired_label'
+                      : 'dashboard.class_card.label'),
                   style: Theme.of(context).textTheme.labelSmall?.copyWith(
                         fontWeight: FontWeight.w600,
                         color: context.sac.textSecondary,
@@ -230,8 +235,8 @@ class _ExpiredBadge extends StatelessWidget {
             color: AppColors.errorDark,
           ),
           const SizedBox(width: 4),
-          const Text(
-            'Vencida',
+          Text(
+            tr('dashboard.class_card.expired_badge'),
             style: TextStyle(
               fontSize: 12,
               fontWeight: FontWeight.w500,

--- a/lib/features/honors/presentation/views/honor_detail_view.dart
+++ b/lib/features/honors/presentation/views/honor_detail_view.dart
@@ -423,8 +423,7 @@ class _HeroSectionState extends ConsumerState<_HeroSection>
                       child: LinearProgressIndicator(
                         value: _progressValue.value * progressPercent,
                         minHeight: 4,
-                        backgroundColor:
-                            Colors.white.withValues(alpha: 0.25),
+                        backgroundColor: Colors.white.withValues(alpha: 0.25),
                         valueColor: const AlwaysStoppedAnimation<Color>(
                           Colors.white,
                         ),
@@ -441,8 +440,7 @@ class _HeroSectionState extends ConsumerState<_HeroSection>
                     if (widget.honor.skillLevel != null)
                       _FrostedPill(
                           label: _skillLevelLabel(widget.honor.skillLevel)),
-                    _FrostedPill(
-                        label: _approvalLabel(widget.honor.approval)),
+                    _FrostedPill(label: _approvalLabel(widget.honor.approval)),
                   ],
                 ),
               ],

--- a/lib/features/investiture/domain/entities/investiture_status.dart
+++ b/lib/features/investiture/domain/entities/investiture_status.dart
@@ -36,13 +36,13 @@ enum InvestitureStatus {
       case InvestitureStatus.investido:
         return tr('investiture.status.investido');
       case InvestitureStatus.expired:
-        return 'Vencida';
+        return tr('investiture.status.expired');
     }
   }
 
   /// Parsea la cadena que devuelve el backend.
   static InvestitureStatus fromString(String value) {
-    switch (value.toUpperCase()) {
+    switch (value.trim().toUpperCase()) {
       case 'IN_PROGRESS':
         return InvestitureStatus.inProgress;
       case 'SUBMITTED_FOR_VALIDATION':

--- a/lib/features/investiture/domain/entities/investiture_status.dart
+++ b/lib/features/investiture/domain/entities/investiture_status.dart
@@ -13,7 +13,8 @@ enum InvestitureStatus {
   fieldApproved,
   approved,
   rejected,
-  investido;
+  investido,
+  expired;
 
   /// Etiqueta localizada para mostrar al usuario.
   String get label {
@@ -34,6 +35,8 @@ enum InvestitureStatus {
         return tr('investiture.status.rejected');
       case InvestitureStatus.investido:
         return tr('investiture.status.investido');
+      case InvestitureStatus.expired:
+        return 'Vencida';
     }
   }
 
@@ -56,6 +59,8 @@ enum InvestitureStatus {
         return InvestitureStatus.rejected;
       case 'INVESTIDO':
         return InvestitureStatus.investido;
+      case 'EXPIRED':
+        return InvestitureStatus.expired;
       default:
         return InvestitureStatus.inProgress;
     }
@@ -80,6 +85,8 @@ enum InvestitureStatus {
         return 'REJECTED';
       case InvestitureStatus.investido:
         return 'INVESTIDO';
+      case InvestitureStatus.expired:
+        return 'EXPIRED';
     }
   }
 }

--- a/lib/features/investiture/presentation/widgets/investiture_status_badge.dart
+++ b/lib/features/investiture/presentation/widgets/investiture_status_badge.dart
@@ -65,7 +65,7 @@ class InvestitureStatusBadge extends StatelessWidget {
       case InvestitureStatus.investido:
         return 'investiture.status.investido'.tr();
       case InvestitureStatus.expired:
-        return 'Vencida';
+        return 'investiture.status.expired'.tr();
     }
   }
 

--- a/lib/features/investiture/presentation/widgets/investiture_status_badge.dart
+++ b/lib/features/investiture/presentation/widgets/investiture_status_badge.dart
@@ -64,6 +64,8 @@ class InvestitureStatusBadge extends StatelessWidget {
         return 'investiture.status.rejected'.tr();
       case InvestitureStatus.investido:
         return 'investiture.status.investido'.tr();
+      case InvestitureStatus.expired:
+        return 'Vencida';
     }
   }
 
@@ -84,6 +86,8 @@ class InvestitureStatusBadge extends StatelessWidget {
         return AppColors.errorLight;
       case InvestitureStatus.investido:
         return AppColors.secondaryLight;
+      case InvestitureStatus.expired:
+        return isDark ? const Color(0xFF3A2F2F) : const Color(0xFFFFF1F2);
     }
   }
 
@@ -102,6 +106,8 @@ class InvestitureStatusBadge extends StatelessWidget {
         return AppColors.error.withValues(alpha: 0.4);
       case InvestitureStatus.investido:
         return AppColors.secondary.withValues(alpha: 0.4);
+      case InvestitureStatus.expired:
+        return AppColors.error.withValues(alpha: 0.35);
     }
   }
 
@@ -120,6 +126,8 @@ class InvestitureStatusBadge extends StatelessWidget {
         return AppColors.errorDark;
       case InvestitureStatus.investido:
         return AppColors.secondaryDark;
+      case InvestitureStatus.expired:
+        return AppColors.errorDark;
     }
   }
 
@@ -138,6 +146,8 @@ class InvestitureStatusBadge extends StatelessWidget {
         return HugeIcons.strokeRoundedCancel01;
       case InvestitureStatus.investido:
         return HugeIcons.strokeRoundedAward01;
+      case InvestitureStatus.expired:
+        return HugeIcons.strokeRoundedClock04;
     }
   }
 }

--- a/lib/features/profile/presentation/widgets/profile_classes_section.dart
+++ b/lib/features/profile/presentation/widgets/profile_classes_section.dart
@@ -255,9 +255,9 @@ class _ClassGridItem extends StatelessWidget {
                         color: AppColors.error,
                         borderRadius: BorderRadius.circular(8),
                       ),
-                      child: const Text(
-                        'Vencida',
-                        style: TextStyle(
+                      child: Text(
+                        'classes.class_card.expired_badge'.tr(),
+                        style: const TextStyle(
                           color: Colors.white,
                           fontSize: 8,
                           fontWeight: FontWeight.w700,

--- a/lib/features/profile/presentation/widgets/profile_classes_section.dart
+++ b/lib/features/profile/presentation/widgets/profile_classes_section.dart
@@ -193,6 +193,7 @@ class _ClassGridItem extends StatelessWidget {
     final progress = progressiveClass.overallProgress ?? 0;
 
     final isInvested = progressiveClass.investitureStatus == 'INVESTIDO';
+    final isExpired = progressiveClass.isExpired;
 
     return Column(
       children: [
@@ -215,8 +216,12 @@ class _ClassGridItem extends StatelessWidget {
                     color: classColor.withAlpha(20),
                     borderRadius: BorderRadius.circular(10),
                     border: Border.all(
-                      color: isInvested ? classColor : classColor.withAlpha(50),
-                      width: isInvested ? 2 : 1,
+                      color: isExpired
+                          ? AppColors.error.withAlpha(120)
+                          : isInvested
+                              ? classColor
+                              : classColor.withAlpha(50),
+                      width: isInvested || isExpired ? 2 : 1,
                     ),
                   ),
                   padding: const EdgeInsets.all(10),
@@ -237,7 +242,30 @@ class _ClassGridItem extends StatelessWidget {
                         ),
                 ),
                 // Progress badge (top-right)
-                if (progress > 0 && !isInvested)
+                if (isExpired)
+                  Positioned(
+                    top: -2,
+                    right: -2,
+                    child: Container(
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: 5,
+                        vertical: 2,
+                      ),
+                      decoration: BoxDecoration(
+                        color: AppColors.error,
+                        borderRadius: BorderRadius.circular(8),
+                      ),
+                      child: const Text(
+                        'Vencida',
+                        style: TextStyle(
+                          color: Colors.white,
+                          fontSize: 8,
+                          fontWeight: FontWeight.w700,
+                        ),
+                      ),
+                    ),
+                  )
+                else if (progress > 0 && !isInvested)
                   Positioned(
                     top: -2,
                     right: -2,

--- a/test/features/certificate_import/data/repositories/certificate_import_repository_impl_test.dart
+++ b/test/features/certificate_import/data/repositories/certificate_import_repository_impl_test.dart
@@ -1,4 +1,3 @@
-import 'package:dio/dio.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:sacdia_app/core/errors/exceptions.dart';
 import 'package:sacdia_app/core/errors/failures.dart';

--- a/test/features/classes/class_model_test.dart
+++ b/test/features/classes/class_model_test.dart
@@ -1,0 +1,46 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sacdia_app/features/classes/data/models/class_model.dart';
+
+void main() {
+  group('ClassModel availability and duration', () {
+    test('parses missing legacy fields with backward-compatible defaults', () {
+      final model = ClassModel.fromJson(const {
+        'class_id': 7,
+        'name': 'Amigo',
+        'club_type_id': 2,
+      });
+
+      expect(model.availableFromYearId, isNull);
+      expect(model.availableUntilYearId, isNull);
+      expect(model.minDurationYears, 1);
+      expect(model.maxDurationYears, 1);
+
+      final entity = model.toEntity();
+      expect(entity.availableFromYearId, isNull);
+      expect(entity.availableUntilYearId, isNull);
+      expect(entity.minDurationYears, 1);
+      expect(entity.maxDurationYears, 1);
+    });
+
+    test('parses explicit availability and duration fields', () {
+      final model = ClassModel.fromJson(const {
+        'class_id': 8,
+        'name': 'Guía Mayor Instructor',
+        'club_type_id': 3,
+        'available_from_year_id': 2026,
+        'available_until_year_id': 2028,
+        'min_duration_years': 2,
+        'max_duration_years': 3,
+      });
+
+      expect(model.availableFromYearId, 2026);
+      expect(model.availableUntilYearId, 2028);
+      expect(model.minDurationYears, 2);
+      expect(model.maxDurationYears, 3);
+      expect(model.toJson(), containsPair('available_from_year_id', 2026));
+      expect(model.toJson(), containsPair('available_until_year_id', 2028));
+      expect(model.toJson(), containsPair('min_duration_years', 2));
+      expect(model.toJson(), containsPair('max_duration_years', 3));
+    });
+  });
+}

--- a/test/features/classes/domain/entities/class_requirement_access_test.dart
+++ b/test/features/classes/domain/entities/class_requirement_access_test.dart
@@ -1,0 +1,51 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sacdia_app/features/classes/domain/entities/class_requirement.dart';
+import 'package:sacdia_app/features/classes/domain/entities/requirement_evidence.dart';
+
+void main() {
+  group('ClassRequirement class-expiration access', () {
+    test('blocks upload and submit when the class is expired', () {
+      final requirement = ClassRequirement(
+        id: 1,
+        name: 'Evidence',
+        moduleId: 10,
+        status: RequirementStatus.pendiente,
+        files: [
+          RequirementEvidence(
+            id: 'file-1',
+            url: 'https://example.test/file.jpg',
+            fileName: 'file.jpg',
+            type: EvidenceFileType.image,
+            uploadedByName: 'Ada',
+            uploadedAt: DateTime.utc(2026, 1, 1),
+          ),
+        ],
+      );
+
+      expect(requirement.canUploadForClass(isClassExpired: true), isFalse);
+      expect(requirement.canSubmitForClass(isClassExpired: true), isFalse);
+    });
+
+    test('allows upload and submit for active editable requirements', () {
+      final requirement = ClassRequirement(
+        id: 1,
+        name: 'Evidence',
+        moduleId: 10,
+        status: RequirementStatus.pendiente,
+        files: [
+          RequirementEvidence(
+            id: 'file-1',
+            url: 'https://example.test/file.jpg',
+            fileName: 'file.jpg',
+            type: EvidenceFileType.image,
+            uploadedByName: 'Ada',
+            uploadedAt: DateTime.utc(2026, 1, 1),
+          ),
+        ],
+      );
+
+      expect(requirement.canUploadForClass(isClassExpired: false), isTrue);
+      expect(requirement.canSubmitForClass(isClassExpired: false), isTrue);
+    });
+  });
+}

--- a/test/features/dashboard/data/models/dashboard_summary_model_test.dart
+++ b/test/features/dashboard/data/models/dashboard_summary_model_test.dart
@@ -1,0 +1,39 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sacdia_app/features/dashboard/data/models/dashboard_summary_model.dart';
+
+void main() {
+  group('DashboardSummaryModel', () {
+    test('parses current class investiture status when backend provides it',
+        () {
+      final model = DashboardSummaryModel.fromJson({
+        'user_name': 'Ada',
+        'current_class_name': 'Amigo',
+        'current_class_id': 10,
+        'investiture_status': 'EXPIRED',
+        'class_progress': 50,
+        'honors_completed': 1,
+        'honors_in_progress': 2,
+        'upcoming_activities': <dynamic>[],
+      });
+
+      expect(model.currentClassInvestitureStatus, 'EXPIRED');
+      expect(model.isCurrentClassExpired, isTrue);
+      expect(model.toJson()['investiture_status'], 'EXPIRED');
+    });
+
+    test(
+        'keeps missing current class investiture status as non-expired fallback',
+        () {
+      final model = DashboardSummaryModel.fromJson({
+        'user_name': 'Ada',
+        'class_progress': 50,
+        'honors_completed': 1,
+        'honors_in_progress': 2,
+        'upcoming_activities': <dynamic>[],
+      });
+
+      expect(model.currentClassInvestitureStatus, isNull);
+      expect(model.isCurrentClassExpired, isFalse);
+    });
+  });
+}

--- a/test/features/investiture/investiture_status_test.dart
+++ b/test/features/investiture/investiture_status_test.dart
@@ -1,27 +1,27 @@
-import 'package:flutter/material.dart';
+import 'dart:convert';
+
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:sacdia_app/features/investiture/domain/entities/investiture_status.dart';
-import 'package:sacdia_app/features/investiture/presentation/widgets/investiture_status_badge.dart';
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
   group('InvestitureStatus', () {
-    test('parses EXPIRED from backend', () {
-      final status = InvestitureStatus.fromString('EXPIRED');
+    test('parses EXPIRED from backend after trimming whitespace', () {
+      final status = InvestitureStatus.fromString(' expired ');
 
       expect(status, InvestitureStatus.expired);
       expect(status.backendValue, 'EXPIRED');
     });
 
-    testWidgets('expired status badge renders Vencida label', (tester) async {
-      await tester.pumpWidget(
-        const MaterialApp(
-          home: Scaffold(
-            body: InvestitureStatusBadge(status: InvestitureStatus.expired),
-          ),
-        ),
-      );
+    test('defines expired status label in translation assets', () async {
+      final raw = await rootBundle.loadString('assets/translations/es.json');
+      final json = jsonDecode(raw) as Map<String, dynamic>;
+      final investiture = json['investiture'] as Map<String, dynamic>;
+      final status = investiture['status'] as Map<String, dynamic>;
 
-      expect(find.text('Vencida'), findsOneWidget);
+      expect(status['expired'], 'Vencida');
     });
   });
 }

--- a/test/features/investiture/investiture_status_test.dart
+++ b/test/features/investiture/investiture_status_test.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sacdia_app/features/investiture/domain/entities/investiture_status.dart';
+import 'package:sacdia_app/features/investiture/presentation/widgets/investiture_status_badge.dart';
+
+void main() {
+  group('InvestitureStatus', () {
+    test('parses EXPIRED from backend', () {
+      final status = InvestitureStatus.fromString('EXPIRED');
+
+      expect(status, InvestitureStatus.expired);
+      expect(status.backendValue, 'EXPIRED');
+    });
+
+    testWidgets('expired status badge renders Vencida label', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: InvestitureStatusBadge(status: InvestitureStatus.expired),
+          ),
+        ),
+      );
+
+      expect(find.text('Vencida'), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Adds Flutter model/entity support for class availability, duration defaults, and `EXPIRED` investiture status.
- Preserves expired class trajectory in profile/dashboard while blocking upload/submit actions.
- Localizes expired-class UX copy and hardens dashboard status propagation.

## Verification
- [x] `flutter test test/features/classes test/features/investiture`
- [x] `flutter analyze`

## Notes
- No builds run per workspace instruction.
- Companion backend/admin/docs PRs carry the API/admin/docs contract.

## Companion PRs
- Backend: https://github.com/abn-r/sacdia-backend/pull/143
- Admin: https://github.com/abn-r/sacdia-admin/pull/181
- App: https://github.com/abn-r/sacdia-app/pull/100
- Docs: https://github.com/abn-r/sacdia/pull/22
