### PR TITLE
feat(master-honors): show band, history, and status modal

### DIFF
--- a/lib/core/notifications/push_notification_service.dart
+++ b/lib/core/notifications/push_notification_service.dart
@@ -16,6 +16,9 @@ import '../realtime/realtime_invalidation_handler.dart';
 import '../realtime/realtime_ref.dart';
 import '../utils/app_logger.dart';
 import '../../features/achievements/presentation/providers/achievements_providers.dart';
+import '../../features/master_honors/presentation/providers/master_honor_modal_queue_provider.dart';
+import '../../features/master_honors/presentation/providers/master_honors_providers.dart';
+import '../../features/master_honors/presentation/widgets/master_honor_change_modal.dart';
 import '../../features/notifications/presentation/providers/notifications_providers.dart';
 import '../../features/notifications/presentation/providers/unread_notifications_count_provider.dart';
 
@@ -405,6 +408,10 @@ class PushNotificationService {
       _handleAchievementUnlockedForeground(message);
       return;
     }
+    if (type == 'master_honor_changed') {
+      _handleMasterHonorChangedForeground(message);
+      return;
+    }
 
     final notification = message.notification;
     if (notification == null) return;
@@ -449,6 +456,16 @@ class PushNotificationService {
   @visibleForTesting
   String achievementRouteForTesting(Map<String, dynamic> data) {
     return _achievementUnlockedRoute(data);
+  }
+
+  @visibleForTesting
+  String masterHonorChangedRouteForTesting(Map<String, dynamic> data) {
+    return _masterHonorsNotificationRoute();
+  }
+
+  @visibleForTesting
+  bool usesGoNavigationForTesting(String route) {
+    return _shouldUseGoNavigation(route);
   }
 
   void _handleAchievementUnlockedForeground(RemoteMessage message) {
@@ -549,6 +566,122 @@ class PushNotificationService {
     );
   }
 
+  void _handleMasterHonorChangedForeground(RemoteMessage message) {
+    final data = message.data;
+    final transition = _parseMasterHonorTransition(data['transition']);
+    final honorNames = _parseMasterHonorNames(data['master_honor_names']);
+
+    _ref.read(unreadNotificationsCountProvider.notifier).increment();
+    _ref.invalidate(notificationsInboxProvider);
+    _ref.read(masterHonorsInvalidationProvider)();
+
+    if (transition == null || honorNames.isEmpty) {
+      AppLogger.w(
+        'No se pudo parsear notificación master_honor_changed',
+        tag: _tag,
+      );
+      return;
+    }
+
+    _ref.read(masterHonorModalQueueProvider.notifier).enqueue(
+          MasterHonorModalEvent(
+            transition: transition,
+            masterHonorIds: _parseMasterHonorIds(data['master_honor_ids']),
+            masterHonorNames: honorNames,
+          ),
+        );
+    _processMasterHonorModalQueue();
+  }
+
+  void _processMasterHonorModalQueue() {
+    final context = navigatorKey?.currentContext;
+    if (context == null) return;
+
+    final queueState = _ref.read(masterHonorModalQueueProvider);
+    if (queueState.isShowingModal) return;
+
+    final nextEvent =
+        _ref.read(masterHonorModalQueueProvider.notifier).peekNext();
+    if (nextEvent == null) return;
+
+    _ref.read(masterHonorModalQueueProvider.notifier).markModalStarted();
+
+    if (!context.mounted) {
+      _discardCurrentMasterHonorModalEvent();
+      return;
+    }
+
+    try {
+      showDialog<void>(
+        context: context,
+        barrierDismissible: true,
+        builder: (dialogContext) => MasterHonorChangeModal(
+          event: nextEvent,
+          onConfirm: () {
+            if (dialogContext.mounted) {
+              Navigator.of(dialogContext).pop();
+            }
+          },
+        ),
+      ).then((_) {
+        final notifier = _ref.read(masterHonorModalQueueProvider.notifier);
+        notifier.removeFirst();
+        notifier.markModalFinished();
+        _processMasterHonorModalQueue();
+      });
+    } catch (error) {
+      AppLogger.w(
+        'No fue posible mostrar el modal de maestrías en foreground',
+        tag: _tag,
+        error: error,
+      );
+      _discardCurrentMasterHonorModalEvent();
+    }
+  }
+
+  void _discardCurrentMasterHonorModalEvent() {
+    final notifier = _ref.read(masterHonorModalQueueProvider.notifier);
+    notifier.removeFirst();
+    notifier.markModalFinished();
+  }
+
+  MasterHonorChangeTransition? _parseMasterHonorTransition(
+      dynamic rawTransition) {
+    final transition = rawTransition?.toString().toLowerCase();
+    return switch (transition) {
+      'awarded' => MasterHonorChangeTransition.awarded,
+      'recovered' => MasterHonorChangeTransition.recovered,
+      'not_current' => MasterHonorChangeTransition.notCurrent,
+      _ => null,
+    };
+  }
+
+  List<String> _parseMasterHonorIds(dynamic rawIds) {
+    final ids = rawIds?.toString().trim();
+    if (ids == null || ids.isEmpty) return const [];
+
+    return ids
+        .split(',')
+        .map((value) => value.trim())
+        .where((value) => value.isNotEmpty)
+        .toList();
+  }
+
+  List<String> _parseMasterHonorNames(dynamic rawNames) {
+    final names = rawNames?.toString().trim();
+    if (names == null || names.isEmpty) return const [];
+
+    return names
+        .split('|')
+        .map((value) => value.trim())
+        .where((value) => value.isNotEmpty)
+        .toList();
+  }
+
+  String _masterHonorsNotificationRoute() {
+    return _ref.read(masterHonorsNotificationTapRouteProvider);
+  }
+
   String _achievementNameFromMessage(RemoteMessage message) {
     final fromData = message.data['achievement_name'] as String?;
     if (fromData != null && fromData.trim().isNotEmpty) {
@@ -587,6 +720,26 @@ class PushNotificationService {
   }
 
   // ── Notification route allowlist ─────────────────────────────────────────
+
+  /// Static shell branch routes that must switch tabs instead of stacking a page.
+  static const Set<String> _goNavigationRoutes = {
+    RouteNames.homeDashboard,
+    RouteNames.homeClasses,
+    RouteNames.homeActivities,
+    RouteNames.homeProfile,
+    RouteNames.homeMembers,
+    RouteNames.homeClub,
+    RouteNames.homeEvidences,
+    RouteNames.homeFinances,
+    RouteNames.homeUnits,
+    RouteNames.homeInsurance,
+    RouteNames.homeInventory,
+    RouteNames.homeResources,
+    RouteNames.homeHonors,
+    RouteNames.homeCertifications,
+    RouteNames.homeCamporees,
+    RouteNames.homeAchievements,
+  };
 
   /// Static routes (no path parameters) that a push notification payload is
   /// allowed to navigate to. Any route NOT in this set (or not matching one
@@ -633,6 +786,7 @@ class PushNotificationService {
     'member_of_month',
     'member_of_month_director',
     'achievement_unlocked',
+    'master_honor_changed',
   };
 
   /// RegExp patterns for routes that carry path parameters.
@@ -671,6 +825,10 @@ class PushNotificationService {
     return false;
   }
 
+  bool _shouldUseGoNavigation(String route) {
+    return _goNavigationRoutes.contains(route);
+  }
+
   void _pushRoute(String route) {
     final context = navigatorKey?.currentContext;
     if (context == null) {
@@ -687,6 +845,11 @@ class PushNotificationService {
         'No hay GoRouter disponible para navegar desde push notification',
         tag: _tag,
       );
+      return;
+    }
+
+    if (_shouldUseGoNavigation(route)) {
+      router.go(route);
       return;
     }
 
@@ -764,6 +927,9 @@ class PushNotificationService {
         // the specific achievement detail.
         // Payload: { type, achievement_id, achievement_name }
         _pushRoute(_achievementUnlockedRoute(data));
+        return;
+      case 'master_honor_changed':
+        _pushRoute(_masterHonorsNotificationRoute());
         return;
 
       default:

--- a/lib/features/master_honors/presentation/providers/master_honor_modal_queue_provider.dart
+++ b/lib/features/master_honors/presentation/providers/master_honor_modal_queue_provider.dart
@@ -1,0 +1,124 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// Transición de estado que llegó desde la notificación de maestrías.
+enum MasterHonorChangeTransition {
+  awarded,
+  recovered,
+  notCurrent,
+}
+
+@immutable
+class MasterHonorModalEvent {
+  final MasterHonorChangeTransition transition;
+  final List<String> masterHonorIds;
+  final List<String> masterHonorNames;
+
+  const MasterHonorModalEvent({
+    required this.transition,
+    required this.masterHonorIds,
+    required this.masterHonorNames,
+  });
+
+  bool get isPlural => masterHonorNames.length > 1;
+
+  String get title => switch (transition) {
+        MasterHonorChangeTransition.awarded when isPlural =>
+          '¡Nuevas maestrías obtenidas!',
+        MasterHonorChangeTransition.awarded => '¡Nueva maestría obtenida!',
+        MasterHonorChangeTransition.recovered when isPlural =>
+          'Maestrías vigentes nuevamente',
+        MasterHonorChangeTransition.recovered => 'Maestría vigente nuevamente',
+        MasterHonorChangeTransition.notCurrent when isPlural =>
+          'Maestrías marcadas como No vigente',
+        MasterHonorChangeTransition.notCurrent =>
+          'Maestría marcada como No vigente',
+      };
+
+  String get body => switch (transition) {
+        MasterHonorChangeTransition.awarded when isPlural => 'Has obtenido:',
+        MasterHonorChangeTransition.awarded =>
+          'Has obtenido la maestría ${masterHonorNames.first}.',
+        MasterHonorChangeTransition.recovered when isPlural =>
+          'Estas maestrías vuelven a estar vigentes en tu perfil:',
+        MasterHonorChangeTransition.recovered =>
+          'La maestría ${masterHonorNames.first} vuelve a estar vigente en tu perfil.',
+        MasterHonorChangeTransition.notCurrent when isPlural =>
+          'Las validaciones requeridas para estas maestrías cambiaron. Actualmente no cumples con los requisitos, por lo que quedaron marcadas como No vigente.',
+        MasterHonorChangeTransition.notCurrent =>
+          'Las validaciones requeridas para la maestría ${masterHonorNames.first} cambiaron. Actualmente no cumples con los requisitos, por lo que quedó marcada como No vigente.',
+      };
+}
+
+@immutable
+class MasterHonorModalQueueState {
+  final List<MasterHonorModalEvent> queue;
+  final bool isShowingModal;
+
+  const MasterHonorModalQueueState({
+    this.queue = const <MasterHonorModalEvent>[],
+    this.isShowingModal = false,
+  });
+
+  int get length => queue.length;
+  bool get isEmpty => queue.isEmpty;
+  MasterHonorModalEvent get single => queue.single;
+  MasterHonorModalEvent? get firstOrNull => queue.isEmpty ? null : queue.first;
+
+  MasterHonorModalQueueState copyWith({
+    List<MasterHonorModalEvent>? queue,
+    bool? isShowingModal,
+  }) {
+    return MasterHonorModalQueueState(
+      queue: queue ?? this.queue,
+      isShowingModal: isShowingModal ?? this.isShowingModal,
+    );
+  }
+}
+
+final masterHonorModalQueueProvider =
+    NotifierProvider<MasterHonorModalQueueNotifier, MasterHonorModalQueueState>(
+  MasterHonorModalQueueNotifier.new,
+);
+
+class MasterHonorModalQueueNotifier
+    extends Notifier<MasterHonorModalQueueState> {
+  @override
+  MasterHonorModalQueueState build() => const MasterHonorModalQueueState();
+
+  void enqueue(MasterHonorModalEvent event) {
+    final names = event.masterHonorNames
+        .map((name) => name.trim())
+        .where((name) => name.isNotEmpty)
+        .toList(growable: false);
+
+    if (names.isEmpty) return;
+
+    final normalized = MasterHonorModalEvent(
+      transition: event.transition,
+      masterHonorIds: event.masterHonorIds,
+      masterHonorNames: names,
+    );
+
+    state = state.copyWith(queue: [...state.queue, normalized]);
+  }
+
+  MasterHonorModalEvent? peekNext() => state.firstOrNull;
+
+  void removeFirst() {
+    if (state.queue.isEmpty) return;
+    state = state.copyWith(queue: state.queue.sublist(1));
+  }
+
+  void markModalStarted() {
+    state = state.copyWith(isShowingModal: true);
+  }
+
+  void markModalFinished() {
+    state = state.copyWith(isShowingModal: false);
+  }
+
+  void clear() {
+    state = const MasterHonorModalQueueState();
+  }
+}

--- a/lib/features/master_honors/presentation/providers/master_honors_providers.dart
+++ b/lib/features/master_honors/presentation/providers/master_honors_providers.dart
@@ -1,6 +1,7 @@
 import 'package:dio/dio.dart';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:sacdia_app/core/config/route_names.dart';
 
 import '../../../../providers/dio_provider.dart';
 import '../../../auth/presentation/providers/auth_providers.dart';
@@ -51,6 +52,14 @@ final userMasterHonorsProvider =
     (failure) => throw Exception(failure.message),
     (masterHonors) => masterHonors,
   );
+});
+
+/// Ruta recomendada para abrir desde el tap de notificaciones de maestrías.
+///
+/// Home Profile concentra estado y acciones de perfil, incluyendo la sección de
+/// maestrías y acceso a la tarjeta virtual, sin introducir una nueva pantalla.
+final masterHonorsNotificationTapRouteProvider = Provider<String>((_) {
+  return RouteNames.homeProfile;
 });
 
 /// Hook estable para que notificaciones `master_honor_changed` invaliden cache.

--- a/lib/features/master_honors/presentation/widgets/master_honor_badge.dart
+++ b/lib/features/master_honors/presentation/widgets/master_honor_badge.dart
@@ -1,0 +1,207 @@
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:flutter/material.dart';
+import 'package:hugeicons/hugeicons.dart';
+import 'package:sacdia_app/core/theme/app_colors.dart';
+import 'package:sacdia_app/features/master_honors/domain/entities/user_master_honor.dart';
+
+/// Badge visual de maestría para usar en la tarjeta virtual y en listas
+/// de perfil.
+class MasterHonorBadge extends StatelessWidget {
+  final UserMasterHonor honor;
+  final bool compact;
+  final bool showStatus;
+
+  const MasterHonorBadge({
+    super.key,
+    required this.honor,
+    this.compact = true,
+    this.showStatus = true,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final isCurrent = honor.isCurrent;
+    final status = _statusLabel(honor);
+    final initials = _initials(honor.name);
+
+    return Container(
+      width: compact ? 128 : 150,
+      padding: const EdgeInsets.all(8),
+      decoration: BoxDecoration(
+        color: _badgeColor(context, isCurrent).withValues(alpha: 0.12),
+        borderRadius: BorderRadius.circular(14),
+        border: Border.all(
+            color: _badgeColor(context, isCurrent).withValues(alpha: 0.5)),
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              _HonorImage(
+                imageUrl: honor.masterImage,
+                initials: initials,
+                size: compact ? 26 : 30,
+              ),
+              const SizedBox(width: 8),
+              Expanded(
+                child: Text(
+                  honor.name,
+                  maxLines: compact ? 2 : 3,
+                  overflow: TextOverflow.ellipsis,
+                  style: TextStyle(
+                    fontWeight: FontWeight.w600,
+                    fontSize: compact ? 12 : 13,
+                  ),
+                ),
+              ),
+            ],
+          ),
+          if (showStatus) ...[
+            const SizedBox(height: 6),
+            _MasterHonorStatusBadge(
+              label: status,
+              isCurrent: isCurrent,
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+
+  String _statusLabel(UserMasterHonor honor) {
+    if (honor.displayStatusLabel.trim().isNotEmpty) {
+      return honor.displayStatusLabel;
+    }
+    return honor.isCurrent ? 'Vigente' : 'No vigente';
+  }
+
+  String _initials(String name) {
+    final parts = name.trim().split(RegExp(r'\s+'));
+    if (parts.isEmpty || parts.first.isEmpty) return '?';
+    if (parts.length == 1) return parts.first[0].toUpperCase();
+    return '${parts.first[0]}${parts[1][0]}'.toUpperCase();
+  }
+
+  Color _badgeColor(BuildContext context, bool isCurrent) {
+    if (isCurrent) {
+      return AppColors.secondary;
+    }
+    return AppColors.error;
+  }
+}
+
+class _HonorImage extends StatelessWidget {
+  const _HonorImage({
+    required this.imageUrl,
+    required this.initials,
+    required this.size,
+  });
+
+  final String? imageUrl;
+  final String initials;
+  final double size;
+
+  @override
+  Widget build(BuildContext context) {
+    final image = imageUrl?.trim() ?? '';
+
+    final fallback = Container(
+      width: size,
+      height: size,
+      alignment: Alignment.center,
+      decoration: BoxDecoration(
+        color: Theme.of(context).brightness == Brightness.dark
+            ? AppColors.darkSurfaceVariant
+            : AppColors.lightSurfaceVariant,
+        shape: BoxShape.circle,
+      ),
+      child: Text(
+        initials,
+        style: TextStyle(
+          fontSize: size * 0.4,
+          fontWeight: FontWeight.w700,
+          color: Theme.of(context).brightness == Brightness.dark
+              ? AppColors.darkText
+              : AppColors.lightText,
+        ),
+      ),
+    );
+
+    if (image.isEmpty) {
+      return fallback;
+    }
+
+    return SizedBox(
+      width: size,
+      height: size,
+      child: ClipOval(
+        child: CachedNetworkImage(
+          imageUrl: image,
+          fit: BoxFit.cover,
+          errorWidget: (_, __, ___) => fallback,
+          placeholder: (_, __) => fallback,
+        ),
+      ),
+    );
+  }
+}
+
+class _MasterHonorStatusBadge extends StatelessWidget {
+  final String label;
+  final bool isCurrent;
+
+  const _MasterHonorStatusBadge({
+    required this.label,
+    required this.isCurrent,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final badgeColor =
+        isCurrent ? AppColors.secondaryLight : AppColors.errorLight;
+    final labelColor =
+        isCurrent ? AppColors.secondaryDark : AppColors.errorDark;
+
+    return Container(
+      decoration: BoxDecoration(
+        color: badgeColor,
+        borderRadius: BorderRadius.circular(20),
+      ),
+      padding: const EdgeInsets.symmetric(
+        vertical: 4,
+        horizontal: 8,
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          if (!isCurrent) ...[
+            HugeIcon(
+              icon: HugeIcons.strokeRoundedCancel01,
+              size: 13,
+              color: labelColor,
+            ),
+            const SizedBox(width: 4),
+          ],
+          ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 76),
+            child: Text(
+              label,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: TextStyle(
+                fontSize: 12,
+                fontWeight: FontWeight.w500,
+                color: labelColor,
+                height: 1.2,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/master_honors/presentation/widgets/master_honor_change_modal.dart
+++ b/lib/features/master_honors/presentation/widgets/master_honor_change_modal.dart
@@ -1,0 +1,112 @@
+import 'package:flutter/material.dart';
+import 'package:sacdia_app/core/theme/app_colors.dart';
+
+import '../providers/master_honor_modal_queue_provider.dart';
+
+/// Modal compacto para cambios de estado de maestrías recibidos por push.
+class MasterHonorChangeModal extends StatelessWidget {
+  const MasterHonorChangeModal({
+    super.key,
+    required this.event,
+    this.onConfirm,
+  });
+
+  final MasterHonorModalEvent event;
+  final VoidCallback? onConfirm;
+
+  @override
+  Widget build(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+
+    return Dialog(
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
+      insetPadding: const EdgeInsets.symmetric(horizontal: 24, vertical: 32),
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(20, 18, 20, 12),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Container(
+                  width: 44,
+                  height: 44,
+                  decoration: BoxDecoration(
+                    shape: BoxShape.circle,
+                    color: (isDark
+                            ? AppColors.darkSurfaceVariant
+                            : AppColors.primaryLight)
+                        .withValues(alpha: 0.9),
+                  ),
+                  alignment: Alignment.center,
+                  child: const Text('🏅', style: TextStyle(fontSize: 20)),
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: Text(
+                    event.title,
+                    style: const TextStyle(
+                      fontWeight: FontWeight.w800,
+                      fontSize: 19,
+                      height: 1.15,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 12),
+            Text(
+              event.body,
+              style: const TextStyle(fontSize: 15, height: 1.35),
+            ),
+            if (event.isPlural) ...[
+              const SizedBox(height: 10),
+              ...event.masterHonorNames.map(
+                (name) => Padding(
+                  padding: const EdgeInsets.only(bottom: 5),
+                  child: _SummaryLine(name: name),
+                ),
+              ),
+            ],
+            const SizedBox(height: 16),
+            Align(
+              alignment: Alignment.centerRight,
+              child: TextButton(
+                onPressed: onConfirm,
+                child: const Text('Entendido'),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _SummaryLine extends StatelessWidget {
+  const _SummaryLine({required this.name});
+
+  final String name;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Padding(
+          padding: EdgeInsets.only(top: 7),
+          child: Icon(Icons.circle, size: 6),
+        ),
+        const SizedBox(width: 8),
+        Expanded(
+          child: Text(
+            name,
+            style: const TextStyle(fontSize: 14, height: 1.3),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/master_honors/presentation/widgets/master_honor_history_section.dart
+++ b/lib/features/master_honors/presentation/widgets/master_honor_history_section.dart
@@ -1,0 +1,377 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:sacdia_app/core/theme/app_colors.dart';
+import 'package:sacdia_app/core/utils/date_formatter.dart';
+import 'package:sacdia_app/features/master_honors/domain/entities/user_master_honor.dart';
+import 'package:sacdia_app/features/master_honors/presentation/providers/master_honors_providers.dart';
+
+import 'master_honor_badge.dart';
+
+/// Strip horizontal de maestrías para la Tarjeta Virtual.
+class MasterHonorBadgeStrip extends ConsumerWidget {
+  final int? maxItems;
+
+  const MasterHonorBadgeStrip({
+    super.key,
+    this.maxItems,
+  });
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final honorsAsync = ref.watch(userMasterHonorsProvider);
+
+    return honorsAsync.when(
+      loading: () => const _MasterHonorStripSkeleton(),
+      error: (_, __) => const SizedBox.shrink(),
+      data: (honors) {
+        if (honors.isEmpty) return const SizedBox.shrink();
+
+        final visible = _orderedMasterHonors(honors);
+        final limit = maxItems;
+        final limited = limit == null || visible.length <= limit
+            ? visible
+            : visible.sublist(0, limit);
+
+        return _MasterHonorStripContent(honors: limited);
+      },
+    );
+  }
+}
+
+/// Historial de maestrías con estado y fechas en perfil.
+class MasterHonorHistorySection extends ConsumerWidget {
+  final bool showHeader;
+
+  const MasterHonorHistorySection({
+    super.key,
+    this.showHeader = true,
+  });
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final honorsAsync = ref.watch(userMasterHonorsProvider);
+
+    return honorsAsync.when(
+      loading: () => const _MasterHonorHistorySkeleton(),
+      error: (error, _) => Padding(
+        padding: const EdgeInsets.symmetric(vertical: 16, horizontal: 16),
+        child: Text(
+          'No fue posible cargar el historial de maestrías.',
+          style: const TextStyle(color: Colors.red, fontSize: 13),
+        ),
+      ),
+      data: (honors) {
+        if (honors.isEmpty) {
+          return const SizedBox.shrink();
+        }
+
+        final ordered = _orderedMasterHonors(honors);
+        return Padding(
+          key: const ValueKey('master-honor-history-data'),
+          padding: const EdgeInsets.fromLTRB(16, 8, 16, 8),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              if (showHeader) ...[
+                Text(
+                  'Maestrías',
+                  style: TextStyle(
+                    fontSize: 16,
+                    fontWeight: FontWeight.w700,
+                    color: _isDark(context)
+                        ? AppColors.darkText
+                        : AppColors.lightText,
+                  ),
+                ),
+                const SizedBox(height: 8),
+              ],
+              ...ordered.map(
+                (honor) => _HistoryItem(honor: honor),
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _MasterHonorStripContent extends StatelessWidget {
+  const _MasterHonorStripContent({required this.honors});
+
+  final List<UserMasterHonor> honors;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(top: 8),
+      child: SizedBox(
+        width: double.infinity,
+        child: SingleChildScrollView(
+          scrollDirection: Axis.horizontal,
+          child: Row(
+            children: honors
+                .map(
+                  (honor) => Padding(
+                    padding: const EdgeInsets.only(right: 8),
+                    child: MasterHonorBadge(
+                      honor: honor,
+                      compact: true,
+                    ),
+                  ),
+                )
+                .toList(),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _HistoryItem extends StatelessWidget {
+  const _HistoryItem({required this.honor});
+
+  final UserMasterHonor honor;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 10),
+      child: Card(
+        elevation: 0,
+        color:
+            _isDark(context) ? AppColors.darkSurface : AppColors.lightSurface,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(12),
+          side: BorderSide(
+            color:
+                _isDark(context) ? AppColors.darkBorder : AppColors.lightBorder,
+          ),
+        ),
+        child: Padding(
+          padding: const EdgeInsets.all(10),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  MasterHonorBadge(
+                    honor: honor,
+                    compact: true,
+                    showStatus: false,
+                  ),
+                  const SizedBox(width: 10),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          honor.name,
+                          style: const TextStyle(
+                            fontWeight: FontWeight.w600,
+                            fontSize: 15,
+                          ),
+                          maxLines: 2,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                        const SizedBox(height: 6),
+                        _StatusLine(honor: honor),
+                        const SizedBox(height: 2),
+                        if (_buildDateLines(honor).isNotEmpty)
+                          ..._buildDateLines(honor).map(
+                            (line) => Text(
+                              line,
+                              style: TextStyle(
+                                fontSize: 12,
+                                color: _isDark(context)
+                                    ? AppColors.darkTextSecondary
+                                    : AppColors.lightTextSecondary,
+                                height: 1.25,
+                              ),
+                            ),
+                          ),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  List<String> _buildDateLines(UserMasterHonor honor) {
+    final lines = <String>[];
+
+    if (honor.awardedAt != null) {
+      lines.add('Concedida: ${SacDateFormatter.date(honor.awardedAt)}');
+    }
+    if (honor.revokedAt != null) {
+      lines.add('Revocada: ${SacDateFormatter.date(honor.revokedAt)}');
+    }
+    if (honor.recoveredAt != null) {
+      lines.add('Recuperada: ${SacDateFormatter.date(honor.recoveredAt)}');
+    }
+
+    return lines;
+  }
+}
+
+class _StatusLine extends StatelessWidget {
+  const _StatusLine({required this.honor});
+
+  final UserMasterHonor honor;
+
+  @override
+  Widget build(BuildContext context) {
+    final isCurrent = honor.isCurrent;
+    final status = honor.displayStatusLabel.trim().isNotEmpty
+        ? honor.displayStatusLabel
+        : (isCurrent ? 'Vigente' : 'No vigente');
+    final statusColor = isCurrent ? AppColors.secondary : AppColors.error;
+
+    return Row(
+      children: [
+        Container(
+          height: 8,
+          width: 8,
+          decoration: BoxDecoration(
+            color: statusColor,
+            shape: BoxShape.circle,
+          ),
+        ),
+        const SizedBox(width: 6),
+        Text(
+          status,
+          style: const TextStyle(fontSize: 12, fontWeight: FontWeight.w600),
+        ),
+        if (honor.statusReason != null &&
+            honor.statusReason!.trim().isNotEmpty) ...[
+          const SizedBox(width: 8),
+          Flexible(
+            child: Text(
+              honor.statusReason!,
+              style: TextStyle(
+                fontSize: 11,
+                color: _isDark(context)
+                    ? AppColors.darkTextSecondary
+                    : AppColors.lightTextSecondary,
+              ),
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
+        ],
+      ],
+    );
+  }
+}
+
+class _MasterHonorStripSkeleton extends StatelessWidget {
+  const _MasterHonorStripSkeleton();
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(top: 8),
+      child: Wrap(
+        spacing: 8,
+        runSpacing: 8,
+        children: List.generate(
+          3,
+          (index) => Container(
+            width: 120,
+            height: 54,
+            decoration: BoxDecoration(
+              color: _isDark(context)
+                  ? AppColors.darkSurfaceVariant
+                  : AppColors.lightSurfaceVariant,
+              borderRadius: BorderRadius.circular(14),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _MasterHonorHistorySkeleton extends StatelessWidget {
+  const _MasterHonorHistorySkeleton();
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Container(
+            width: 110,
+            height: 18,
+            decoration: BoxDecoration(
+              borderRadius: BorderRadius.circular(12),
+              color: _isDark(context)
+                  ? AppColors.darkSurfaceVariant
+                  : AppColors.lightSurfaceVariant,
+            ),
+          ),
+          const SizedBox(height: 10),
+          ...List.generate(
+            2,
+            (index) => Padding(
+              padding: const EdgeInsets.only(bottom: 10),
+              child: Container(
+                height: 84,
+                decoration: BoxDecoration(
+                  color: _isDark(context)
+                      ? AppColors.darkSurfaceVariant
+                      : AppColors.lightSurfaceVariant,
+                  borderRadius: BorderRadius.circular(12),
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+List<UserMasterHonor> _orderedMasterHonors(List<UserMasterHonor> honors) {
+  final ordered = List<UserMasterHonor>.from(honors)
+    ..sort((a, b) {
+      if (a.isCurrent != b.isCurrent) {
+        return a.isCurrent ? -1 : 1;
+      }
+
+      final aDate = _latestDate(a);
+      final bDate = _latestDate(b);
+
+      if (aDate == null && bDate == null) {
+        return a.name.compareTo(b.name);
+      }
+      if (aDate == null) return 1;
+      if (bDate == null) return -1;
+
+      return bDate.compareTo(aDate);
+    });
+
+  return ordered;
+}
+
+DateTime? _latestDate(UserMasterHonor honor) {
+  final dates = [
+    honor.awardedAt,
+    honor.revokedAt,
+    honor.recoveredAt,
+  ].whereType<DateTime>().toList();
+  if (dates.isEmpty) return null;
+  return dates.reduce((a, b) => a.isAfter(b) ? a : b);
+}
+
+bool _isDark(BuildContext context) {
+  return Theme.of(context).brightness == Brightness.dark;
+}

--- a/lib/features/profile/presentation/widgets/profile_honors_section.dart
+++ b/lib/features/profile/presentation/widgets/profile_honors_section.dart
@@ -11,6 +11,7 @@ import 'package:sacdia_app/core/config/route_names.dart';
 import 'package:sacdia_app/core/widgets/sac_button.dart';
 import 'package:sacdia_app/features/honors/domain/entities/user_honor.dart';
 import 'package:sacdia_app/features/honors/presentation/providers/honors_providers.dart';
+import 'package:sacdia_app/features/master_honors/presentation/widgets/master_honor_history_section.dart';
 
 const Map<String, List<List<dynamic>>> _categoryIcons = {
   'ADRA': HugeIcons.strokeRoundedCharity,
@@ -56,35 +57,42 @@ class ProfileHonorsSection extends ConsumerWidget {
         ),
         data: (userHonors) {
           if (userHonors.isEmpty) {
-            return Padding(
+            return Column(
               key: const ValueKey('honors-data'),
-              padding: const EdgeInsets.symmetric(vertical: 32, horizontal: 20),
-              child: Column(
-                children: [
-                  HugeIcon(
-                    icon: HugeIcons.strokeRoundedAward01,
-                    size: 48,
-                    color: context.sac.textTertiary,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Padding(
+                  padding:
+                      const EdgeInsets.symmetric(vertical: 32, horizontal: 20),
+                  child: Column(
+                    children: [
+                      HugeIcon(
+                        icon: HugeIcons.strokeRoundedAward01,
+                        size: 48,
+                        color: context.sac.textTertiary,
+                      ),
+                      const SizedBox(height: 12),
+                      Text(
+                        'profile.honors_section.no_honors'.tr(),
+                        style: TextStyle(
+                          fontSize: 15,
+                          color: context.sac.textSecondary,
+                        ),
+                        textAlign: TextAlign.center,
+                      ),
+                      const SizedBox(height: 20),
+                      SacButton.outline(
+                        text: 'profile.honors_section.add_honor'.tr(),
+                        icon: HugeIcons.strokeRoundedAdd01,
+                        onPressed: () {
+                          context.push(RouteNames.homeHonors);
+                        },
+                      ),
+                    ],
                   ),
-                  const SizedBox(height: 12),
-                  Text(
-                    'profile.honors_section.no_honors'.tr(),
-                    style: TextStyle(
-                      fontSize: 15,
-                      color: context.sac.textSecondary,
-                    ),
-                    textAlign: TextAlign.center,
-                  ),
-                  const SizedBox(height: 20),
-                  SacButton.outline(
-                    text: 'profile.honors_section.add_honor'.tr(),
-                    icon: HugeIcons.strokeRoundedAdd01,
-                    onPressed: () {
-                      context.push(RouteNames.homeHonors);
-                    },
-                  ),
-                ],
-              ),
+                ),
+                const MasterHonorHistorySection(),
+              ],
             );
           }
 
@@ -122,6 +130,7 @@ class ProfileHonorsSection extends ConsumerWidget {
                   },
                 ),
               ),
+              const MasterHonorHistorySection(),
             ],
           );
         },

--- a/lib/features/virtual_card/presentation/views/virtual_card_view.dart
+++ b/lib/features/virtual_card/presentation/views/virtual_card_view.dart
@@ -16,6 +16,7 @@ import '../widgets/credencial/credencial_tokens.dart';
 import '../widgets/credencial/credencial_view_model.dart';
 import '../widgets/virtual_card_skeleton.dart';
 import 'virtual_card_photo_view.dart';
+import '../../../master_honors/presentation/widgets/master_honor_history_section.dart';
 
 class VirtualCardView extends ConsumerStatefulWidget {
   const VirtualCardView({super.key});
@@ -207,6 +208,7 @@ class _VirtualCardViewState extends ConsumerState<VirtualCardView> {
                               ),
                             ],
                           ),
+                          const MasterHonorBadgeStrip(),
                           if (card.photoUrl?.trim().isNotEmpty == true) ...[
                             const SizedBox(height: 8),
                             Center(

--- a/test/core/notifications/push_notification_service_master_honor_test.dart
+++ b/test/core/notifications/push_notification_service_master_honor_test.dart
@@ -1,0 +1,153 @@
+import 'package:dartz/dartz.dart';
+import 'package:dio/dio.dart';
+import 'package:firebase_messaging/firebase_messaging.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sacdia_app/core/config/route_names.dart';
+import 'package:sacdia_app/core/errors/failures.dart';
+import 'package:sacdia_app/core/notifications/push_notification_service.dart';
+import 'package:sacdia_app/features/master_honors/presentation/providers/master_honor_modal_queue_provider.dart';
+import 'package:sacdia_app/features/master_honors/presentation/providers/master_honors_providers.dart';
+import 'package:sacdia_app/features/notifications/domain/entities/notification_item.dart';
+import 'package:sacdia_app/features/notifications/domain/repositories/notifications_repository.dart';
+import 'package:sacdia_app/features/notifications/presentation/providers/notifications_providers.dart';
+import 'package:sacdia_app/features/notifications/presentation/providers/unread_notifications_count_provider.dart';
+
+class _FakeNotificationsRepository implements NotificationsRepository {
+  @override
+  Future<
+          Either<Failure,
+              ({List<NotificationItem> items, int total, int totalPages})>>
+      getHistory({
+    int page = 1,
+    int limit = 20,
+    CancelToken? cancelToken,
+  }) async {
+    return right((items: <NotificationItem>[], total: 0, totalPages: 1));
+  }
+
+  @override
+  Future<Either<Failure, int>> getUnreadCount() async => right(0);
+
+  @override
+  Future<Either<Failure, void>> markAsRead(String deliveryId) async =>
+      right(null);
+
+  @override
+  Future<Either<Failure, int>> markAllAsRead() async => right(0);
+}
+
+void main() {
+  Widget buildHarness({
+    required GlobalKey<NavigatorState> navigatorKey,
+    required ProviderContainer container,
+    required void Function(PushNotificationService service) onService,
+  }) {
+    final pushNotificationServiceProvider =
+        Provider<PushNotificationService>((ref) {
+      return PushNotificationService(
+        dio: Dio(),
+        ref: ref,
+        navigatorKey: navigatorKey,
+      );
+    });
+
+    return UncontrolledProviderScope(
+      container: container,
+      child: MaterialApp(
+        navigatorKey: navigatorKey,
+        home: Scaffold(
+          body: Consumer(
+            builder: (context, ref, _) {
+              onService(ref.read(pushNotificationServiceProvider));
+              return const Text('Home');
+            },
+          ),
+        ),
+      ),
+    );
+  }
+
+  group('PushNotificationService master honor changes', () {
+    late ProviderContainer container;
+    late GlobalKey<NavigatorState> navigatorKey;
+    late PushNotificationService service;
+    late _FakeNotificationsRepository repository;
+    late int masterHonorInvalidations;
+
+    setUp(() {
+      repository = _FakeNotificationsRepository();
+      navigatorKey = GlobalKey<NavigatorState>();
+      masterHonorInvalidations = 0;
+      container = ProviderContainer(
+        overrides: [
+          notificationsRepositoryProvider.overrideWithValue(repository),
+          masterHonorsInvalidationProvider.overrideWithValue(
+            () => masterHonorInvalidations++,
+          ),
+        ],
+      );
+    });
+
+    tearDown(() {
+      container.dispose();
+    });
+
+    testWidgets(
+      'foreground payload updates notification state and queues one grouped modal event',
+      (tester) async {
+        await tester.pumpWidget(
+          buildHarness(
+            navigatorKey: navigatorKey,
+            container: container,
+            onService: (created) => service = created,
+          ),
+        );
+
+        service.handleForegroundMessageForTesting(
+          RemoteMessage(
+            data: const {
+              'type': 'master_honor_changed',
+              'transition': 'not_current',
+              'master_honor_ids': '1,2',
+              'master_honor_names':
+                  'Maestría en Acuática|Maestría en Artesanía',
+            },
+          ),
+        );
+        await tester.pump();
+
+        expect(container.read(unreadNotificationsCountProvider), 1);
+        expect(masterHonorInvalidations, 1);
+
+        final queue = container.read(masterHonorModalQueueProvider);
+        expect(queue, hasLength(1));
+        expect(queue.single.transition, MasterHonorChangeTransition.notCurrent);
+        expect(
+          queue.single.masterHonorNames,
+          ['Maestría en Acuática', 'Maestría en Artesanía'],
+        );
+        expect(find.text('Maestrías marcadas como No vigente'), findsOneWidget);
+
+        await tester.tap(find.text('Entendido'));
+        await tester.pumpAndSettle();
+        expect(container.read(masterHonorModalQueueProvider), isEmpty);
+      },
+    );
+
+    test('master honor notification tap routes to profile', () {
+      final testRefProvider = Provider((ref) => ref);
+      final service = PushNotificationService(
+        dio: Dio(),
+        ref: container.read(testRefProvider),
+        navigatorKey: navigatorKey,
+      );
+
+      final route = service.masterHonorChangedRouteForTesting({});
+
+      expect(route, RouteNames.homeProfile);
+      expect(service.usesGoNavigationForTesting(route), isTrue);
+    });
+  });
+}

--- a/test/features/master_honors/master_honor_badge_test.dart
+++ b/test/features/master_honors/master_honor_badge_test.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sacdia_app/features/master_honors/domain/entities/user_master_honor.dart';
+import 'package:sacdia_app/features/master_honors/presentation/widgets/master_honor_badge.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  Widget wrap(Widget child) {
+    return MaterialApp(
+      home: Scaffold(
+        body: Center(
+          child: SizedBox(
+            width: 360,
+            child: child,
+          ),
+        ),
+      ),
+    );
+  }
+
+  testWidgets('current master honor renders normal badge', (tester) async {
+    await tester.pumpWidget(
+      wrap(
+        MasterHonorBadge(
+          honor: UserMasterHonor(
+            userMasterHonorId: 1,
+            masterHonorId: 1,
+            name: 'Maestría de Servicio',
+            status: 'AWARDED',
+            isCurrent: true,
+            displayStatusLabel: 'Vigente',
+            awardedAt: DateTime(2026, 6, 3),
+          ),
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    expect(find.text('Maestría de Servicio'), findsOneWidget);
+    expect(find.text('Vigente'), findsOneWidget);
+    expect(find.text('No vigente'), findsNothing);
+  });
+
+  testWidgets('revoked or retired master honor shows no vigente status',
+      (tester) async {
+    await tester.pumpWidget(
+      wrap(
+        MasterHonorBadge(
+          honor: UserMasterHonor(
+            userMasterHonorId: 2,
+            masterHonorId: 2,
+            name: 'Maestría de Liderazgo',
+            status: 'REVOKED',
+            isCurrent: false,
+            displayStatusLabel: 'No vigente',
+            awardedAt: DateTime(2026, 2, 12),
+            revokedAt: DateTime(2026, 6, 1),
+            statusReason: 'No cumple con requisitos vigentes',
+          ),
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    expect(find.text('Maestría de Liderazgo'), findsOneWidget);
+    expect(find.text('No vigente'), findsOneWidget);
+  });
+}

--- a/test/features/master_honors/master_honor_change_modal_test.dart
+++ b/test/features/master_honors/master_honor_change_modal_test.dart
@@ -1,0 +1,91 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sacdia_app/features/master_honors/presentation/providers/master_honor_modal_queue_provider.dart';
+import 'package:sacdia_app/features/master_honors/presentation/widgets/master_honor_change_modal.dart';
+
+void main() {
+  Widget wrap(Widget child) {
+    return MaterialApp(
+      home: Scaffold(body: child),
+    );
+  }
+
+  testWidgets('renders awarded singular copy', (tester) async {
+    await tester.pumpWidget(
+      wrap(
+        MasterHonorChangeModal(
+          event: MasterHonorModalEvent(
+            transition: MasterHonorChangeTransition.awarded,
+            masterHonorIds: const ['1'],
+            masterHonorNames: const ['Maestría en Acuática'],
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('¡Nueva maestría obtenida!'), findsOneWidget);
+    expect(
+      find.text('Has obtenido la maestría Maestría en Acuática.'),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('renders not current plural copy with grouped names',
+      (tester) async {
+    await tester.pumpWidget(
+      wrap(
+        MasterHonorChangeModal(
+          event: MasterHonorModalEvent(
+            transition: MasterHonorChangeTransition.notCurrent,
+            masterHonorIds: const ['1', '2'],
+            masterHonorNames: const [
+              'Maestría en Acuática',
+              'Maestría en Artesanía',
+            ],
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('Maestrías marcadas como No vigente'), findsOneWidget);
+    expect(
+      find.text(
+        'Las validaciones requeridas para estas maestrías cambiaron. Actualmente no cumples con los requisitos, por lo que quedaron marcadas como No vigente.',
+      ),
+      findsOneWidget,
+    );
+    expect(find.text('Maestría en Acuática'), findsOneWidget);
+    expect(find.text('Maestría en Artesanía'), findsOneWidget);
+  });
+
+  test('master honor modal queue removes current event before continuing', () {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    final notifier = container.read(masterHonorModalQueueProvider.notifier);
+
+    notifier.enqueue(
+      const MasterHonorModalEvent(
+        transition: MasterHonorChangeTransition.notCurrent,
+        masterHonorIds: ['1'],
+        masterHonorNames: ['Maestría en Acuática'],
+      ),
+    );
+    notifier.enqueue(
+      const MasterHonorModalEvent(
+        transition: MasterHonorChangeTransition.recovered,
+        masterHonorIds: ['2'],
+        masterHonorNames: ['Maestría en Artesanía'],
+      ),
+    );
+
+    notifier.markModalStarted();
+    notifier.removeFirst();
+    notifier.markModalFinished();
+
+    final state = container.read(masterHonorModalQueueProvider);
+    expect(state.isShowingModal, isFalse);
+    expect(state.length, 1);
+    expect(state.single.transition, MasterHonorChangeTransition.recovered);
+  });
+}

--- a/test/features/virtual_card/virtual_card_master_honors_test.dart
+++ b/test/features/virtual_card/virtual_card_master_honors_test.dart
@@ -1,0 +1,165 @@
+import 'package:easy_localization/easy_localization.dart';
+import 'package:intl/date_symbol_data_local.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sacdia_app/features/auth/domain/entities/user_entity.dart';
+import 'package:sacdia_app/features/auth/presentation/providers/auth_providers.dart';
+import 'package:sacdia_app/features/master_honors/domain/entities/user_master_honor.dart';
+import 'package:sacdia_app/features/master_honors/presentation/providers/master_honors_providers.dart';
+import 'package:sacdia_app/features/master_honors/presentation/widgets/master_honor_history_section.dart';
+import 'package:sacdia_app/features/virtual_card/domain/entities/virtual_card.dart';
+import 'package:sacdia_app/features/virtual_card/presentation/providers/virtual_card_providers.dart';
+import 'package:sacdia_app/features/virtual_card/presentation/views/virtual_card_view.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _FakeAuthNotifier extends AuthNotifier {
+  _FakeAuthNotifier(this._user);
+
+  final UserEntity _user;
+
+  @override
+  Future<UserEntity?> build() async => _user;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() async {
+    SharedPreferences.setMockInitialValues({});
+    await initializeDateFormatting('es');
+    await EasyLocalization.ensureInitialized();
+  });
+
+  UserEntity buildUser() {
+    return const UserEntity(
+      id: 'user-123',
+      email: 'test@example.com',
+      name: 'Ana Test',
+    );
+  }
+
+  VirtualCard buildCard() {
+    return VirtualCard(
+      userId: 'user-123',
+      fullName: 'Ana Test',
+      qrToken: 'qr-token',
+      qrExpiresAt: DateTime(2026, 10, 1),
+      isActive: true,
+      isOffline: false,
+    );
+  }
+
+  List<UserMasterHonor> buildHonors() {
+    return [
+      UserMasterHonor(
+        userMasterHonorId: 1,
+        masterHonorId: 1,
+        name: 'Maestría de Servicio',
+        status: 'AWARDED',
+        isCurrent: true,
+        displayStatusLabel: 'Vigente',
+        awardedAt: DateTime(2026, 1, 2),
+      ),
+      UserMasterHonor(
+        userMasterHonorId: 2,
+        masterHonorId: 2,
+        name: 'Maestría de Liderazgo',
+        status: 'REVOKED',
+        isCurrent: false,
+        displayStatusLabel: 'No vigente',
+        awardedAt: DateTime(2025, 5, 10),
+        revokedAt: DateTime(2026, 2, 11),
+        statusReason: 'No cumple requisitos vigentes.',
+      ),
+    ];
+  }
+
+  List<UserMasterHonor> buildVirtualCardHonors() {
+    return [
+      ...List.generate(
+        7,
+        (index) => UserMasterHonor(
+          userMasterHonorId: index + 1,
+          masterHonorId: index + 1,
+          name: 'Maestría Vigente ${index + 1}',
+          status: 'AWARDED',
+          isCurrent: true,
+          displayStatusLabel: 'Vigente',
+          awardedAt: DateTime(2026, 1, index + 1),
+        ),
+      ),
+      buildHonors().last,
+    ];
+  }
+
+  Future<void> pumpVirtualCard(WidgetTester tester) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          authNotifierProvider
+              .overrideWith(() => _FakeAuthNotifier(buildUser())),
+          virtualCardFetcherProvider.overrideWith((ref) async => buildCard()),
+          userMasterHonorsProvider.overrideWith(
+            (ref) async => buildVirtualCardHonors(),
+          ),
+        ],
+        child: EasyLocalization(
+          supportedLocales: const [Locale('es')],
+          path: 'assets/translations',
+          fallbackLocale: const Locale('es'),
+          child: const MaterialApp(
+            home: VirtualCardView(),
+          ),
+        ),
+      ),
+    );
+
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 500));
+  }
+
+  Future<void> pumpHistorySection(WidgetTester tester) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          userMasterHonorsProvider.overrideWith((ref) async => buildHonors()),
+        ],
+        child: MaterialApp(
+          home: const Scaffold(
+            body: MasterHonorHistorySection(),
+          ),
+        ),
+      ),
+    );
+
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 500));
+  }
+
+  group('Virtual card master honors band', () {
+    testWidgets(
+      'shows current and non-current master honors in the virtual card band',
+      (tester) async {
+        await pumpVirtualCard(tester);
+
+        expect(find.text('Maestría Vigente 1'), findsOneWidget);
+        expect(find.text('Maestría de Liderazgo'), findsOneWidget);
+        expect(find.text('No vigente'), findsOneWidget);
+      },
+    );
+  });
+
+  group('Profile history section', () {
+    testWidgets('lists status and date lines for master honors',
+        (tester) async {
+      await pumpHistorySection(tester);
+
+      expect(find.text('Maestrías'), findsOneWidget);
+      expect(find.textContaining('Concedida:'), findsNWidgets(2));
+      expect(find.textContaining('Revocada:'), findsOneWidget);
+      expect(find.textContaining('No vigente'), findsOneWidget);
+      expect(find.textContaining('Vigente'), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
Closes #109
Closes abn-r/sacdia-app#109

## PR Type
- [ ] Bug fix
- [x] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary
- Shows current and non-current master honors in the virtual card band and profile history.
- Handles `master_honor_changed` foreground notifications by refreshing data and showing a grouped modal.
- Uses neutral Spanish copy for awarded, recovered, and no-current master honor states.

## Changes
| File | Change |
|------|--------|
| `lib/features/virtual_card/presentation/views/virtual_card_view.dart` | Adds master honors band to the virtual card. |
| `lib/features/profile/presentation/widgets/profile_honors_section.dart` | Adds the master honors history section. |
| `lib/features/master_honors/presentation/widgets/master_honor_badge.dart` | Adds reusable current/no-current badge UI. |
| `lib/features/master_honors/presentation/widgets/master_honor_history_section.dart` | Adds profile history UI with status/date lines. |
| `lib/core/notifications/push_notification_service.dart` | Handles master honor notification routing, invalidation, and modal dispatch. |
| `lib/features/master_honors/presentation/providers/master_honor_modal_queue_provider.dart` | Adds modal queue state to avoid stacked dialogs. |
| `lib/features/master_honors/presentation/widgets/master_honor_change_modal.dart` | Adds the elegant grouped status modal. |
| `test/**` | Adds widget/unit coverage for badge, virtual card, modal, and notification handling. |

## Test Plan
- [x] `flutter test test/features/master_honors/master_honor_badge_test.dart test/features/virtual_card/virtual_card_master_honors_test.dart test/core/notifications/push_notification_service_master_honor_test.dart test/features/master_honors/master_honor_change_modal_test.dart`
- [x] `flutter analyze lib/core/notifications lib/features/master_honors lib/features/virtual_card lib/features/profile test/core/notifications test/features/master_honors test/features/virtual_card`
- [x] `dart format --set-exit-if-changed --output=none lib/core/notifications/push_notification_service.dart lib/features/master_honors/presentation/providers/master_honor_modal_queue_provider.dart lib/features/master_honors/presentation/providers/master_honors_providers.dart lib/features/master_honors/presentation/widgets/master_honor_badge.dart lib/features/master_honors/presentation/widgets/master_honor_change_modal.dart lib/features/master_honors/presentation/widgets/master_honor_history_section.dart lib/features/profile/presentation/widgets/profile_honors_section.dart lib/features/virtual_card/presentation/views/virtual_card_view.dart test/core/notifications/push_notification_service_master_honor_test.dart test/features/master_honors/master_honor_badge_test.dart test/features/master_honors/master_honor_change_modal_test.dart test/features/virtual_card/virtual_card_master_honors_test.dart`
- [x] `git diff --check origin/development`

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Shellcheck not applicable: no shell scripts modified
- [x] Docs update tracked as follow-up Task 12
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers
