### PR TITLE
feat(master-honors): add mobile data layer

### DIFF
--- a/lib/features/master_honors/data/datasources/master_honors_remote_data_source.dart
+++ b/lib/features/master_honors/data/datasources/master_honors_remote_data_source.dart
@@ -1,0 +1,71 @@
+import 'package:dio/dio.dart';
+
+import '../../../../core/constants/api_endpoints.dart';
+import '../../../../core/errors/exceptions.dart';
+import '../../../../core/utils/app_logger.dart';
+import '../models/user_master_honor_model.dart';
+
+abstract class MasterHonorsRemoteDataSource {
+  Future<List<UserMasterHonorModel>> getUserMasterHonors(
+    String userId, {
+    CancelToken? cancelToken,
+  });
+}
+
+class MasterHonorsRemoteDataSourceImpl implements MasterHonorsRemoteDataSource {
+  final Dio _dio;
+  final String _baseUrl;
+
+  static const _tag = 'MasterHonorsDS';
+
+  MasterHonorsRemoteDataSourceImpl({
+    required Dio dio,
+    required String baseUrl,
+  })  : _dio = dio,
+        _baseUrl = baseUrl;
+
+  @override
+  Future<List<UserMasterHonorModel>> getUserMasterHonors(
+    String userId, {
+    CancelToken? cancelToken,
+  }) async {
+    try {
+      final response = await _dio.get(
+        '$_baseUrl${ApiEndpoints.users}/$userId/master-honors',
+        cancelToken: cancelToken,
+      );
+
+      if (response.statusCode == 200 || response.statusCode == 201) {
+        final data = _extractList(response.data);
+        return data
+            .map((json) =>
+                UserMasterHonorModel.fromJson(json as Map<String, dynamic>))
+            .toList();
+      }
+
+      throw ServerException(
+        message: 'No se pudieron obtener las maestrías del usuario',
+        code: response.statusCode,
+      );
+    } catch (e) {
+      AppLogger.e('Error en getUserMasterHonors', tag: _tag, error: e);
+      if (e is DioException) {
+        if (e.type == DioExceptionType.cancel) rethrow;
+        throw ServerException(
+          message: e.message ?? 'Error de red',
+          code: e.response?.statusCode,
+        );
+      }
+      if (e is ServerException || e is AuthException) rethrow;
+      throw ServerException(message: e.toString());
+    }
+  }
+
+  List<dynamic> _extractList(dynamic raw) {
+    if (raw is List) return raw;
+    if (raw is Map<String, dynamic> && raw['data'] is List) {
+      return raw['data'] as List<dynamic>;
+    }
+    throw ServerException(message: 'Respuesta inválida de maestrías');
+  }
+}

--- a/lib/features/master_honors/data/models/user_master_honor_model.dart
+++ b/lib/features/master_honors/data/models/user_master_honor_model.dart
@@ -1,0 +1,101 @@
+import 'package:equatable/equatable.dart';
+
+import '../../../../core/utils/json_helpers.dart';
+import '../../domain/entities/user_master_honor.dart';
+
+class UserMasterHonorModel extends Equatable {
+  final int userMasterHonorId;
+  final int masterHonorId;
+  final String name;
+  final String? masterImage;
+  final String status;
+  final bool isCurrent;
+  final String displayStatusLabel;
+  final DateTime? awardedAt;
+  final DateTime? revokedAt;
+  final DateTime? recoveredAt;
+  final String? statusReason;
+
+  const UserMasterHonorModel({
+    required this.userMasterHonorId,
+    required this.masterHonorId,
+    required this.name,
+    this.masterImage,
+    required this.status,
+    required this.isCurrent,
+    required this.displayStatusLabel,
+    this.awardedAt,
+    this.revokedAt,
+    this.recoveredAt,
+    this.statusReason,
+  });
+
+  factory UserMasterHonorModel.fromJson(Map<String, dynamic> json) {
+    return UserMasterHonorModel(
+      userMasterHonorId: safeInt(json['user_master_honor_id']),
+      masterHonorId: safeInt(json['master_honor_id']),
+      name: safeString(json['name']),
+      masterImage: safeStringOrNull(json['master_image']),
+      status: safeString(json['status']),
+      isCurrent: safeBool(json['is_current']),
+      displayStatusLabel: safeString(json['display_status_label']),
+      awardedAt: _parseDate(json['awarded_at']),
+      revokedAt: _parseDate(json['revoked_at']),
+      recoveredAt: _parseDate(json['recovered_at']),
+      statusReason: safeStringOrNull(json['status_reason']),
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'user_master_honor_id': userMasterHonorId,
+      'master_honor_id': masterHonorId,
+      'name': name,
+      'master_image': masterImage,
+      'status': status,
+      'is_current': isCurrent,
+      'display_status_label': displayStatusLabel,
+      'awarded_at': awardedAt?.toIso8601String(),
+      'revoked_at': revokedAt?.toIso8601String(),
+      'recovered_at': recoveredAt?.toIso8601String(),
+      'status_reason': statusReason,
+    };
+  }
+
+  UserMasterHonor toEntity() {
+    return UserMasterHonor(
+      userMasterHonorId: userMasterHonorId,
+      masterHonorId: masterHonorId,
+      name: name,
+      masterImage: masterImage,
+      status: status,
+      isCurrent: isCurrent,
+      displayStatusLabel: displayStatusLabel,
+      awardedAt: awardedAt,
+      revokedAt: revokedAt,
+      recoveredAt: recoveredAt,
+      statusReason: statusReason,
+    );
+  }
+
+  static DateTime? _parseDate(dynamic value) {
+    final raw = safeStringOrNull(value);
+    if (raw == null || raw.isEmpty) return null;
+    return DateTime.tryParse(raw);
+  }
+
+  @override
+  List<Object?> get props => [
+        userMasterHonorId,
+        masterHonorId,
+        name,
+        masterImage,
+        status,
+        isCurrent,
+        displayStatusLabel,
+        awardedAt,
+        revokedAt,
+        recoveredAt,
+        statusReason,
+      ];
+}

