### PR TITLE
feat: handle pending membership app flow

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -705,6 +705,7 @@
       "upload_profile_photo": "Error uploading profile photo",
       "delete_profile_photo": "Error deleting profile photo",
       "complete_step_1": "Error completing post-registration step 1",
+      "cancel_membership_request": "Error cancelling membership request",
       "max_emergency_contacts": "Maximum 5 emergency contacts allowed"
     },
     "personal_info": {
@@ -2922,7 +2923,13 @@
       "pending_expires": "Expires on {date}",
       "rejected_title": "Your membership request was rejected",
       "expired_title": "Your membership request has expired",
-      "reapply": "Re-apply"
+      "reapply": "Re-apply",
+      "upload_certificates": "Upload certificates",
+      "cancel_request": "Cancel request",
+      "cancel_request_title": "Cancel request?",
+      "cancel_request_body": "You will return to club and section selection. Your profile and personal information will be kept.",
+      "cancel_request_confirm": "Yes, cancel",
+      "cancel_request_success": "Request cancelled"
     },
     "quick_access": {
       "title": "Quick access",

--- a/assets/translations/es.json
+++ b/assets/translations/es.json
@@ -705,6 +705,7 @@
       "upload_profile_photo": "Error al subir foto de perfil",
       "delete_profile_photo": "Error al eliminar foto de perfil",
       "complete_step_1": "Error al completar el paso 1 del post-registro",
+      "cancel_membership_request": "Error al cancelar la solicitud de membresía",
       "max_emergency_contacts": "Máximo 5 contactos de emergencia permitidos"
     },
     "personal_info": {
@@ -2922,7 +2923,13 @@
       "pending_expires": "Expira el {date}",
       "rejected_title": "Tu solicitud de membresía fue rechazada",
       "expired_title": "Tu solicitud de membresía expiró",
-      "reapply": "Volver a solicitar"
+      "reapply": "Volver a solicitar",
+      "upload_certificates": "Cargar certificados",
+      "cancel_request": "Cancelar solicitud",
+      "cancel_request_title": "¿Cancelar solicitud?",
+      "cancel_request_body": "Vas a volver a la selección de club y sección. Tu perfil y tu información personal se conservan.",
+      "cancel_request_confirm": "Sí, cancelar",
+      "cancel_request_success": "Solicitud cancelada"
     },
     "quick_access": {
       "title": "Acceso rápido",

--- a/assets/translations/fr.json
+++ b/assets/translations/fr.json
@@ -705,6 +705,7 @@
       "upload_profile_photo": "Erreur lors du téléversement de la photo de profil",
       "delete_profile_photo": "Erreur lors de la suppression de la photo de profil",
       "complete_step_1": "Erreur lors de la finalisation de l'étape 1 du post-inscription",
+      "cancel_membership_request": "Erreur lors de l’annulation de la demande d’adhésion",
       "max_emergency_contacts": "5 contacts d'urgence maximum autorisés"
     },
     "personal_info": {
@@ -2922,7 +2923,13 @@
       "pending_expires": "Expire le {date}",
       "rejected_title": "Votre demande d'adhésion a été refusée",
       "expired_title": "Votre demande d'adhésion a expiré",
-      "reapply": "Faire une nouvelle demande"
+      "reapply": "Faire une nouvelle demande",
+      "upload_certificates": "Téléverser des certificats",
+      "cancel_request": "Annuler la demande",
+      "cancel_request_title": "Annuler la demande ?",
+      "cancel_request_body": "Vous reviendrez à la sélection du club et de la section. Votre profil et vos informations personnelles seront conservés.",
+      "cancel_request_confirm": "Oui, annuler",
+      "cancel_request_success": "Demande annulée"
     },
     "quick_access": {
       "title": "Accès rapide",

--- a/assets/translations/pt-BR.json
+++ b/assets/translations/pt-BR.json
@@ -705,6 +705,7 @@
       "upload_profile_photo": "Erro ao enviar foto de perfil",
       "delete_profile_photo": "Erro ao excluir foto de perfil",
       "complete_step_1": "Erro ao concluir a etapa 1 do pós-cadastro",
+      "cancel_membership_request": "Erro ao cancelar solicitação de associação",
       "max_emergency_contacts": "Máximo de 5 contatos de emergência permitidos"
     },
     "personal_info": {
@@ -2922,7 +2923,13 @@
       "pending_expires": "Expira em {date}",
       "rejected_title": "Sua solicitação de associação foi rejeitada",
       "expired_title": "Sua solicitação de associação expirou",
-      "reapply": "Solicitar novamente"
+      "reapply": "Solicitar novamente",
+      "upload_certificates": "Enviar certificados",
+      "cancel_request": "Cancelar solicitação",
+      "cancel_request_title": "Cancelar solicitação?",
+      "cancel_request_body": "Você voltará para a seleção de clube e seção. Seu perfil e suas informações pessoais serão mantidos.",
+      "cancel_request_confirm": "Sim, cancelar",
+      "cancel_request_success": "Solicitação cancelada"
     },
     "quick_access": {
       "title": "Acesso rápido",

--- a/devtools_options.yaml
+++ b/devtools_options.yaml
@@ -1,3 +1,4 @@
 description: This file stores settings for Dart & Flutter DevTools.
 documentation: https://docs.flutter.dev/tools/devtools/extensions#configure-extension-enablement-states
 extensions:
+  - shared_preferences: true

--- a/lib/core/config/router.dart
+++ b/lib/core/config/router.dart
@@ -1335,6 +1335,7 @@ List<_NavItemConfig> _filterNavItems(
 
   return items.where((item) {
     if (item.requiredPermissions.isEmpty) return true;
+    if (!canAccessClubOperationalSurface(user)) return false;
     return hasAnyPermission(user, item.requiredPermissions);
   }).toList();
 }

--- a/lib/features/auth/data/datasources/auth_remote_data_source.dart
+++ b/lib/features/auth/data/datasources/auth_remote_data_source.dart
@@ -325,16 +325,6 @@ class AuthRemoteDataSourceImpl implements AuthRemoteDataSource {
               break;
             }
           }
-          // If no explicit-active grant found, fall back to the first available
-          // regardless of status (handles fresh accounts with no status yet).
-          fallbackAssignmentId ??= (() {
-            for (final grant
-                in user.authorization?.clubAssignments ?? const []) {
-              final candidate = grant.assignmentId?.trim();
-              if (candidate != null && candidate.isNotEmpty) return candidate;
-            }
-            return null;
-          })();
         }
 
         if (!_attemptedContextAutoActivation &&

--- a/lib/features/auth/domain/utils/authorization_utils.dart
+++ b/lib/features/auth/domain/utils/authorization_utils.dart
@@ -1,4 +1,5 @@
 import '../entities/user_entity.dart';
+import '../entities/authorization_snapshot.dart';
 
 enum SensitiveUserFamily {
   health,
@@ -89,6 +90,29 @@ bool hasAnyRole(UserEntity? user, Iterable<String> roles) {
     }
   }
   return false;
+}
+
+AuthorizationGrant? membershipGrantForDisplay(
+  AuthorizationSnapshot? authorization,
+) {
+  if (authorization == null) return null;
+
+  final activeGrant = authorization.activeGrant;
+  if (activeGrant != null) {
+    return activeGrant.isActive ? null : activeGrant;
+  }
+
+  for (final grant in authorization.clubAssignments) {
+    if (!grant.isActive) return grant;
+  }
+
+  return null;
+}
+
+bool canAccessClubOperationalSurface(UserEntity? user) {
+  final authorization = user?.authorization;
+  if (authorization == null) return false;
+  return membershipGrantForDisplay(authorization) == null;
 }
 
 bool isUserOwner(UserEntity? user, String targetUserId) {

--- a/lib/features/auth/presentation/providers/auth_providers.dart
+++ b/lib/features/auth/presentation/providers/auth_providers.dart
@@ -377,6 +377,50 @@ class AuthNotifier extends AsyncNotifier<UserEntity?> {
     _cacheUser(updatedUser);
   }
 
+  void markPostRegisterIncomplete() {
+    final current = state.valueOrNull;
+    if (current == null) return;
+    final updatedUser = UserEntity(
+      id: current.id,
+      email: current.email,
+      name: current.name,
+      avatar: current.avatar,
+      metadata: current.metadata,
+      authorization: current.authorization,
+      lastSignInAt: current.lastSignInAt,
+      createdAt: current.createdAt,
+      postRegisterComplete: false,
+    );
+    state = AsyncValue.data(updatedUser);
+    _cacheUser(updatedUser);
+  }
+
+  Future<UserEntity?> refreshCurrentUser({
+    bool keepCurrentOnFailure = false,
+  }) async {
+    final result = await ref.read(getCurrentUserProvider)(NoParams());
+
+    return result.fold(
+      (failure) {
+        final errorMessage = failure is AuthFailure
+            ? failure.message
+            : 'common.error_generic'.tr();
+        AppLogger.w('Error al refrescar usuario: $errorMessage', tag: _tag);
+        if (!keepCurrentOnFailure) {
+          state = AsyncValue.error(errorMessage, StackTrace.current);
+        }
+        return null;
+      },
+      (user) {
+        if (user != null) {
+          _cacheUser(user);
+        }
+        state = AsyncValue.data(user);
+        return user;
+      },
+    );
+  }
+
   /// Procesa el callback OAuth recibido por deep link.
   ///
   /// Llamar desde el router cuando se intercepta

--- a/lib/features/dashboard/presentation/widgets/membership_status_banner.dart
+++ b/lib/features/dashboard/presentation/widgets/membership_status_banner.dart
@@ -9,7 +9,9 @@ import '../../../../core/theme/app_colors.dart';
 import '../../../../core/theme/sac_colors.dart';
 import '../../../../core/widgets/sac_button.dart';
 import '../../../auth/domain/entities/authorization_snapshot.dart';
+import '../../../auth/domain/utils/authorization_utils.dart';
 import '../../../auth/presentation/providers/auth_providers.dart';
+import '../../../post_registration/presentation/providers/post_registration_providers.dart';
 
 /// Banner that shows the membership status of the user's active club assignment.
 ///
@@ -23,22 +25,22 @@ class MembershipStatusBanner extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final user = ref.watch(authNotifierProvider).valueOrNull;
-    final activeGrant = user?.authorization?.activeGrant;
+    final statusGrant = membershipGrantForDisplay(user?.authorization);
 
     // Nothing to show if there's no grant or grant is active.
-    if (activeGrant == null || activeGrant.isActive) {
+    if (statusGrant == null || statusGrant.isActive) {
       return const SizedBox.shrink();
     }
 
-    if (activeGrant.isPending) {
-      return _PendingBanner(grant: activeGrant);
+    if (statusGrant.isPending) {
+      return _PendingBanner(grant: statusGrant);
     }
 
-    if (activeGrant.isRejected) {
-      return _RejectedBanner(grant: activeGrant);
+    if (statusGrant.isRejected) {
+      return _RejectedBanner(grant: statusGrant);
     }
 
-    if (activeGrant.isExpired) {
+    if (statusGrant.isExpired) {
       return const _ExpiredBanner();
     }
 
@@ -48,14 +50,16 @@ class MembershipStatusBanner extends ConsumerWidget {
 
 // ── Pending ──────────────────────────────────────────────────────────────────
 
-class _PendingBanner extends StatelessWidget {
+class _PendingBanner extends ConsumerWidget {
   final AuthorizationGrant grant;
 
   const _PendingBanner({required this.grant});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final expiresAt = grant.expiresAt;
+    final cancelState = ref.watch(cancelPendingMembershipRequestProvider);
+    final isCancelling = cancelState.isLoading;
     String? expiryLabel;
     if (expiresAt != null) {
       final localDate = expiresAt.toLocal();
@@ -75,6 +79,28 @@ class _PendingBanner extends StatelessWidget {
       titleColor: AppColors.accentDark,
       subtitle: expiryLabel,
       subtitleColor: AppColors.accentDark.withValues(alpha: 0.8),
+      action: Wrap(
+        spacing: 8,
+        runSpacing: 8,
+        children: [
+          SacButton(
+            text: tr('dashboard.banner.upload_certificates'),
+            variant: SacButtonVariant.primary,
+            size: SacButtonSize.small,
+            backgroundColor: AppColors.accent,
+            textColor: Colors.white,
+            onPressed: () => context.push(RouteNames.certificateImportUpload),
+          ),
+          SacButton(
+            text: tr('dashboard.banner.cancel_request'),
+            variant: SacButtonVariant.outline,
+            size: SacButtonSize.small,
+            isLoading: isCancelling,
+            isEnabled: !isCancelling,
+            onPressed: () => _cancelPendingRequest(context, ref),
+          ),
+        ],
+      ),
     );
   }
 }
@@ -232,5 +258,53 @@ class _BannerContainer extends StatelessWidget {
 // ── Navigation helper ────────────────────────────────────────────────────────
 
 void _navigateToReapply(BuildContext context) {
+  context.go(RouteNames.postRegistration);
+}
+
+Future<void> _cancelPendingRequest(BuildContext context, WidgetRef ref) async {
+  final confirmed = await showDialog<bool>(
+    context: context,
+    builder: (dialogContext) => AlertDialog(
+      title: Text(tr('dashboard.banner.cancel_request_title')),
+      content: Text(tr('dashboard.banner.cancel_request_body')),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(dialogContext).pop(false),
+          child: Text(tr('common.cancel')),
+        ),
+        TextButton(
+          onPressed: () => Navigator.of(dialogContext).pop(true),
+          child: Text(tr('dashboard.banner.cancel_request_confirm')),
+        ),
+      ],
+    ),
+  );
+
+  if (confirmed != true || !context.mounted) return;
+
+  final userId = ref.read(authNotifierProvider).valueOrNull?.id;
+  if (userId == null) {
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text(tr('errors.user_not_authenticated'))),
+    );
+    return;
+  }
+
+  final error = await ref
+      .read(cancelPendingMembershipRequestProvider.notifier)
+      .cancel(userId: userId);
+
+  if (!context.mounted) return;
+
+  if (error != null) {
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text(error)),
+    );
+    return;
+  }
+
+  ScaffoldMessenger.of(context).showSnackBar(
+    SnackBar(content: Text(tr('dashboard.banner.cancel_request_success'))),
+  );
   context.go(RouteNames.postRegistration);
 }

--- a/lib/features/dashboard/presentation/widgets/quick_access_grid.dart
+++ b/lib/features/dashboard/presentation/widgets/quick_access_grid.dart
@@ -196,6 +196,10 @@ class QuickAccessGrid extends ConsumerWidget {
       return const SizedBox.shrink();
     }
 
+    if (!canAccessClubOperationalSurface(user)) {
+      return const SizedBox.shrink();
+    }
+
     final filteredItems = _quickAccessItemsConfig.where((item) {
       // Ungated items (no permissions AND no roles) are visible to every
       // authenticated user — used only when authorization is not a concern.

--- a/lib/features/post_registration/data/datasources/post_registration_remote_data_source.dart
+++ b/lib/features/post_registration/data/datasources/post_registration_remote_data_source.dart
@@ -16,6 +16,7 @@ abstract class PostRegistrationRemoteDataSource {
   Future<bool> getPhotoStatus(
       {required String userId, CancelToken? cancelToken});
   Future<void> completeStep1(String userId);
+  Future<void> cancelPendingMembershipRequest({required String userId});
 }
 
 /// Implementación de la fuente de datos remota de post-registro
@@ -163,6 +164,28 @@ class PostRegistrationRemoteDataSourceImpl
       }
     } catch (e) {
       AppLogger.e('Error en completeStep1', tag: _tag, error: e);
+      if (e is DioException) {
+        throw ServerException(message: e.message ?? tr('common.error_network'));
+      }
+      if (e is AppException) rethrow;
+      throw ServerException(message: e.toString());
+    }
+  }
+
+  @override
+  Future<void> cancelPendingMembershipRequest({required String userId}) async {
+    try {
+      final response = await _dio.post(
+        '$_baseUrl${ApiEndpoints.users}/$userId/post-registration/membership-request/cancel',
+      );
+
+      if (response.statusCode != 200 && response.statusCode != 201) {
+        throw ServerException(
+          message: tr('post_registration.errors.cancel_membership_request'),
+        );
+      }
+    } catch (e) {
+      AppLogger.e('Error al cancelar solicitud pendiente', tag: _tag, error: e);
       if (e is DioException) {
         throw ServerException(message: e.message ?? tr('common.error_network'));
       }

--- a/lib/features/post_registration/data/repositories/post_registration_repository_impl.dart
+++ b/lib/features/post_registration/data/repositories/post_registration_repository_impl.dart
@@ -105,4 +105,20 @@ class PostRegistrationRepositoryImpl implements PostRegistrationRepository {
       return Left(ServerFailure(message: e.toString()));
     }
   }
+
+  @override
+  Future<Either<Failure, void>> cancelPendingMembershipRequest({
+    required String userId,
+  }) async {
+    try {
+      await remoteDataSource.cancelPendingMembershipRequest(userId: userId);
+      return const Right(null);
+    } on core_exceptions.ServerException catch (e) {
+      return Left(ServerFailure(message: e.message, code: e.code));
+    } on core_exceptions.AuthException catch (e) {
+      return Left(AuthFailure(message: e.message, code: e.code));
+    } catch (e) {
+      return Left(ServerFailure(message: e.toString()));
+    }
+  }
 }

--- a/lib/features/post_registration/domain/repositories/post_registration_repository.dart
+++ b/lib/features/post_registration/domain/repositories/post_registration_repository.dart
@@ -29,4 +29,9 @@ abstract class PostRegistrationRepository {
 
   /// Completa el paso 1 del post-registro
   Future<Either<Failure, void>> completeStep1(String userId);
+
+  /// Cancela la solicitud pendiente de membresía y reabre selección de club.
+  Future<Either<Failure, void>> cancelPendingMembershipRequest({
+    required String userId,
+  });
 }

--- a/lib/features/post_registration/presentation/providers/post_registration_providers.dart
+++ b/lib/features/post_registration/presentation/providers/post_registration_providers.dart
@@ -68,6 +68,41 @@ final profilePhotoUploadNotifierProvider =
   ProfilePhotoUploadNotifier.new,
 );
 
