### PR TITLE
fix: restore language picker emoji flags

### DIFF
--- a/lib/features/settings/presentation/widgets/language_picker_tile.dart
+++ b/lib/features/settings/presentation/widgets/language_picker_tile.dart
@@ -4,6 +4,7 @@ import 'package:hugeicons/hugeicons.dart';
 
 import '../../../profile/presentation/widgets/setting_tile.dart';
 import '../../../../core/theme/app_colors.dart';
+import '../../../../core/theme/sac_colors.dart';
 
 class LanguagePickerTile extends StatelessWidget {
   const LanguagePickerTile({super.key});
@@ -46,9 +47,29 @@ class LanguagePickerTile extends StatelessWidget {
     return SettingTile(
       icon: HugeIcons.strokeRoundedGlobe02,
       title: 'settings.language_picker_title'.tr(),
-      trailing: Text(
-        '${current.flag}  ${current.label}',
-        style: Theme.of(context).textTheme.bodySmall,
+      trailing: ConstrainedBox(
+        constraints: BoxConstraints(
+          maxWidth: MediaQuery.of(context).size.width * 0.42,
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          mainAxisAlignment: MainAxisAlignment.end,
+          children: [
+            _FlagEmoji(flag: current.flag, compact: true),
+            const SizedBox(width: 8),
+            Flexible(
+              child: Text(
+                current.label,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                textAlign: TextAlign.end,
+                style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                  color: context.sac.textSecondary,
+                ),
+              ),
+            ),
+          ],
+        ),
       ),
       iconColor: AppColors.primary,
       onTap: () => _showPicker(context),
@@ -67,16 +88,42 @@ class _LocaleOption {
   });
 }
 
+class _FlagEmoji extends StatelessWidget {
+  const _FlagEmoji({required this.flag, this.compact = false});
+
+  static const _emojiFontFallback = <String>[
+    'Apple Color Emoji',
+    'Noto Color Emoji',
+    'Segoe UI Emoji',
+  ];
+
+  final String flag;
+  final bool compact;
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(
+      flag,
+      style: TextStyle(
+        fontSize: compact ? 17 : 24,
+        fontFamilyFallback: _emojiFontFallback,
+      ),
+    );
+  }
+}
+
 class _LocalePickerSheet extends StatelessWidget {
   const _LocalePickerSheet({required this.current});
   final Locale current;
 
   @override
   Widget build(BuildContext context) {
+    final c = context.sac;
+
     return Container(
-      decoration: const BoxDecoration(
-        color: Colors.white,
-        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+      decoration: BoxDecoration(
+        color: c.surface,
+        borderRadius: const BorderRadius.vertical(top: Radius.circular(20)),
       ),
       padding: EdgeInsets.only(
         top: 12,
@@ -92,7 +139,7 @@ class _LocalePickerSheet extends StatelessWidget {
               width: 36,
               height: 5,
               decoration: BoxDecoration(
-                color: Colors.black12,
+                color: c.border,
                 borderRadius: BorderRadius.circular(3),
               ),
             ),
@@ -101,18 +148,20 @@ class _LocalePickerSheet extends StatelessWidget {
           Text(
             'settings.language_picker_title'.tr(),
             style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                  fontWeight: FontWeight.w600,
-                ),
+              fontWeight: FontWeight.w600,
+              color: c.text,
+            ),
           ),
           const SizedBox(height: 12),
           ...LanguagePickerTile._locales.map((o) {
-            final isCurrent = o.locale.languageCode == current.languageCode &&
+            final isCurrent =
+                o.locale.languageCode == current.languageCode &&
                 (o.locale.countryCode ?? '') == (current.countryCode ?? '');
             return ListTile(
-              leading: Text(o.flag, style: const TextStyle(fontSize: 24)),
-              title: Text(o.label),
+              leading: _FlagEmoji(flag: o.flag),
+              title: Text(o.label, style: TextStyle(color: c.text)),
               trailing: isCurrent
-                  ? const Icon(Icons.check, color: Colors.green)
+                  ? const Icon(Icons.check, color: AppColors.secondary)
                   : null,
               onTap: () => Navigator.of(context).pop(o.locale),
             );


### PR DESCRIPTION
## Summary
- Restaura banderas emoji en selector de idioma.
- Aísla render de emojis con fallback de fuentes y mantiene theming SACDIA.

## Verification
- `flutter analyze lib/features/settings/presentation/widgets/language_picker_tile.dart`
- Branch pushed to origin.
- No build executed.