--- a/lib/features/master_honors/data/repositories/master_honors_repository_impl.dart
+++ b/lib/features/master_honors/data/repositories/master_honors_repository_impl.dart
@@ -1,0 +1,39 @@
+import 'package:dartz/dartz.dart';
+import 'package:dio/dio.dart';
+
+import '../../../../core/errors/exceptions.dart';
+import '../../../../core/errors/failures.dart';
+import '../../../../core/network/network_info.dart';
+import '../../domain/entities/user_master_honor.dart';
+import '../../domain/repositories/master_honors_repository.dart';
+import '../datasources/master_honors_remote_data_source.dart';
+
+class MasterHonorsRepositoryImpl implements MasterHonorsRepository {
+  final MasterHonorsRemoteDataSource remoteDataSource;
+  final NetworkInfo networkInfo;
+
+  MasterHonorsRepositoryImpl({
+    required this.remoteDataSource,
+    required this.networkInfo,
+  });
+
+  @override
+  Future<Either<Failure, List<UserMasterHonor>>> getUserMasterHonors(
+    String userId, {
+    CancelToken? cancelToken,
+  }) async {
+    try {
+      final models = await remoteDataSource.getUserMasterHonors(
+        userId,
+        cancelToken: cancelToken,
+      );
+      return Right(models.map((model) => model.toEntity()).toList());
+    } on ServerException catch (e) {
+      return Left(ServerFailure(message: e.message, code: e.code));
+    } on AuthException catch (e) {
+      return Left(AuthFailure(message: e.message, code: e.code));
+    } catch (e) {
+      return Left(UnexpectedFailure(message: e.toString()));
+    }
+  }
+}

--- a/lib/features/master_honors/domain/entities/user_master_honor.dart
+++ b/lib/features/master_honors/domain/entities/user_master_honor.dart
@@ -1,0 +1,47 @@
+import 'package:equatable/equatable.dart';
+
+/// Maestría obtenida o histórica de un usuario.
+class UserMasterHonor extends Equatable {
+  final int userMasterHonorId;
+  final int masterHonorId;
+  final String name;
+  final String? masterImage;
+  final String status;
+  final bool isCurrent;
+  final String displayStatusLabel;
+  final DateTime? awardedAt;
+  final DateTime? revokedAt;
+  final DateTime? recoveredAt;
+  final String? statusReason;
+
+  const UserMasterHonor({
+    required this.userMasterHonorId,
+    required this.masterHonorId,
+    required this.name,
+    this.masterImage,
+    required this.status,
+    required this.isCurrent,
+    required this.displayStatusLabel,
+    this.awardedAt,
+    this.revokedAt,
+    this.recoveredAt,
+    this.statusReason,
+  });
+
+  bool get isNoCurrent => !isCurrent;
+
+  @override
+  List<Object?> get props => [
+        userMasterHonorId,
+        masterHonorId,
+        name,
+        masterImage,
+        status,
+        isCurrent,
+        displayStatusLabel,
+        awardedAt,
+        revokedAt,
+        recoveredAt,
+        statusReason,
+      ];
+}