+class CancelPendingMembershipRequestNotifier
+    extends AutoDisposeAsyncNotifier<void> {
+  @override
+  Future<void> build() async {}
+
+  Future<String?> cancel({required String userId}) async {
+    state = const AsyncValue.loading();
+
+    final result = await ref
+        .read(postRegistrationRepositoryProvider)
+        .cancelPendingMembershipRequest(userId: userId);
+
+    return result.fold(
+      (failure) {
+        state = AsyncValue.error(failure.message, StackTrace.current);
+        return failure.message;
+      },
+      (_) async {
+        state = const AsyncValue.data(null);
+        ref.read(authNotifierProvider.notifier).markPostRegisterIncomplete();
+        await ref
+            .read(authNotifierProvider.notifier)
+            .refreshCurrentUser(keepCurrentOnFailure: true);
+        ref.invalidate(completionStatusProvider);
+        return null;
+      },
+    );
+  }
+}
+
+final cancelPendingMembershipRequestProvider = AsyncNotifierProvider
+    .autoDispose<CancelPendingMembershipRequestNotifier, void>(
+  CancelPendingMembershipRequestNotifier.new,
+);
+
 /// Provider para el estado de completitud del post-registro
 final completionStatusProvider = AsyncNotifierProvider.autoDispose<
     CompletionStatusNotifier, CompletionStatus?>(() {

--- a/test/features/auth/data/auth_current_user_context_test.dart
+++ b/test/features/auth/data/auth_current_user_context_test.dart
@@ -1,0 +1,125 @@
+import 'dart:convert';
+
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sacdia_app/core/constants/app_constants.dart';
+import 'package:sacdia_app/core/storage/secure_storage.dart';
+import 'package:sacdia_app/features/auth/data/datasources/auth_remote_data_source.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _FakeSecureStorage implements SecureStorage {
+  final _store = <String, String>{};
+
+  @override
+  Future<void> write(String key, String value) async => _store[key] = value;
+
+  @override
+  Future<String?> read(String key) async => _store[key];
+
+  @override
+  Future<bool> contains(String key) async => _store.containsKey(key);
+
+  @override
+  Future<void> delete(String key) async => _store.remove(key);
+
+  @override
+  Future<void> deleteAll() async => _store.clear();
+
+  @override
+  Future<Map<String, String>> readAll() async => Map.unmodifiable(_store);
+}
+
+class _RecordingAdapter implements HttpClientAdapter {
+  final requests = <RequestOptions>[];
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<List<int>>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    requests.add(options);
+
+    if (options.path.endsWith('/auth/me') && options.method == 'GET') {
+      return _jsonResponse(
+        200,
+        {
+          'data': {
+            'user_id': 'user-1',
+            'email': 'elena@example.com',
+            'name': 'Elena',
+            'authorization': {
+              'effective': {
+                'permissions': ['users:read_detail', 'classes:read'],
+              },
+              'grants': {
+                'global_roles': [],
+                'club_assignments': [
+                  {
+                    'assignment_id': 'assignment-pending',
+                    'role_name': 'member',
+                    'permissions': ['users:read_detail', 'classes:read'],
+                    'status': 'pending',
+                    'section': {'club_section_id': 30},
+                  }
+                ],
+              },
+              'active_assignment': null,
+            },
+          },
+          'post_register_complete': true,
+        },
+      );
+    }
+
+    if (options.path.endsWith('/auth/me/context') &&
+        options.method == 'PATCH') {
+      return _jsonResponse(200, {'success': true});
+    }
+
+    return _jsonResponse(404, {'message': 'unexpected ${options.path}'});
+  }
+
+  ResponseBody _jsonResponse(int statusCode, Map<String, dynamic> body) {
+    return ResponseBody.fromString(
+      jsonEncode(body),
+      statusCode,
+      headers: {
+        Headers.contentTypeHeader: [Headers.jsonContentType],
+      },
+    );
+  }
+
+  @override
+  void close({bool force = false}) {}
+}
+
+void main() {
+  test('does not auto-activate a pending-only membership request', () async {
+    SharedPreferences.setMockInitialValues({});
+    final storage = _FakeSecureStorage();
+    await storage.write(AppConstants.tokenKey, 'jwt');
+    final adapter = _RecordingAdapter();
+    final dio = Dio(BaseOptions(baseUrl: 'http://localhost:3000'))
+      ..httpClientAdapter = adapter;
+
+    final dataSource = AuthRemoteDataSourceImpl(
+      dio: dio,
+      baseUrl: 'http://localhost:3000/api/v1',
+      secureStorage: storage,
+    );
+
+    final user = await dataSource.getCurrentUser();
+
+    expect(user?.authorization?.clubAssignments.single.isPending, isTrue);
+    expect(user?.authorization?.activeAssignmentId, isNull);
+    expect(
+      adapter.requests.where(
+        (request) =>
+            request.method == 'PATCH' &&
+            request.path.endsWith('/auth/me/context'),
+      ),
+      isEmpty,
+    );
+  });
+}

