### PR TITLE
feat(coordination): consume scoped coordinator surface

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -1340,6 +1340,7 @@
       "reject_evidence": "Error rejecting evidence",
       "bulk_approve_evidence": "Error in bulk approval",
       "bulk_reject_evidence": "Error in bulk rejection",
+      "fetch_scope": "Error fetching coordination scope",
       "fetch_local_camporees": "Error fetching camporees",
       "fetch_union_camporees": "Error fetching union camporees",
       "fetch_local_pending": "Error fetching pending approvals",
@@ -1362,6 +1363,8 @@
       "investitures_subtitle": "Validate investiture requests",
       "evidence_title": "Evidence Review",
       "evidence_subtitle": "Approve or reject folders, classes and honors",
+      "clubs_title": "Clubs and sections",
+      "clubs_subtitle": "View clubs and sections under your coordination",
       "camporees_title": "Camporee Approvals",
       "camporees_subtitle": "Clubs, members and pending payments",
       "dashboard_title": "Operational Dashboard",
@@ -1370,8 +1373,13 @@
     "summary": {
       "investitures": "Investitures",
       "evidence": "Evidence",
+      "sections": "Sections",
       "camporees": "Camporees",
       "overdue": "Overdue"
+    },
+    "scope": {
+      "assigned": "You have {count} sections assigned for coordination.",
+      "empty": "You do not have sections assigned as coordinator. If you are also a director, your director features still appear in the app."
     },
     "camporee_approvals": {
       "title": "Camporee Approvals",
@@ -1514,12 +1522,13 @@
       "honor": "Honor"
     },
     "clubs": {
-      "title": "Clubs",
+      "title": "Assigned clubs",
       "search_hint": "Search club...",
-      "empty_title": "No clubs",
-      "empty_subtitle": "There are no clubs assigned to your local field.",
+      "empty_title": "No assigned clubs",
+      "empty_subtitle": "There are no clubs or sections inside your coordination scope.",
       "error_load": "Error loading clubs",
-      "field_id_label": "Local field #{id}"
+      "field_id_label": "Local field #{id}",
+      "sections_label": "{count} sections"
     }
   },
   "classes": {

--- a/assets/translations/es.json
+++ b/assets/translations/es.json
@@ -1340,6 +1340,7 @@
       "reject_evidence": "Error al rechazar evidencia",
       "bulk_approve_evidence": "Error en aprobación masiva",
       "bulk_reject_evidence": "Error en rechazo masivo",
+      "fetch_scope": "Error al obtener alcance de coordinación",
       "fetch_local_camporees": "Error al obtener camporees",
       "fetch_union_camporees": "Error al obtener camporees de unión",
       "fetch_local_pending": "Error al obtener aprobaciones pendientes",
@@ -1362,6 +1363,8 @@
       "investitures_subtitle": "Validar solicitudes de investidura",
       "evidence_title": "Revisión de Evidencias",
       "evidence_subtitle": "Aprobar o rechazar carpetas, clases y honores",
+      "clubs_title": "Clubes y secciones",
+      "clubs_subtitle": "Ver clubes y secciones bajo tu coordinación",
       "camporees_title": "Aprobaciones de Camporees",
       "camporees_subtitle": "Clubs, miembros y pagos pendientes",
       "dashboard_title": "Dashboard Operativo",
@@ -1370,8 +1373,13 @@
     "summary": {
       "investitures": "Investiduras",
       "evidence": "Evidencias",
+      "sections": "Secciones",
       "camporees": "Camporees",
       "overdue": "Vencidos"
+    },
+    "scope": {
+      "assigned": "Tienes {count} secciones asignadas para coordinación.",
+      "empty": "No tienes secciones asignadas como coordinador. Si también eres director, tus funciones de director siguen apareciendo en la app."
     },
     "camporee_approvals": {
       "title": "Aprobaciones de Camporees",
@@ -1514,12 +1522,13 @@
       "honor": "Honor"
     },
     "clubs": {
-      "title": "Clubs",
+      "title": "Clubes asignados",
       "search_hint": "Buscar club...",
-      "empty_title": "Sin clubs",
-      "empty_subtitle": "No hay clubs asignados a tu campo local.",
-      "error_load": "Error al cargar clubs",
-      "field_id_label": "Campo local #{id}"
+      "empty_title": "Sin clubes asignados",
+      "empty_subtitle": "No hay clubes o secciones dentro de tu alcance de coordinación.",
+      "error_load": "Error al cargar clubes",
+      "field_id_label": "Campo local #{id}",
+      "sections_label": "{count} secciones"
     }
   },
   "classes": {

--- a/assets/translations/fr.json
+++ b/assets/translations/fr.json
@@ -1340,6 +1340,7 @@
       "reject_evidence": "Erreur lors du rejet de la preuve",
       "bulk_approve_evidence": "Erreur lors de l'approbation en lot",
       "bulk_reject_evidence": "Erreur lors du rejet en lot",
+      "fetch_scope": "Erreur lors de la récupération du périmètre de coordination",
       "fetch_local_camporees": "Erreur lors de la récupération des camporées",
       "fetch_union_camporees": "Erreur lors de la récupération des camporées d'union",
       "fetch_local_pending": "Erreur lors de la récupération des approbations en attente",
@@ -1362,6 +1363,8 @@
       "investitures_subtitle": "Valider les demandes d'investiture",
       "evidence_title": "Révision des preuves",
       "evidence_subtitle": "Approuver ou rejeter dossiers, cours et honneurs",
+      "clubs_title": "Clubs et sections",
+      "clubs_subtitle": "Voir les clubs et sections sous votre coordination",
       "camporees_title": "Approbations de camporées",
       "camporees_subtitle": "Clubs, membres et paiements en attente",
       "dashboard_title": "Tableau de bord opérationnel",
@@ -1370,8 +1373,13 @@
     "summary": {
       "investitures": "Investitures",
       "evidence": "Preuves",
+      "sections": "Sections",
       "camporees": "Camporées",
       "overdue": "En retard"
+    },
+    "scope": {
+      "assigned": "Vous avez {count} sections assignées pour la coordination.",
+      "empty": "Vous n'avez aucune section assignée comme coordinateur. Si vous êtes aussi directeur, vos fonctions de directeur restent visibles dans l'app."
     },
     "camporee_approvals": {
       "title": "Approbations de camporées",
@@ -1514,12 +1522,13 @@
       "honor": "Honneur"
     },
     "clubs": {
-      "title": "Clubs",
+      "title": "Clubs assignés",
       "search_hint": "Rechercher un club...",
-      "empty_title": "Aucun club",
-      "empty_subtitle": "Il n'y a aucun club assigné à votre champ local.",
+      "empty_title": "Aucun club assigné",
+      "empty_subtitle": "Il n'y a aucun club ou section dans votre périmètre de coordination.",
       "error_load": "Erreur lors du chargement des clubs",
-      "field_id_label": "Champ local #{id}"
+      "field_id_label": "Champ local #{id}",
+      "sections_label": "{count} sections"
     }
   },
   "classes": {

--- a/assets/translations/pt-BR.json
+++ b/assets/translations/pt-BR.json
@@ -1340,6 +1340,7 @@
       "reject_evidence": "Erro ao rejeitar evidência",
       "bulk_approve_evidence": "Erro na aprovação em massa",
       "bulk_reject_evidence": "Erro na rejeição em massa",
+      "fetch_scope": "Erro ao obter escopo de coordenação",
       "fetch_local_camporees": "Erro ao obter camporis",
       "fetch_union_camporees": "Erro ao obter camporis da união",
       "fetch_local_pending": "Erro ao obter aprovações pendentes",
@@ -1362,6 +1363,8 @@
       "investitures_subtitle": "Validar solicitações de investidura",
       "evidence_title": "Revisão de Evidências",
       "evidence_subtitle": "Aprovar ou rejeitar pastas, aulas e honras",
+      "clubs_title": "Clubes e seções",
+      "clubs_subtitle": "Ver clubes e seções sob sua coordenação",
       "camporees_title": "Aprovações de Camporis",
       "camporees_subtitle": "Clubes, membros e pagamentos pendentes",
       "dashboard_title": "Painel Operacional",
@@ -1370,8 +1373,13 @@
     "summary": {
       "investitures": "Investiduras",
       "evidence": "Evidências",
+      "sections": "Seções",
       "camporees": "Camporis",
       "overdue": "Vencidos"
+    },
+    "scope": {
+      "assigned": "Você tem {count} seções atribuídas para coordenação.",
+      "empty": "Você não tem seções atribuídas como coordenador. Se também for diretor, suas funções de diretor continuam aparecendo no app."
     },
     "camporee_approvals": {
       "title": "Aprovações de Camporis",
@@ -1514,12 +1522,13 @@
       "honor": "Honra"
     },
     "clubs": {
-      "title": "Clubes",
+      "title": "Clubes atribuídos",
       "search_hint": "Buscar clube...",
-      "empty_title": "Sem clubes",
-      "empty_subtitle": "Não há clubes atribuídos ao seu campo local.",
+      "empty_title": "Sem clubes atribuídos",
+      "empty_subtitle": "Não há clubes ou seções dentro do seu escopo de coordenação.",
       "error_load": "Erro ao carregar clubes",
-      "field_id_label": "Campo local #{id}"
+      "field_id_label": "Campo local #{id}",
+      "sections_label": "{count} seções"
     }
   },
   "classes": {

--- a/lib/core/config/route_names.dart
+++ b/lib/core/config/route_names.dart
@@ -152,12 +152,13 @@ class RouteNames {
       '/coordinator/evidence-review';
   static const String coordinatorEvidenceReviewDetailRoute =
       '/coordinator/evidence-review/:type/:id';
+  // Legacy constant retained for compatibility; no active GoRoute.
   static const String coordinatorCamporeeApprovals =
       '/coordinator/camporee-approvals';
 
   // Coordinator shell tab routes (PR-4, separate StatefulShellRoute)
   // Branch 0: /coordinator        — Hub (reuses coordinator root)
-  // Branch 1: /coordinator/clubs  — Clubes / Aprobaciones
+  // Branch 1: /coordinator/clubs  — Clubes / secciones asignadas
   static const String coordinatorClubs = '/coordinator/clubs';
   // Branch 2: /coordinator/reports — Reportes / SLA dashboard
   static const String coordinatorReports = '/coordinator/reports';

--- a/lib/core/config/router.dart
+++ b/lib/core/config/router.dart
@@ -51,7 +51,6 @@ import 'package:sacdia_app/features/coordinator/presentation/views/coordinator_h
 import 'package:sacdia_app/features/coordinator/presentation/views/sla_dashboard_view.dart';
 import 'package:sacdia_app/features/coordinator/presentation/views/evidence_review_list_view.dart';
 import 'package:sacdia_app/features/coordinator/presentation/views/evidence_review_detail_view.dart';
-import 'package:sacdia_app/features/coordinator/presentation/views/camporee_approvals_view.dart';
 import 'package:sacdia_app/features/coordinator/presentation/views/coordinator_clubs_list_view.dart';
 import 'package:sacdia_app/features/coordinator/domain/entities/evidence_review_item.dart';
 import 'package:sacdia_app/features/notifications/presentation/views/notifications_inbox_view.dart';
@@ -1086,16 +1085,6 @@ final routerProvider = Provider<GoRouter>((ref) {
             EvidenceReviewDetailView(type: type, id: id),
           );
         },
-      ),
-
-      // Coordinador: aprobaciones de camporees (deep-link / sub-view entry)
-      GoRoute(
-        path: RouteNames.coordinatorCamporeeApprovals,
-        pageBuilder: (context, state) => _sharedAxisBuild(
-          context,
-          state,
-          const CamporeeApprovalsView(),
-        ),
       ),
 
       // Bandeja de notificaciones

--- a/lib/core/constants/api_endpoints.dart
+++ b/lib/core/constants/api_endpoints.dart
@@ -95,6 +95,9 @@ class ApiEndpoints {
   // ── Evidence Review ────────────────────────────────────────────────────────
   static const String evidenceReview = '/evidence-review';
 
+  // ── Coordination ─────────────────────────────────────────────────────────
+  static const String coordination = '/coordination';
+
   // ── Certificate Bulk Imports ─────────────────────────────────────────────
   static const String certificateBulkImports = '/certificate-bulk-imports';
 

--- a/lib/core/notifications/push_notification_service.dart
+++ b/lib/core/notifications/push_notification_service.dart
@@ -778,7 +778,6 @@ class PushNotificationService {
     RouteNames.coordinator,
     RouteNames.coordinatorSla,
     RouteNames.coordinatorEvidenceReview,
-    RouteNames.coordinatorCamporeeApprovals,
   };
 
   // ── Notification type handlers ───────────────────���───────────────────────

--- a/lib/core/widgets/evidence_staging/evidence_staging_manager.dart
+++ b/lib/core/widgets/evidence_staging/evidence_staging_manager.dart
@@ -633,7 +633,7 @@ class EvidenceStagingManagerState extends State<EvidenceStagingManager> {
       title: tr('core.evidence_staging.submit_dialog_title'),
       content: tr('core.evidence_staging.submit_dialog_body'),
       highlight: fileCountLabel,
-      icon: Icons.send_rounded,
+      icon: HugeIcons.strokeRoundedMailSend01,
       cancelLabel: tr('core.evidence_staging.cancel'),
       confirmLabel: tr('core.evidence_staging.submit'),
     );

--- a/lib/core/widgets/evidence_staging/upload_progress_sheet.dart
+++ b/lib/core/widgets/evidence_staging/upload_progress_sheet.dart
@@ -353,7 +353,7 @@ class _UploadProgressSheetContentState
         'core.evidence_staging.partial_dialog_body',
         namedArgs: {'count': '$_errorCount'},
       ),
-      icon: Icons.warning_amber_rounded,
+      icon: HugeIcons.strokeRoundedAlert02,
       iconColor: AppColors.observedDark,
       iconBackgroundColor: AppColors.observedBg,
       cancelLabel: tr('core.evidence_staging.cancel'),

--- a/lib/core/widgets/sac_dialog.dart
+++ b/lib/core/widgets/sac_dialog.dart
@@ -1,5 +1,6 @@
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
+import 'package:hugeicons/hugeicons.dart';
 import 'package:sacdia_app/core/theme/app_colors.dart';
 import 'package:sacdia_app/core/theme/sac_colors.dart';
 
@@ -25,7 +26,7 @@ class SacDialog extends StatelessWidget {
   final String title;
   final String? content;
   final String? highlight;
-  final IconData? icon;
+  final List<List<dynamic>>? icon;
   final Color? iconColor;
   final Color? iconBackgroundColor;
   final List<SacDialogAction> actions;
@@ -53,7 +54,7 @@ class SacDialog extends StatelessWidget {
     String? cancelLabel,
     bool confirmIsDestructive = false,
     String? highlight,
-    IconData? icon,
+    List<List<dynamic>>? icon,
     Color? iconColor,
     Color? iconBackgroundColor,
   }) {
@@ -67,8 +68,8 @@ class SacDialog extends StatelessWidget {
         highlight: highlight,
         icon: icon ??
             (confirmIsDestructive
-                ? Icons.warning_amber_rounded
-                : Icons.check_rounded),
+                ? HugeIcons.strokeRoundedAlert02
+                : HugeIcons.strokeRoundedCheckmarkCircle02),
         iconColor: iconColor ??
             (confirmIsDestructive ? AppColors.error : AppColors.coral700),
         iconBackgroundColor: iconBackgroundColor ??
@@ -135,8 +136,8 @@ class SacDialog extends StatelessWidget {
                                   .withValues(alpha: 0.14),
                             ),
                           ),
-                          child: Icon(
-                            icon,
+                          child: HugeIcon(
+                            icon: icon!,
                             size: 26,
                             color: iconColor,
                           ),

--- a/lib/features/annual_folders/presentation/views/annual_folder_view.dart
+++ b/lib/features/annual_folders/presentation/views/annual_folder_view.dart
@@ -193,7 +193,7 @@ class _FolderContent extends ConsumerWidget {
       context,
       title: 'annual_folders.submit_dialog_title'.tr(),
       content: 'annual_folders.submit_dialog_content'.tr(),
-      icon: Icons.send_rounded,
+      icon: HugeIcons.strokeRoundedMailSend01,
       cancelLabel: 'common.cancel'.tr(),
       confirmLabel: 'annual_folders.send'.tr(),
     );

--- a/lib/features/classes/presentation/views/class_detail_with_progress_view.dart
+++ b/lib/features/classes/presentation/views/class_detail_with_progress_view.dart
@@ -206,7 +206,7 @@ class _ClassBodyState extends ConsumerState<_ClassBody> {
       highlight: 'Requisitos validados: 100%',
       confirmLabel: 'Enviar',
       cancelLabel: 'Cancelar',
-      icon: Icons.send_rounded,
+      icon: HugeIcons.strokeRoundedMailSend01,
       iconColor: AppColors.coral700,
       iconBackgroundColor: AppColors.coral50,
     );

--- a/lib/features/coordinator/data/datasources/coordinator_remote_data_source.dart
+++ b/lib/features/coordinator/data/datasources/coordinator_remote_data_source.dart
@@ -6,13 +6,17 @@ import '../../../../core/utils/app_logger.dart';
 import '../../domain/entities/evidence_review_item.dart';
 import '../../domain/entities/camporee_approval.dart';
 import '../models/coordinator_club_model.dart';
+import '../models/coordinator_scope_model.dart';
 import '../models/sla_dashboard_model.dart';
 import '../models/evidence_review_model.dart';
 import '../models/camporee_approval_model.dart';
 
 /// Interfaz para la fuente de datos remota del coordinador.
 abstract class CoordinatorRemoteDataSource {
-  /// GET /clubs?localFieldId=...
+  /// GET /coordination/me/scope
+  Future<CoordinatorScopeModel> getMyScope({CancelToken? cancelToken});
+
+  /// Lista los clubs agrupando las secciones de /coordination/me/scope.
   Future<List<CoordinatorClubModel>> listClubs({
     int? localFieldId,
     CancelToken? cancelToken,
@@ -213,7 +217,37 @@ class CoordinatorRemoteDataSourceImpl implements CoordinatorRemoteDataSource {
 
   bool _isOk(int? code) => code == 200 || code == 201 || code == 204;
 
-  // ── GET /clubs ───────────────────────────────────────────────────────────────
+  // ── GET /coordination/me/scope ─────────────────────────────────────────────
+
+  @override
+  Future<CoordinatorScopeModel> getMyScope({CancelToken? cancelToken}) async {
+    try {
+      final response = await _dio.get(
+        '$_baseUrl${ApiEndpoints.coordination}/me/scope',
+        cancelToken: cancelToken,
+      );
+
+      if (_isOk(response.statusCode)) {
+        final raw = response.data;
+        final data = raw is Map
+            ? raw['data'] is Map
+                ? Map<String, dynamic>.from(raw['data'] as Map)
+                : Map<String, dynamic>.from(raw)
+            : <String, dynamic>{};
+
+        return CoordinatorScopeModel.fromJson(data);
+      }
+      throw ServerException(
+        message: tr('coordinator.errors.fetch_scope'),
+        code: response.statusCode,
+      );
+    } catch (e) {
+      AppLogger.e('Error en getMyScope (coordinator)', tag: _tag, error: e);
+      _rethrow(e);
+    }
+  }
+
+  // ── GET /coordination/me/scope → clubs agrupados ───────────────────────────
 
   @override
   Future<List<CoordinatorClubModel>> listClubs({
@@ -222,28 +256,11 @@ class CoordinatorRemoteDataSourceImpl implements CoordinatorRemoteDataSource {
   }) async {
     try {
       AppLogger.i(
-        'Listando clubs para coordinador (localFieldId=$localFieldId)',
+        'Listando clubs para coordinador desde scope efectivo',
         tag: _tag,
       );
-      final queryParams = <String, dynamic>{};
-      if (localFieldId != null) queryParams['localFieldId'] = localFieldId;
-
-      final response = await _dio.get(
-        '$_baseUrl${ApiEndpoints.clubs}',
-        queryParameters: queryParams.isEmpty ? null : queryParams,
-        cancelToken: cancelToken,
-      );
-
-      if (_isOk(response.statusCode)) {
-        return _parseList(
-          response.data,
-          CoordinatorClubModel.fromJson,
-        );
-      }
-      throw ServerException(
-        message: tr('coordinator.clubs.error_load'),
-        code: response.statusCode,
-      );
+      final scope = await getMyScope(cancelToken: cancelToken);
+      return CoordinatorClubModel.fromSections(scope.sections);
     } catch (e) {
       AppLogger.e('Error en listClubs (coordinator)', tag: _tag, error: e);
       _rethrow(e);

--- a/lib/features/coordinator/data/models/coordinator_club_model.dart
+++ b/lib/features/coordinator/data/models/coordinator_club_model.dart
@@ -1,16 +1,18 @@
 import '../../domain/entities/coordinator_club.dart';
+import '../../domain/entities/coordinator_scope.dart';
 
 /// Modelo de datos para la lista de clubs vista por el coordinador.
 ///
-/// Mapea la respuesta paginada de:
-///   GET /api/v1/clubs?localFieldId=...
-///
-/// El backend envuelve en { data: [...] } o devuelve la lista directamente.
+/// Hoy se puede construir desde el scope efectivo de coordinación:
+///   GET /api/v1/coordination/me/scope
 class CoordinatorClubModel extends CoordinatorClub {
   const CoordinatorClubModel({
     required super.id,
     required super.name,
     required super.localFieldId,
+    super.localFieldName,
+    super.districtName,
+    super.sections,
   });
 
   factory CoordinatorClubModel.fromJson(Map<String, dynamic> json) {
@@ -23,12 +25,43 @@ class CoordinatorClubModel extends CoordinatorClub {
       localFieldId: rawFieldId is int
           ? rawFieldId
           : (int.tryParse(rawFieldId?.toString() ?? '') ?? 0),
+      localFieldName: json['local_field_name'] as String?,
+      districtName: json['district_name'] as String?,
     );
+  }
+
+  static List<CoordinatorClubModel> fromSections(
+    List<CoordinatorSectionScope> sections,
+  ) {
+    final grouped = <int, List<CoordinatorSectionScope>>{};
+
+    for (final section in sections) {
+      final clubId = section.clubId;
+      if (clubId == null) continue;
+      grouped.putIfAbsent(clubId, () => []).add(section);
+    }
+
+    final clubs = grouped.entries.map((entry) {
+      final first = entry.value.first;
+      return CoordinatorClubModel(
+        id: entry.key,
+        name: first.clubName ?? 'Club #${entry.key}',
+        localFieldId: first.localFieldId ?? 0,
+        localFieldName: first.localFieldName,
+        districtName: first.districtName,
+        sections: entry.value,
+      );
+    }).toList();
+
+    clubs.sort((a, b) => a.name.toLowerCase().compareTo(b.name.toLowerCase()));
+    return clubs;
   }
 
   Map<String, dynamic> toJson() => {
         'club_id': id,
         'name': name,
         'local_field_id': localFieldId,
+        'local_field_name': localFieldName,
+        'district_name': districtName,
       };
 }

--- a/lib/features/coordinator/data/models/coordinator_scope_model.dart
+++ b/lib/features/coordinator/data/models/coordinator_scope_model.dart
@@ -1,0 +1,73 @@
+import '../../domain/entities/coordinator_scope.dart';
+
+class CoordinatorScopeModel extends CoordinatorScope {
+  const CoordinatorScopeModel({
+    required super.isCoordinator,
+    super.clubSectionIds,
+    super.sections,
+  });
+
+  factory CoordinatorScopeModel.fromJson(Map<String, dynamic> json) {
+    final rawSectionIds = json['club_section_ids'];
+    final rawSections = json['sections'];
+
+    return CoordinatorScopeModel(
+      isCoordinator: json['is_coordinator'] == true,
+      clubSectionIds: rawSectionIds is List
+          ? rawSectionIds.map(_toInt).where((id) => id > 0).toList()
+          : const [],
+      sections: rawSections is List
+          ? rawSections
+              .whereType<Map<String, dynamic>>()
+              .map(CoordinatorSectionScopeModel.fromJson)
+              .toList()
+          : const [],
+    );
+  }
+}
+
+class CoordinatorSectionScopeModel extends CoordinatorSectionScope {
+  const CoordinatorSectionScopeModel({
+    required super.clubSectionId,
+    super.name,
+    required super.clubTypeId,
+    super.clubTypeName,
+    super.clubId,
+    super.clubName,
+    super.districtId,
+    super.districtName,
+    super.localFieldId,
+    super.localFieldName,
+  });
+
+  factory CoordinatorSectionScopeModel.fromJson(Map<String, dynamic> json) {
+    return CoordinatorSectionScopeModel(
+      clubSectionId: _toInt(json['club_section_id']),
+      name: _toNullableString(json['name']),
+      clubTypeId: _toInt(json['club_type_id']),
+      clubTypeName: _toNullableString(json['club_type_name']),
+      clubId: _toNullableInt(json['club_id']),
+      clubName: _toNullableString(json['club_name']),
+      districtId: _toNullableInt(json['district_id']),
+      districtName: _toNullableString(json['district_name']),
+      localFieldId: _toNullableInt(json['local_field_id']),
+      localFieldName: _toNullableString(json['local_field_name']),
+    );
+  }
+}
+
+int _toInt(dynamic value) {
+  if (value is int) return value;
+  return int.tryParse(value?.toString() ?? '') ?? 0;
+}
+
+int? _toNullableInt(dynamic value) {
+  if (value == null) return null;
+  final parsed = _toInt(value);
+  return parsed == 0 ? null : parsed;
+}
+
+String? _toNullableString(dynamic value) {
+  final parsed = value?.toString().trim();
+  return parsed == null || parsed.isEmpty ? null : parsed;
+}

--- a/lib/features/coordinator/data/repositories/coordinator_repository_impl.dart
+++ b/lib/features/coordinator/data/repositories/coordinator_repository_impl.dart
@@ -5,6 +5,7 @@ import '../../../../core/network/network_info.dart';
 import '../../../../core/usecases/cancellation_token.dart';
 import '../../../../core/network/cancel_token_adapter.dart';
 import '../../domain/entities/coordinator_club.dart';
+import '../../domain/entities/coordinator_scope.dart';
 import '../../domain/entities/sla_dashboard.dart';
 import '../../domain/entities/evidence_review_item.dart';
 import '../../domain/entities/camporee_approval.dart';
@@ -33,6 +34,24 @@ class CoordinatorRepositoryImpl implements CoordinatorRepository {
       Left(UnexpectedFailure(message: e.toString()));
 
   // ── Clubs list ────────────────────────────────────────────────────────────────
+
+  @override
+  Future<Either<Failure, CoordinatorScope>> getMyScope({
+    RequestCancelToken? cancelToken,
+  }) async {
+    try {
+      final model = await remoteDataSource.getMyScope(
+        cancelToken: cancelToken.asDioCancelToken(),
+      );
+      return Right(model);
+    } on ServerException catch (e) {
+      return _serverFailure(e);
+    } on AuthException catch (e) {
+      return _authFailure(e);
+    } catch (e) {
+      return _unexpectedFailure(e);
+    }
+  }
 
   @override
   Future<Either<Failure, List<CoordinatorClub>>> listClubs({

--- a/lib/features/coordinator/domain/entities/coordinator_club.dart
+++ b/lib/features/coordinator/domain/entities/coordinator_club.dart
@@ -1,10 +1,11 @@
 import 'package:equatable/equatable.dart';
+import 'coordinator_scope.dart';
 
 /// Entidad de dominio que representa un club visible para un coordinador.
 ///
 /// Encapsula la información mínima necesaria para la lista de clubes en
-/// el panel de coordinación. Los coordinadores ven todos los clubes de su
-/// campo local sin importar la sección (Conquistadores, Aventureros, GM).
+/// el panel de coordinación. El acceso real se deriva de las secciones
+/// asignadas al coordinador.
 class CoordinatorClub extends Equatable {
   /// ID numérico del club (club_id).
   final int id;
@@ -15,12 +16,38 @@ class CoordinatorClub extends Equatable {
   /// ID del campo local al que pertenece el club.
   final int localFieldId;
 
+  /// Nombre del campo local, cuando el backend lo expone.
+  final String? localFieldName;
+
+  /// Nombre del distrito, cuando el backend lo expone.
+  final String? districtName;
+
+  /// Secciones específicas que el coordinador puede gestionar en este club.
+  final List<CoordinatorSectionScope> sections;
+
   const CoordinatorClub({
     required this.id,
     required this.name,
     required this.localFieldId,
+    this.localFieldName,
+    this.districtName,
+    this.sections = const [],
   });
 
+  int get sectionCount => sections.length;
+
+  String get sectionSummary {
+    final labels = sections.map((section) => section.displayName).toSet();
+    return labels.join(', ');
+  }
+
   @override
-  List<Object?> get props => [id, name, localFieldId];
+  List<Object?> get props => [
+        id,
+        name,
+        localFieldId,
+        localFieldName,
+        districtName,
+        sections,
+      ];
 }

--- a/lib/features/coordinator/domain/entities/coordinator_scope.dart
+++ b/lib/features/coordinator/domain/entities/coordinator_scope.dart
@@ -1,0 +1,68 @@
+import 'package:equatable/equatable.dart';
+
+class CoordinatorScope extends Equatable {
+  final bool isCoordinator;
+  final List<int> clubSectionIds;
+  final List<CoordinatorSectionScope> sections;
+
+  const CoordinatorScope({
+    required this.isCoordinator,
+    this.clubSectionIds = const [],
+    this.sections = const [],
+  });
+
+  bool get hasAssignedSections => clubSectionIds.isNotEmpty;
+
+  @override
+  List<Object?> get props => [isCoordinator, clubSectionIds, sections];
+}
+
+class CoordinatorSectionScope extends Equatable {
+  final int clubSectionId;
+  final String? name;
+  final int clubTypeId;
+  final String? clubTypeName;
+  final int? clubId;
+  final String? clubName;
+  final int? districtId;
+  final String? districtName;
+  final int? localFieldId;
+  final String? localFieldName;
+
+  const CoordinatorSectionScope({
+    required this.clubSectionId,
+    this.name,
+    required this.clubTypeId,
+    this.clubTypeName,
+    this.clubId,
+    this.clubName,
+    this.districtId,
+    this.districtName,
+    this.localFieldId,
+    this.localFieldName,
+  });
+
+  String get displayName {
+    final type = clubTypeName?.trim();
+    if (type != null && type.isNotEmpty) return type;
+
+    final sectionName = name?.trim();
+    if (sectionName != null && sectionName.isNotEmpty) return sectionName;
+
+    return 'Sección #$clubSectionId';
+  }
+
+  @override
+  List<Object?> get props => [
+        clubSectionId,
+        name,
+        clubTypeId,
+        clubTypeName,
+        clubId,
+        clubName,
+        districtId,
+        districtName,
+        localFieldId,
+        localFieldName,
+      ];
+}

--- a/lib/features/coordinator/domain/repositories/coordinator_repository.dart
+++ b/lib/features/coordinator/domain/repositories/coordinator_repository.dart
@@ -2,16 +2,25 @@ import 'package:dartz/dartz.dart';
 import '../../../../core/errors/failures.dart';
 import '../../../../core/usecases/cancellation_token.dart';
 import '../entities/coordinator_club.dart';
+import '../entities/coordinator_scope.dart';
 import '../entities/sla_dashboard.dart';
 import '../entities/evidence_review_item.dart';
 import '../entities/camporee_approval.dart';
 
 /// Repositorio del módulo de coordinador (interfaz del dominio).
 abstract class CoordinatorRepository {
+  // ── Scope ────────────────────────────────────────────────────────────────
+
+  /// Devuelve el alcance efectivo del coordinador actual.
+  /// GET /coordination/me/scope
+  Future<Either<Failure, CoordinatorScope>> getMyScope({
+    RequestCancelToken? cancelToken,
+  });
+
   // ── Clubs list ────────────────────────────────────────────────────────────
 
   /// Devuelve la lista de clubs accesibles para el coordinador.
-  /// GET /clubs?localFieldId=... (coordinadores ven todos los clubs de su campo)
+  /// Derivado de /coordination/me/scope, agrupado por club.
   Future<Either<Failure, List<CoordinatorClub>>> listClubs({
     int? localFieldId,
     RequestCancelToken? cancelToken,

--- a/lib/features/coordinator/presentation/providers/coordinator_providers.dart
+++ b/lib/features/coordinator/presentation/providers/coordinator_providers.dart
@@ -7,6 +7,7 @@ import '../../../../core/errors/failures.dart';
 import '../../data/datasources/coordinator_remote_data_source.dart';
 import '../../data/repositories/coordinator_repository_impl.dart';
 import '../../domain/entities/coordinator_club.dart';
+import '../../domain/entities/coordinator_scope.dart';
 import '../../domain/entities/sla_dashboard.dart';
 import '../../domain/entities/evidence_review_item.dart';
 import '../../domain/entities/camporee_approval.dart';
@@ -28,6 +29,21 @@ final coordinatorRepositoryProvider = Provider<CoordinatorRepository>((ref) {
   return CoordinatorRepositoryImpl(
     remoteDataSource: ref.read(coordinatorRemoteDataSourceProvider),
     networkInfo: ref.read(networkInfoProvider),
+  );
+});
+
+// ── Scope ───────────────────────────────────────────────────────────────────
+
+/// Alcance efectivo del coordinador actual.
+final coordinatorScopeProvider =
+    FutureProvider.autoDispose<CoordinatorScope>((ref) async {
+  final repository = ref.read(coordinatorRepositoryProvider);
+  final cancelToken = CancelToken();
+  ref.onDispose(() => cancelToken.cancel());
+  final result = await repository.getMyScope(cancelToken: cancelToken);
+  return result.fold(
+    (failure) => throw Exception(failure.message),
+    (scope) => scope,
   );
 });
 

--- a/lib/features/coordinator/presentation/views/coordinator_clubs_list_view.dart
+++ b/lib/features/coordinator/presentation/views/coordinator_clubs_list_view.dart
@@ -14,9 +14,6 @@ import 'package:sacdia_app/features/coordinator/presentation/providers/coordinat
 
 /// Vista principal de la rama Clubes del coordinador.
 ///
-/// Reemplaza el placeholder [CamporeeApprovalsView] que ocupaba el
-/// branchIndex=1 del StatefulShellRoute de coordinación (PR-4 / FR-2).
-///
 /// Muestra todos los clubs accesibles al coordinador con búsqueda por nombre
 /// y navega al detalle de club al tocar una tarjeta.
 class CoordinatorClubsListView extends ConsumerWidget {
@@ -52,7 +49,12 @@ class CoordinatorClubsListView extends ConsumerWidget {
                 ),
                 data: (clubs) => clubs.isEmpty
                     ? const _ClubsEmptyState()
-                    : _ClubsList(clubs: clubs, hPad: hPad),
+                    : _ClubsList(
+                        clubs: clubs,
+                        hPad: hPad,
+                        onRefresh: () =>
+                            ref.invalidate(coordinatorClubsRawProvider),
+                      ),
               ),
             ),
           ],
@@ -218,15 +220,20 @@ class _ClubSearchBarState extends ConsumerState<_ClubSearchBar> {
 class _ClubsList extends StatelessWidget {
   final List<CoordinatorClub> clubs;
   final double hPad;
+  final VoidCallback onRefresh;
 
-  const _ClubsList({required this.clubs, required this.hPad});
+  const _ClubsList({
+    required this.clubs,
+    required this.hPad,
+    required this.onRefresh,
+  });
 
   @override
   Widget build(BuildContext context) {
     return RefreshIndicator(
       color: AppColors.primary,
       onRefresh: () async {
-        // Handled by invalidate in header — pull-to-refresh triggers same path
+        onRefresh();
       },
       child: ListView.separated(
         padding: EdgeInsets.fromLTRB(hPad, 4, hPad, 24),
@@ -257,10 +264,18 @@ class _ClubCard extends StatelessWidget {
   Widget build(BuildContext context) {
     final c = context.sac;
 
-    // ClubModel only carries name and localFieldId — no clubTypeName.
-    // We fall back to AppColors.primary until the backend exposes type info.
-    // GAP: coordinator list endpoint does not return club type — documented.
     final accentColor = AppColors.primary;
+    final locationParts = <String>[
+      if (club.districtName != null && club.districtName!.isNotEmpty)
+        club.districtName!,
+      if (club.localFieldName != null && club.localFieldName!.isNotEmpty)
+        club.localFieldName!
+      else if (club.localFieldId > 0)
+        'coordinator.clubs.field_id_label'
+            .tr(namedArgs: {'id': '${club.localFieldId}'}),
+    ];
+    final locationLabel = locationParts.join(' · ');
+    final sectionSummary = club.sectionSummary;
 
     return Semantics(
       label: club.name,
@@ -313,14 +328,28 @@ class _ClubCard extends StatelessWidget {
                         overflow: TextOverflow.ellipsis,
                       ),
                       const SizedBox(height: 4),
-                      Text(
-                        'coordinator.clubs.field_id_label'
-                            .tr(namedArgs: {'id': '${club.localFieldId}'}),
-                        style: TextStyle(
-                          fontSize: 12,
-                          color: c.textSecondary,
+                      if (locationLabel.isNotEmpty) ...[
+                        Text(
+                          locationLabel,
+                          style: TextStyle(
+                            fontSize: 12,
+                            color: c.textSecondary,
+                          ),
                         ),
-                      ),
+                        const SizedBox(height: 4),
+                      ],
+                      if (sectionSummary.isNotEmpty)
+                        Text(
+                          '${'coordinator.clubs.sections_label'.tr(namedArgs: {
+                                'count': '${club.sectionCount}',
+                              })}: $sectionSummary',
+                          style: TextStyle(
+                            fontSize: 12,
+                            color: c.textSecondary,
+                          ),
+                          maxLines: 2,
+                          overflow: TextOverflow.ellipsis,
+                        ),
                     ],
                   ),
                 ),

--- a/lib/features/coordinator/presentation/views/coordinator_hub_view.dart
+++ b/lib/features/coordinator/presentation/views/coordinator_hub_view.dart
@@ -8,6 +8,7 @@ import '../../../../core/theme/app_colors.dart';
 import '../../../../core/theme/sac_colors.dart';
 import '../../../../core/utils/responsive.dart';
 import '../../../auth/presentation/providers/auth_providers.dart';
+import '../../domain/entities/coordinator_scope.dart';
 import '../../domain/entities/sla_dashboard.dart';
 import '../providers/coordinator_providers.dart';
 import 'package:sacdia_app/core/widgets/sac_back_button.dart';
@@ -16,13 +17,14 @@ import 'package:sacdia_app/core/widgets/sac_back_button.dart';
 ///
 /// Muestra resumen de KPIs desde el endpoint SLA y accesos directos a cada
 /// sub-módulo del coordinador: investiduras, revisión de evidencias,
-/// aprobaciones de camporees y dashboard operativo.
+/// clubes/secciones bajo gestión y dashboard operativo.
 class CoordinatorHubView extends ConsumerWidget {
   const CoordinatorHubView({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final slaAsync = ref.watch(slaDashboardProvider);
+    final scopeAsync = ref.watch(coordinatorScopeProvider);
     final user = ref.watch(
       authNotifierProvider.select((v) => v.valueOrNull),
     );
@@ -33,7 +35,11 @@ class CoordinatorHubView extends ConsumerWidget {
       backgroundColor: c.background,
       body: RefreshIndicator(
         color: AppColors.primary,
-        onRefresh: () async => ref.invalidate(slaDashboardProvider),
+        onRefresh: () async {
+          ref.invalidate(slaDashboardProvider);
+          ref.invalidate(coordinatorScopeProvider);
+          ref.invalidate(coordinatorClubsRawProvider);
+        },
         child: CustomScrollView(
           physics: const AlwaysScrollableScrollPhysics(),
           slivers: [
@@ -94,9 +100,21 @@ class CoordinatorHubView extends ConsumerWidget {
               padding: EdgeInsets.fromLTRB(hPad, 20, hPad, 32),
               sliver: SliverList(
                 delegate: SliverChildListDelegate([
+                  scopeAsync.when(
+                    data: (scope) => _ScopeBanner(scope: scope),
+                    loading: () => const SizedBox.shrink(),
+                    error: (_, __) => const SizedBox.shrink(),
+                  ),
+
+                  const SizedBox(height: 16),
+
                   // ── Summary cards ──────────────────────────────────────
                   slaAsync.when(
-                    data: (sla) => _SummaryRow(sla: sla),
+                    data: (sla) => _SummaryRow(
+                      sla: sla,
+                      sectionCount:
+                          scopeAsync.valueOrNull?.clubSectionIds.length,
+                    ),
                     loading: () => const _SummarySkeleton(),
                     error: (_, __) => const SizedBox.shrink(),
                   ),
@@ -134,12 +152,11 @@ class CoordinatorHubView extends ConsumerWidget {
                   const SizedBox(height: 10),
 
                   _NavCard(
-                    icon: HugeIcons.strokeRoundedCalendar04,
+                    icon: HugeIcons.strokeRoundedBuilding04,
                     color: AppColors.secondary,
-                    title: 'coordinator.nav.camporees_title'.tr(),
-                    subtitle: 'coordinator.nav.camporees_subtitle'.tr(),
-                    onTap: () =>
-                        context.push(RouteNames.coordinatorCamporeeApprovals),
+                    title: 'coordinator.nav.clubs_title'.tr(),
+                    subtitle: 'coordinator.nav.clubs_subtitle'.tr(),
+                    onTap: () => context.push(RouteNames.coordinatorClubs),
                   ),
                   const SizedBox(height: 10),
 
@@ -162,10 +179,67 @@ class CoordinatorHubView extends ConsumerWidget {
 
 // ── Summary row ───────────────────────────────────────────────────────────────
 
+class _ScopeBanner extends StatelessWidget {
+  final CoordinatorScope scope;
+
+  const _ScopeBanner({required this.scope});
+
+  @override
+  Widget build(BuildContext context) {
+    final c = context.sac;
+    final hasScope = scope.hasAssignedSections;
+
+    return Container(
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: hasScope
+            ? AppColors.info.withValues(alpha: 0.10)
+            : AppColors.warning.withValues(alpha: 0.12),
+        borderRadius: BorderRadius.circular(14),
+        border: Border.all(
+          color: hasScope
+              ? AppColors.info.withValues(alpha: 0.30)
+              : AppColors.warning.withValues(alpha: 0.35),
+        ),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          HugeIcon(
+            icon: hasScope
+                ? HugeIcons.strokeRoundedCheckmarkCircle01
+                : HugeIcons.strokeRoundedInformationCircle,
+            size: 20,
+            color: hasScope ? AppColors.info : AppColors.warning,
+          ),
+          const SizedBox(width: 10),
+          Expanded(
+            child: Text(
+              hasScope
+                  ? 'coordinator.scope.assigned'.tr(
+                      namedArgs: {
+                        'count': scope.clubSectionIds.length.toString(),
+                      },
+                    )
+                  : 'coordinator.scope.empty'.tr(),
+              style: TextStyle(
+                fontSize: 13,
+                color: c.text,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
 class _SummaryRow extends StatelessWidget {
   final SlaDashboard sla;
+  final int? sectionCount;
 
-  const _SummaryRow({required this.sla});
+  const _SummaryRow({required this.sla, this.sectionCount});
 
   @override
   Widget build(BuildContext context) {
@@ -206,10 +280,10 @@ class _SummaryRow extends StatelessWidget {
             children: [
               Expanded(
                 child: _SummaryTile(
-                  label: 'coordinator.summary.camporees'.tr(),
-                  count: sla.camporee.pending,
+                  label: 'coordinator.summary.sections'.tr(),
+                  count: sectionCount ?? 0,
                   color: AppColors.secondary,
-                  icon: HugeIcons.strokeRoundedCalendar04,
+                  icon: HugeIcons.strokeRoundedBuilding04,
                 ),
               ),
               const SizedBox(width: 10),

--- a/lib/features/coordinator/presentation/views/sla_dashboard_view.dart
+++ b/lib/features/coordinator/presentation/views/sla_dashboard_view.dart
@@ -15,8 +15,9 @@ import 'package:sacdia_app/core/widgets/sac_back_button.dart';
 
 /// Dashboard SLA operativo del coordinador.
 ///
-/// Muestra KPIs de los tres procesos (investiture, evidence, camporee),
-/// pipeline de revisión y throughput semanal.
+/// Muestra KPIs de investiduras y evidencias, pipeline de revisión y
+/// throughput semanal. Camporee no forma parte de la superficie móvil de
+/// coordinación.
 /// Se auto-refresca cada 60 segundos.
 class SLADashboardView extends ConsumerStatefulWidget {
   const SLADashboardView({super.key});
@@ -101,13 +102,6 @@ class _SLADashboardViewState extends ConsumerState<SLADashboardView> {
                     stat: sla.evidence,
                     accentColor: AppColors.accent,
                     icon: HugeIcons.strokeRoundedFolder01,
-                  ),
-                  const SizedBox(height: 10),
-                  SlaStatCard(
-                    title: 'coordinator.summary.camporees'.tr(),
-                    stat: sla.camporee,
-                    accentColor: AppColors.secondary,
-                    icon: HugeIcons.strokeRoundedCalendar04,
                   ),
 
                   const SizedBox(height: 24),

--- a/lib/features/dashboard/presentation/widgets/quick_access_grid.dart
+++ b/lib/features/dashboard/presentation/widgets/quick_access_grid.dart
@@ -47,7 +47,14 @@ final List<_QuickAccessItemConfig> _quickAccessItemsConfig = [
     icon: HugeIcons.strokeRoundedAnalytics01,
     color: AppColors.info,
     route: RouteNames.coordinator,
-    requiredRoles: {'coordinator', 'admin', 'super-admin', 'assistant-admin'},
+    requiredRoles: {
+      'coordinator',
+      'zone-coordinator',
+      'general-coordinator',
+      'admin',
+      'super-admin',
+      'assistant-admin',
+    },
   ),
   // Administrative: member list — users:read_detail is held by counselor+
   _QuickAccessItemConfig(

--- a/lib/features/evidence_folder/presentation/views/evidence_folder_view.dart
+++ b/lib/features/evidence_folder/presentation/views/evidence_folder_view.dart
@@ -101,7 +101,7 @@ class _FolderBodyState extends ConsumerState<_FolderBody> {
       content: 'evidence_folder.submit_section_dialog.message'.tr(namedArgs: {
         'sectionName': section.name,
       }),
-      icon: Icons.send_rounded,
+      icon: HugeIcons.strokeRoundedMailSend01,
       cancelLabel: 'common.cancel'.tr(),
       confirmLabel: 'evidence_folder.send'.tr(),
     );

--- a/lib/features/master_honors/presentation/providers/master_honors_providers.dart
+++ b/lib/features/master_honors/presentation/providers/master_honors_providers.dart
@@ -83,9 +83,10 @@ final userMasterHonorRoadmapProvider =
 
 /// Ruta recomendada para abrir desde el tap de notificaciones de maestrías.
 ///
-/// La pantalla dedicada concentra el roadmap completo y los requisitos.
+/// El perfil contiene el resumen histórico y mantiene el contrato de
+/// navegación de notificaciones ya cubierto por pruebas.
 final masterHonorsNotificationTapRouteProvider = Provider<String>((_) {
-  return RouteNames.homeMasterHonors;
+  return RouteNames.homeProfile;
 });
 
 /// Hook estable para que notificaciones `master_honor_changed` invaliden cache.

--- a/lib/features/master_honors/presentation/widgets/master_honor_history_section.dart
+++ b/lib/features/master_honors/presentation/widgets/master_honor_history_section.dart
@@ -5,7 +5,6 @@ import 'package:hugeicons/hugeicons.dart';
 import 'package:sacdia_app/core/config/route_names.dart';
 import 'package:sacdia_app/core/theme/app_colors.dart';
 import 'package:sacdia_app/core/theme/sac_colors.dart';
-import 'package:sacdia_app/features/master_honors/domain/entities/master_honor_roadmap.dart';
 import 'package:sacdia_app/features/master_honors/domain/entities/user_master_honor.dart';
 import 'package:sacdia_app/features/master_honors/presentation/providers/master_honors_providers.dart';
 
@@ -54,11 +53,11 @@ class MasterHonorHistorySection extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final roadmapAsync = ref.watch(userMasterHonorRoadmapProvider);
+    final honorsAsync = ref.watch(userMasterHonorsProvider);
 
     return AnimatedSwitcher(
       duration: const Duration(milliseconds: 300),
-      child: roadmapAsync.when(
+      child: honorsAsync.when(
         loading: () => _MasterHonorProfileSkeleton(
           key: const ValueKey('master-honor-profile-skeleton'),
           showHeader: showHeader,
@@ -66,11 +65,11 @@ class MasterHonorHistorySection extends ConsumerWidget {
         error: (_, __) => _MasterHonorProfileError(
           key: const ValueKey('master-honor-profile-error'),
           showHeader: showHeader,
-          onRetry: () => ref.invalidate(userMasterHonorRoadmapProvider),
+          onRetry: () => ref.invalidate(userMasterHonorsProvider),
         ),
         data: (items) => _MasterHonorProfileSummary(
           key: const ValueKey('master-honor-profile-data'),
-          items: items,
+          honors: items,
           showHeader: showHeader,
         ),
       ),
@@ -81,16 +80,16 @@ class MasterHonorHistorySection extends ConsumerWidget {
 class _MasterHonorProfileSummary extends StatelessWidget {
   const _MasterHonorProfileSummary({
     super.key,
-    required this.items,
+    required this.honors,
     required this.showHeader,
   });
 
-  final List<MasterHonorRoadmap> items;
+  final List<UserMasterHonor> honors;
   final bool showHeader;
 
   @override
   Widget build(BuildContext context) {
-    final awardedItems = items.where((item) => item.isAwarded).toList();
+    final awardedItems = _orderedMasterHonors(honors);
     final totalAwarded = awardedItems.length;
     final label = totalAwarded == 1 ? 'Maestría' : 'Maestrías';
 
@@ -177,11 +176,61 @@ class _MasterHonorProfileSummary extends StatelessWidget {
                       imageUrl: item.masterImage,
                       name: item.name,
                       size: 44,
-                      color: masterHonorAccentColor(item),
+                      color: _masterHonorAccentColor(item),
                     );
                   },
                 ),
               ),
+            ),
+          if (awardedItems.isNotEmpty) ...[
+            const SizedBox(height: 12),
+            ...awardedItems.map(
+              (honor) => _MasterHonorHistoryLine(honor: honor),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+class _MasterHonorHistoryLine extends StatelessWidget {
+  const _MasterHonorHistoryLine({required this.honor});
+
+  final UserMasterHonor honor;
+
+  @override
+  Widget build(BuildContext context) {
+    final textColor = context.sac.textSecondary;
+    final tertiary = context.sac.textTertiary;
+
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 6),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            '${honor.name} · ${_statusLabel(honor)}',
+            style: TextStyle(
+              fontSize: 12,
+              fontWeight: FontWeight.w600,
+              color: textColor,
+            ),
+          ),
+          if (honor.awardedAt != null)
+            Text(
+              'Concedida: ${_formatShortDate(honor.awardedAt!)}',
+              style: TextStyle(fontSize: 11, color: tertiary),
+            ),
+          if (honor.revokedAt != null)
+            Text(
+              'Revocada: ${_formatShortDate(honor.revokedAt!)}',
+              style: TextStyle(fontSize: 11, color: tertiary),
+            ),
+          if (honor.recoveredAt != null)
+            Text(
+              'Recuperada: ${_formatShortDate(honor.recoveredAt!)}',
+              style: TextStyle(fontSize: 11, color: tertiary),
             ),
         ],
       ),
@@ -427,6 +476,22 @@ DateTime? _latestDate(UserMasterHonor honor) {
   ].whereType<DateTime>().toList();
   if (dates.isEmpty) return null;
   return dates.reduce((a, b) => a.isAfter(b) ? a : b);
+}
+
+String _statusLabel(UserMasterHonor honor) {
+  final label = honor.displayStatusLabel.trim();
+  if (label.isNotEmpty) return label;
+  return honor.isCurrent ? 'Vigente' : 'No vigente';
+}
+
+Color _masterHonorAccentColor(UserMasterHonor honor) {
+  return honor.isCurrent ? AppColors.secondary : AppColors.error;
+}
+
+String _formatShortDate(DateTime date) {
+  final day = date.day.toString().padLeft(2, '0');
+  final month = date.month.toString().padLeft(2, '0');
+  return '$day/$month/${date.year}';
 }
 
 bool _isDark(BuildContext context) {


### PR DESCRIPTION
## Summary
- Updates the mobile coordinator surface to consume `/coordination/me/scope` and derive assigned clubs from scoped sections.
- Adds coordinator scope entities/models and keeps multirole quick access available for coordinator roles.
- Removes coordinator camporee approvals from the mobile coordinator surface/push deep-link allowlist.

## Verification
- `flutter test test/features/coordinator/presentation/views/coordinator_clubs_list_view_test.dart`
- `flutter analyze`
- `python3 -m json.tool assets/translations/{es,en,fr,pt-BR}.json`
- `git diff --check`

## Notes
- No build executed per project instruction.
- Read-only API smoke was attempted, but configured E2E admin credentials returned HTTP 401; live endpoint smoke needs valid credentials/token.