--- a/lib/features/master_honors/domain/repositories/master_honors_repository.dart
+++ b/lib/features/master_honors/domain/repositories/master_honors_repository.dart
@@ -1,0 +1,12 @@
+import 'package:dartz/dartz.dart';
+import 'package:dio/dio.dart';
+
+import '../../../../core/errors/failures.dart';
+import '../entities/user_master_honor.dart';
+
+abstract class MasterHonorsRepository {
+  Future<Either<Failure, List<UserMasterHonor>>> getUserMasterHonors(
+    String userId, {
+    CancelToken? cancelToken,
+  });
+}

--- a/lib/features/master_honors/presentation/providers/master_honors_providers.dart
+++ b/lib/features/master_honors/presentation/providers/master_honors_providers.dart
@@ -1,0 +1,59 @@
+import 'package:dio/dio.dart';
+import 'package:easy_localization/easy_localization.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../../providers/dio_provider.dart';
+import '../../../auth/presentation/providers/auth_providers.dart';
+import '../../data/datasources/master_honors_remote_data_source.dart';
+import '../../data/repositories/master_honors_repository_impl.dart';
+import '../../domain/entities/user_master_honor.dart';
+import '../../domain/repositories/master_honors_repository.dart';
+
+final masterHonorsRemoteDataSourceProvider =
+    Provider<MasterHonorsRemoteDataSource>((ref) {
+  final dio = ref.read(dioProvider);
+  final baseUrl = ref.read(apiBaseUrlProvider);
+
+  return MasterHonorsRemoteDataSourceImpl(
+    dio: dio,
+    baseUrl: baseUrl,
+  );
+});
+
+final masterHonorsRepositoryProvider = Provider<MasterHonorsRepository>((ref) {
+  return MasterHonorsRepositoryImpl(
+    remoteDataSource: ref.read(masterHonorsRemoteDataSourceProvider),
+    networkInfo: ref.read(networkInfoProvider),
+  );
+});
+
+final userMasterHonorsProvider =
+    FutureProvider.autoDispose<List<UserMasterHonor>>((ref) async {
+  ref.keepAlive();
+  final cancelToken = CancelToken();
+  ref.onDispose(() => cancelToken.cancel());
+
+  final userId = await ref.watch(
+    authNotifierProvider.selectAsync((user) => user?.id),
+  );
+
+  if (userId == null) {
+    throw Exception(tr('errors.user_not_authenticated'));
+  }
+
+  final repository = ref.read(masterHonorsRepositoryProvider);
+  final result = await repository.getUserMasterHonors(
+    userId,
+    cancelToken: cancelToken,
+  );
+
+  return result.fold(
+    (failure) => throw Exception(failure.message),
+    (masterHonors) => masterHonors,
+  );
+});
+
+/// Hook estable para que notificaciones `master_honor_changed` invaliden cache.
+final masterHonorsInvalidationProvider = Provider<void Function()>((ref) {
+  return () => ref.invalidate(userMasterHonorsProvider);
+});

--- a/test/features/master_honors/data/datasources/master_honors_remote_data_source_test.dart
+++ b/test/features/master_honors/data/datasources/master_honors_remote_data_source_test.dart
@@ -1,0 +1,51 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sacdia_app/features/master_honors/data/datasources/master_honors_remote_data_source.dart';
+
+void main() {
+  group('MasterHonorsRemoteDataSourceImpl', () {
+    test('uses live users/:userId/master-honors endpoint', () async {
+      late RequestOptions captured;
+
+      final dio = Dio();
+      dio.interceptors.add(
+        InterceptorsWrapper(
+          onRequest: (options, handler) {
+            captured = options;
+            handler.resolve(
+              Response<List<dynamic>>(
+                requestOptions: options,
+                statusCode: 200,
+                data: const [
+                  {
+                    'user_master_honor_id': 10,
+                    'master_honor_id': 2,
+                    'name': 'Maestría en Acuática',
+                    'master_image': 'https://example.com/a.png',
+                    'status': 'REVOKED',
+                    'is_current': false,
+                    'display_status_label': 'No vigente',
+                    'awarded_at': '2026-06-03T10:00:00Z',
+                  },
+                ],
+              ),
+            );
+          },
+        ),
+      );
+
+      final dataSource = MasterHonorsRemoteDataSourceImpl(
+        dio: dio,
+        baseUrl: 'https://api.test/api/v1',
+      );
+
+      final result = await dataSource.getUserMasterHonors('user-1');
+
+      expect(captured.path,
+          'https://api.test/api/v1/users/user-1/master-honors');
+      expect(result, hasLength(1));
+      expect(result.single.masterHonorId, 2);
+      expect(result.single.displayStatusLabel, 'No vigente');
+    });
+  });
+}