--- a/test/features/auth/domain/authorization_utils_test.dart
+++ b/test/features/auth/domain/authorization_utils_test.dart
@@ -1,0 +1,56 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sacdia_app/features/auth/domain/entities/authorization_snapshot.dart';
+import 'package:sacdia_app/features/auth/domain/entities/user_entity.dart';
+import 'package:sacdia_app/features/auth/domain/utils/authorization_utils.dart';
+
+UserEntity _userWithStatus(String status) {
+  return UserEntity(
+    id: 'user-1',
+    email: 'elena@example.com',
+    postRegisterComplete: true,
+    authorization: AuthorizationSnapshot(
+      effectivePermissions: const ['users:read_detail', 'classes:read'],
+      clubAssignments: [
+        AuthorizationGrant(
+          assignmentId: 'assignment-1',
+          roleName: 'member',
+          permissions: const ['users:read_detail', 'classes:read'],
+          status: status,
+        ),
+      ],
+      activeAssignmentId: 'assignment-1',
+    ),
+  );
+}
+
+void main() {
+  group('membershipGrantForDisplay', () {
+    test('returns a pending request when no active assignment is selected', () {
+      const auth = AuthorizationSnapshot(
+        clubAssignments: [
+          AuthorizationGrant(
+            assignmentId: 'pending-1',
+            roleName: 'member',
+            status: 'pending',
+          ),
+        ],
+      );
+
+      expect(membershipGrantForDisplay(auth)?.assignmentId, 'pending-1');
+    });
+  });
+
+  group('canAccessClubOperationalSurface', () {
+    test('blocks pending users even when permissions are present', () {
+      final user = _userWithStatus('pending');
+
+      expect(hasAnyPermission(user, const {'classes:read'}), isTrue);
+      expect(canAccessClubOperationalSurface(user), isFalse);
+    });
+
+    test('allows active users with authorization', () {
+      expect(
+          canAccessClubOperationalSurface(_userWithStatus('active')), isTrue);
+    });
+  });
+}

