### PR TITLE
fix(honors): use live requirement progress endpoint

### DIFF
--- a/lib/features/honors/data/datasources/honors_remote_data_source.dart
+++ b/lib/features/honors/data/datasources/honors_remote_data_source.dart
@@ -49,8 +49,9 @@ abstract class HonorsRemoteDataSource {
       {CancelToken? cancelToken});
 
   /// Actualiza el progreso de un requisito individual.
-  /// PATCH /honors/:honorId/progress/:requirementId
+  /// PATCH /users/:userId/honors/:honorId/requirements/:requirementId/progress
   Future<UserHonorRequirementProgressModel> updateRequirementProgress({
+    required String userId,
     required int honorId,
     required int requirementId,
     required bool completed,
@@ -530,6 +531,7 @@ class HonorsRemoteDataSourceImpl implements HonorsRemoteDataSource {
 
   @override
   Future<UserHonorRequirementProgressModel> updateRequirementProgress({
+    required String userId,
     required int honorId,
     required int requirementId,
     required bool completed,
@@ -540,16 +542,17 @@ class HonorsRemoteDataSourceImpl implements HonorsRemoteDataSource {
         'completed': completed,
         if (notes != null) 'notes': notes,
       };
-      // New API: PATCH /honors/:honorId/progress/:requirementId
+      // Live API: PATCH /users/:userId/honors/:honorId/requirements/:requirementId/progress
       final response = await _dio.patch(
-        '$_baseUrl${ApiEndpoints.honors}/$honorId/progress/$requirementId',
+        '$_baseUrl${ApiEndpoints.users}/$userId${ApiEndpoints.honors}/$honorId/requirements/$requirementId/progress',
         data: body,
       );
 
       if (response.statusCode == 200 || response.statusCode == 201) {
         final raw = response.data as Map<String, dynamic>;
         final data = raw['data'] as Map<String, dynamic>;
-        return UserHonorRequirementProgressModel.fromJson(data);
+        final payload = (data['requirement'] as Map<String, dynamic>?) ?? data;
+        return UserHonorRequirementProgressModel.fromJson(payload);
       }
 
       throw ServerException(

--- a/lib/features/honors/data/repositories/honors_repository_impl.dart
+++ b/lib/features/honors/data/repositories/honors_repository_impl.dart
@@ -242,6 +242,7 @@ class HonorsRepositoryImpl implements HonorsRepository {
   @override
   Future<Either<Failure, UserHonorRequirementProgress>>
       updateRequirementProgress({
+    required String userId,
     required int honorId,
     required int requirementId,
     required bool completed,
@@ -249,6 +250,7 @@ class HonorsRepositoryImpl implements HonorsRepository {
   }) async {
     try {
       final model = await remoteDataSource.updateRequirementProgress(
+        userId: userId,
         honorId: honorId,
         requirementId: requirementId,
         completed: completed,

--- a/lib/features/honors/domain/repositories/honors_repository.dart
+++ b/lib/features/honors/domain/repositories/honors_repository.dart
@@ -74,6 +74,7 @@ abstract class HonorsRepository {
   /// Actualiza el progreso de un requisito individual.
   Future<Either<Failure, UserHonorRequirementProgress>>
       updateRequirementProgress({
+    required String userId,
     required int honorId,
     required int requirementId,
     required bool completed,

--- a/test/features/honors/data/datasources/honors_remote_data_source_test.dart
+++ b/test/features/honors/data/datasources/honors_remote_data_source_test.dart
@@ -1,0 +1,60 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sacdia_app/features/honors/data/datasources/honors_remote_data_source.dart';
+
+void main() {
+  group('HonorsRemoteDataSourceImpl.updateRequirementProgress', () {
+    test(
+        'uses live users/:userId/honors/:honorId/requirements/:requirementId/progress endpoint',
+        () async {
+      late RequestOptions captured;
+
+      final dio = Dio();
+      dio.interceptors.add(
+        InterceptorsWrapper(
+          onRequest: (options, handler) {
+            captured = options;
+            handler.resolve(
+              Response<Map<String, dynamic>>(
+                requestOptions: options,
+                statusCode: 200,
+                data: const {
+                  'status': 'success',
+                  'data': {
+                    'requirement_id': 10,
+                    'requirement_number': 1,
+                    'requirement_text': 'Texto requisito',
+                    'completed': true,
+                    'has_sub_items': false,
+                    'notes': 'ok',
+                  },
+                },
+              ),
+            );
+          },
+        ),
+      );
+
+      final ds = HonorsRemoteDataSourceImpl(
+        dio: dio,
+        baseUrl: 'https://api.test/api/v1',
+      );
+
+      final result = await ds.updateRequirementProgress(
+        userId: 'user-1',
+        honorId: 7,
+        requirementId: 10,
+        completed: true,
+        notes: 'ok',
+      );
+
+      expect(
+        captured.path,
+        'https://api.test/api/v1/users/user-1/honors/7/requirements/10/progress',
+      );
+      expect(captured.data, {'completed': true, 'notes': 'ok'});
+      expect(result.requirementId, 10);
+      expect(result.completed, isTrue);
+    });
+  });
+}

--- a/test/features/honors/domain/usecases/upload_honor_file_test.dart
+++ b/test/features/honors/domain/usecases/upload_honor_file_test.dart
@@ -104,7 +104,8 @@ class _FakeHonorsRepository implements HonorsRepository {
   @override
   Future<Either<Failure, UserHonorRequirementProgress>>
       updateRequirementProgress(
-              {required int honorId,
+              {required String userId,
+              required int honorId,
               required int requirementId,
               required bool completed,
               String? notes}) =>

--- a/test/features/honors/upload_requirement_evidence_test.dart
+++ b/test/features/honors/upload_requirement_evidence_test.dart
@@ -117,6 +117,7 @@ class _StubHonorsRepository implements HonorsRepository {
   @override
   Future<Either<Failure, UserHonorRequirementProgress>>
       updateRequirementProgress({
+    required String userId,
     required int honorId,
     required int requirementId,
     required bool completed,


### PR DESCRIPTION
## Summary
- Update single requirement progress updates to use the live user-scoped honors endpoint.
- Propagate `userId` through datasource and repository contracts.
- Add a datasource test covering the live endpoint path.

## Test Plan
- [x] `dart format <touched files>`
- [x] `flutter test test/features/honors/data/datasources/honors_remote_data_source_test.dart test/features/honors/upload_requirement_evidence_test.dart test/features/honors/domain/usecases/upload_honor_file_test.dart`
- [x] `flutter analyze lib/features/honors test/features/honors`

## Notes
Post-QA follow-up for the honors/especialidades workflow merged to development. Existing unrelated virtual_card/translation changes were left unstaged.