--- a/test/features/master_honors/data/datasources/master_honors_remote_data_source_test.dart
+++ b/test/features/master_honors/data/datasources/master_honors_remote_data_source_test.dart
@@ -41,8 +41,8 @@ void main() {
 
       final result = await dataSource.getUserMasterHonors('user-1');
 
-      expect(captured.path,
-          'https://api.test/api/v1/users/user-1/master-honors');
+      expect(
+          captured.path, 'https://api.test/api/v1/users/user-1/master-honors');
       expect(result, hasLength(1));
       expect(result.single.masterHonorId, 2);
       expect(result.single.displayStatusLabel, 'No vigente');

--- a/test/features/master_honors/data/models/user_master_honor_model_test.dart
+++ b/test/features/master_honors/data/models/user_master_honor_model_test.dart
@@ -1,0 +1,47 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sacdia_app/features/master_honors/data/models/user_master_honor_model.dart';
+
+void main() {
+  group('UserMasterHonorModel', () {
+    test('parses no-current master honor payload from backend', () {
+      final model = UserMasterHonorModel.fromJson({
+        'user_master_honor_id': 10,
+        'master_honor_id': 2,
+        'name': 'Maestría en Acuática',
+        'master_image': 'https://example.com/a.png',
+        'status': 'REVOKED',
+        'is_current': false,
+        'display_status_label': 'No vigente',
+        'awarded_at': '2026-06-03T10:00:00Z',
+      });
+
+      expect(model.userMasterHonorId, 10);
+      expect(model.masterHonorId, 2);
+      expect(model.name, 'Maestría en Acuática');
+      expect(model.masterImage, 'https://example.com/a.png');
+      expect(model.status, 'REVOKED');
+      expect(model.isCurrent, isFalse);
+      expect(model.displayStatusLabel, 'No vigente');
+      expect(model.awardedAt, DateTime.parse('2026-06-03T10:00:00Z'));
+      expect(model.revokedAt, isNull);
+      expect(model.recoveredAt, isNull);
+      expect(model.statusReason, isNull);
+    });
+
+    test('maps to domain entity without losing status fields', () {
+      final entity = UserMasterHonorModel.fromJson({
+        'user_master_honor_id': 10,
+        'master_honor_id': 2,
+        'name': 'Maestría en Acuática',
+        'status': 'AWARDED',
+        'is_current': true,
+        'display_status_label': 'Vigente',
+      }).toEntity();
+
+      expect(entity.userMasterHonorId, 10);
+      expect(entity.masterHonorId, 2);
+      expect(entity.isCurrent, isTrue);
+      expect(entity.displayStatusLabel, 'Vigente');
+    });
+  });
+}


### PR DESCRIPTION
Closes abn-r/sacdia-app#107

## Summary
- Adds Flutter data/domain/provider layer for user maestrías.
- Consumes the live `/users/:userId/master-honors` endpoint.
- Preserves current and No vigente status fields for upcoming UI integration.

## Changes
| File | Change |
|------|--------|
| `lib/features/master_honors/data/datasources/master_honors_remote_data_source.dart` | Adds remote endpoint integration. |
| `lib/features/master_honors/data/models/user_master_honor_model.dart` | Maps backend payload to model/entity. |
| `lib/features/master_honors/domain/*` | Adds entity and repository contract. |
| `lib/features/master_honors/presentation/providers/master_honors_providers.dart` | Adds Riverpod providers and invalidation hook. |
| `test/features/master_honors/*` | Covers model mapping and endpoint path. |

## Test Plan
- [x] `dart format --output=none --set-exit-if-changed .`
- [x] `flutter test test/features/master_honors/data/models/user_master_honor_model_test.dart test/features/master_honors/data/datasources/master_honors_remote_data_source_test.dart`
- [x] `flutter analyze lib/features/master_honors test/features/master_honors`
- [x] `git diff --check`

## Checklist
- [x] Linked an approved issue.
- [x] Added exactly one `type:*` label.
- [x] Conventional commit format.
- [x] No `Co-Authored-By` trailers.