--- a/test/features/post_registration/data/post_registration_cancel_request_test.dart
+++ b/test/features/post_registration/data/post_registration_cancel_request_test.dart
@@ -1,0 +1,50 @@
+import 'dart:convert';
+
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sacdia_app/features/post_registration/data/datasources/post_registration_remote_data_source.dart';
+
+class _RecordingAdapter implements HttpClientAdapter {
+  RequestOptions? lastRequest;
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<List<int>>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    lastRequest = options;
+    return ResponseBody.fromString(
+      jsonEncode({'success': true}),
+      200,
+      headers: {
+        Headers.contentTypeHeader: [Headers.jsonContentType],
+      },
+    );
+  }
+
+  @override
+  void close({bool force = false}) {}
+}
+
+void main() {
+  test(
+      'cancelPendingMembershipRequest posts to the user post-registration endpoint',
+      () async {
+    final adapter = _RecordingAdapter();
+    final dio = Dio(BaseOptions(baseUrl: 'http://localhost:3000'))
+      ..httpClientAdapter = adapter;
+    final dataSource = PostRegistrationRemoteDataSourceImpl(
+      dio: dio,
+      baseUrl: 'http://localhost:3000/api/v1',
+    );
+
+    await dataSource.cancelPendingMembershipRequest(userId: 'user-1');
+
+    expect(adapter.lastRequest?.method, 'POST');
+    expect(
+      adapter.lastRequest?.path,
+      'http://localhost:3000/api/v1/users/user-1/post-registration/membership-request/cancel',
+    );
+  });
+}


### PR DESCRIPTION
## Summary
- Maneja flujo de membresía pendiente en app.
- Ajusta auth, post-registro, dashboard y tests relacionados.

## Verification
- Branch pushed to origin.
- Working tree clean before PR creation.
- No build executed.
