### PR TITLE
feat: redesign evidence folder progress

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -2562,6 +2562,9 @@
       "create_folder_empty": "The folder was requested, but it is not available yet. Try refreshing."
     },
     "title": "Annual Evidence Folder",
+    "overview_label": "{name} · PROGRESS",
+    "search_hint": "Search evidence section…",
+    "no_results_body": "Try another name or description.",
     "section_title": "Section",
     "send": "Send",
     "stay": "Stay",
@@ -2587,6 +2590,8 @@
     "stats": {
       "pending": "Pending",
       "submitted": "Submitted",
+      "preapproved": "Pre-approved",
+      "rejected": "Rejected",
       "validated": "Validated"
     },
     "sections_title": "Sections",

--- a/assets/translations/es.json
+++ b/assets/translations/es.json
@@ -2562,6 +2562,9 @@
       "create_folder_empty": "La carpeta fue solicitada, pero aún no está disponible. Intenta actualizar."
     },
     "title": "Carpeta Anual de Evidencias",
+    "overview_label": "{name} · AVANCE",
+    "search_hint": "Buscar sección de evidencia…",
+    "no_results_body": "Intenta con otro nombre o descripción.",
     "section_title": "Sección",
     "send": "Enviar",
     "stay": "Quedarme",
@@ -2587,6 +2590,8 @@
     "stats": {
       "pending": "Pendientes",
       "submitted": "Enviadas",
+      "preapproved": "Preaprobadas",
+      "rejected": "Rechazadas",
       "validated": "Validadas"
     },
     "sections_title": "Secciones",

--- a/assets/translations/fr.json
+++ b/assets/translations/fr.json
@@ -2562,6 +2562,9 @@
       "create_folder_empty": "Le dossier a été demandé, mais il n'est pas encore disponible. Essayez d'actualiser."
     },
     "title": "Dossier Annuel de Preuves",
+    "overview_label": "{name} · PROGRESSION",
+    "search_hint": "Rechercher une section de preuves…",
+    "no_results_body": "Essayez un autre nom ou une autre description.",
     "section_title": "Section",
     "send": "Envoyer",
     "stay": "Rester",
@@ -2587,6 +2590,8 @@
     "stats": {
       "pending": "En attente",
       "submitted": "Envoyées",
+      "preapproved": "Pré-approuvées",
+      "rejected": "Rejetées",
       "validated": "Validées"
     },
     "sections_title": "Sections",

--- a/assets/translations/pt-BR.json
+++ b/assets/translations/pt-BR.json
@@ -2562,6 +2562,9 @@
       "create_folder_empty": "A pasta foi solicitada, mas ainda não está disponível. Tente atualizar."
     },
     "title": "Pasta Anual de Evidências",
+    "overview_label": "{name} · PROGRESSO",
+    "search_hint": "Buscar seção de evidências…",
+    "no_results_body": "Tente outro nome ou descrição.",
     "section_title": "Seção",
     "send": "Enviar",
     "stay": "Ficar",
@@ -2587,6 +2590,8 @@
     "stats": {
       "pending": "Pendentes",
       "submitted": "Enviadas",
+      "preapproved": "Pré-aprovadas",
+      "rejected": "Rejeitadas",
       "validated": "Validadas"
     },
     "sections_title": "Seções",

--- a/lib/features/evidence_folder/presentation/views/evidence_folder_view.dart
+++ b/lib/features/evidence_folder/presentation/views/evidence_folder_view.dart
@@ -4,7 +4,6 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:hugeicons/hugeicons.dart';
 
 import '../../../../core/animations/page_transitions.dart';
-import '../../../../core/animations/staggered_list_animation.dart';
 import '../../../../core/errors/exceptions.dart';
 import '../../../../core/theme/app_colors.dart';
 import '../../../../core/theme/sac_colors.dart';
@@ -295,27 +294,51 @@ class _FolderBodyState extends ConsumerState<_FolderBody> {
             ),
           ),
 
-          // Sections list
-          SliverList(
-            delegate: SliverChildBuilderDelegate(
-              (context, index) {
-                final section = filteredSections[index];
-                return StaggeredListItem(
-                  index: index,
-                  child: SectionCard(
-                    section: section,
-                    folderIsOpen: folder.isOpen,
-                    onTap: () => _openSectionDetail(section),
-                    onSubmit: folder.isOpen && section.canSubmit
-                        ? () => _handleSectionSubmit(section)
-                        : null,
-                    isSubmitting: _submittingSectionId == section.id,
+          // Compact sections grouped inside one paper container.
+          if (filteredSections.isNotEmpty)
+            SliverToBoxAdapter(
+              child: Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 16),
+                child: Material(
+                  key: const ValueKey('evidence-sections-card'),
+                  color: c.surface,
+                  clipBehavior: Clip.antiAlias,
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(16),
+                    side: BorderSide(color: c.border),
                   ),
-                );
-              },
-              childCount: filteredSections.length,
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      for (var index = 0;
+                          index < filteredSections.length;
+                          index++) ...[
+                        if (index > 0)
+                          Divider(
+                            height: 1,
+                            thickness: 1,
+                            color: c.divider,
+                          ),
+                        SectionCard(
+                          section: filteredSections[index],
+                          folderIsOpen: folder.isOpen,
+                          onTap: () =>
+                              _openSectionDetail(filteredSections[index]),
+                          onSubmit:
+                              folder.isOpen && filteredSections[index].canSubmit
+                                  ? () => _handleSectionSubmit(
+                                        filteredSections[index],
+                                      )
+                                  : null,
+                          isSubmitting: _submittingSectionId ==
+                              filteredSections[index].id,
+                        ),
+                      ],
+                    ],
+                  ),
+                ),
+              ),
             ),
-          ),
 
           SliverToBoxAdapter(
             child: folder.sections.isEmpty

--- a/lib/features/evidence_folder/presentation/views/evidence_folder_view.dart
+++ b/lib/features/evidence_folder/presentation/views/evidence_folder_view.dart
@@ -10,10 +10,10 @@ import '../../../../core/theme/app_colors.dart';
 import '../../../../core/theme/sac_colors.dart';
 import '../../../../core/widgets/sac_button.dart';
 import '../../../../core/widgets/sac_dialog.dart';
-import '../../../../core/widgets/sac_progress_bar.dart';
 import '../../../auth/domain/utils/authorization_utils.dart';
 import '../../../auth/presentation/providers/auth_providers.dart';
 import '../widgets/evidence_folder_loading_skeleton.dart';
+import '../widgets/evidence_folder_overview.dart';
 import '../../domain/entities/evidence_folder.dart';
 import '../../domain/entities/evidence_section.dart';
 import '../providers/evidence_folder_providers.dart';
@@ -97,6 +97,39 @@ class _FolderBody extends ConsumerStatefulWidget {
 class _FolderBodyState extends ConsumerState<_FolderBody> {
   /// Tracks which sectionId is currently being submitted (null = none).
   String? _submittingSectionId;
+  final TextEditingController _searchController = TextEditingController();
+  final FocusNode _searchFocusNode = FocusNode();
+  String _query = '';
+
+  List<EvidenceSection> get _filteredSections {
+    final normalizedQuery = _query.trim().toLowerCase();
+    if (normalizedQuery.isEmpty) return widget.folder.sections;
+
+    return widget.folder.sections.where((section) {
+      final nameMatches = section.name.toLowerCase().contains(normalizedQuery);
+      final descriptionMatches =
+          section.description?.toLowerCase().contains(normalizedQuery) ?? false;
+      return nameMatches || descriptionMatches;
+    }).toList(growable: false);
+  }
+
+  @override
+  void dispose() {
+    _searchController.dispose();
+    _searchFocusNode.dispose();
+    super.dispose();
+  }
+
+  void _handleQueryChanged(String query) {
+    if (query == _query) return;
+    setState(() => _query = query);
+  }
+
+  void _clearQuery() {
+    _searchController.clear();
+    setState(() => _query = '');
+    _searchFocusNode.requestFocus();
+  }
 
   Future<void> _handleSectionSubmit(EvidenceSection section) async {
     final confirmed = await SacDialog.show(
@@ -191,6 +224,7 @@ class _FolderBodyState extends ConsumerState<_FolderBody> {
   Widget build(BuildContext context) {
     final c = context.sac;
     final folder = widget.folder;
+    final filteredSections = _filteredSections;
 
     return RefreshIndicator(
       color: AppColors.primary,
@@ -232,11 +266,9 @@ class _FolderBodyState extends ConsumerState<_FolderBody> {
                 if (folder.isOpen && folder.isUnderEvaluation)
                   _UnderEvaluationBanner(folder: folder),
 
-                // Header card
-                _FolderHeaderCard(folder: folder),
+                EvidenceFolderHero(folder: folder),
 
-                // Progress summary
-                _ProgressSummaryRow(folder: folder),
+                EvidenceStatusPills(sections: folder.sections),
 
                 const SizedBox(height: 8),
 
@@ -251,6 +283,14 @@ class _FolderBodyState extends ConsumerState<_FolderBody> {
                         ),
                   ),
                 ),
+
+                EvidenceSectionSearchField(
+                  controller: _searchController,
+                  focusNode: _searchFocusNode,
+                  query: _query,
+                  onChanged: _handleQueryChanged,
+                  onClear: _clearQuery,
+                ),
               ],
             ),
           ),
@@ -259,7 +299,7 @@ class _FolderBodyState extends ConsumerState<_FolderBody> {
           SliverList(
             delegate: SliverChildBuilderDelegate(
               (context, index) {
-                final section = folder.sections[index];
+                final section = filteredSections[index];
                 return StaggeredListItem(
                   index: index,
                   child: SectionCard(
@@ -273,260 +313,18 @@ class _FolderBodyState extends ConsumerState<_FolderBody> {
                   ),
                 );
               },
-              childCount: folder.sections.length,
+              childCount: filteredSections.length,
             ),
           ),
 
           SliverToBoxAdapter(
             child: folder.sections.isEmpty
                 ? _EmptySections()
-                : const SizedBox(height: 32),
+                : _query.trim().isNotEmpty && filteredSections.isEmpty
+                    ? const EvidenceSearchEmpty()
+                    : const SizedBox(height: 32),
           ),
         ],
-      ),
-    );
-  }
-}
-
-// ── Header card con nombre y estado de la carpeta ─────────────────────────────
-
-class _FolderHeaderCard extends StatelessWidget {
-  final EvidenceFolder folder;
-
-  const _FolderHeaderCard({required this.folder});
-
-  @override
-  Widget build(BuildContext context) {
-    final c = context.sac;
-    final percentage = (folder.completionRatio * 100).toStringAsFixed(0);
-
-    // Status badge colors
-    final statusColor = folder.isOpen ? AppColors.secondary : AppColors.accent;
-    final statusBg =
-        folder.isOpen ? AppColors.secondaryLight : AppColors.accentLight;
-
-    return Container(
-      margin: const EdgeInsets.fromLTRB(16, 12, 16, 0),
-      padding: const EdgeInsets.all(16),
-      decoration: BoxDecoration(
-        color: c.surfaceVariant,
-        borderRadius: BorderRadius.circular(16),
-        border: Border.all(color: c.border),
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          // Nombre + estado en una fila compacta
-          Row(
-            crossAxisAlignment: CrossAxisAlignment.center,
-            children: [
-              Expanded(
-                child: Text(
-                  folder.name,
-                  style: Theme.of(context).textTheme.titleSmall?.copyWith(
-                        fontWeight: FontWeight.w700,
-                        color: c.text,
-                      ),
-                  maxLines: 2,
-                  overflow: TextOverflow.ellipsis,
-                ),
-              ),
-              const SizedBox(width: 10),
-              Container(
-                padding: const EdgeInsets.symmetric(horizontal: 9, vertical: 4),
-                decoration: BoxDecoration(
-                  color: statusBg,
-                  borderRadius: BorderRadius.circular(20),
-                  border: Border.all(
-                    color: statusColor.withValues(alpha: 0.35),
-                  ),
-                ),
-                child: Row(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    HugeIcon(
-                      icon: folder.isOpen
-                          ? HugeIcons.strokeRoundedLock
-                          : HugeIcons.strokeRoundedLocked,
-                      size: 11,
-                      color: statusColor,
-                    ),
-                    const SizedBox(width: 4),
-                    Text(
-                      folder.isOpen
-                          ? 'evidence_folder.status.open'.tr()
-                          : 'evidence_folder.status.closed'.tr(),
-                      style: TextStyle(
-                        fontSize: 11,
-                        fontWeight: FontWeight.w600,
-                        color: statusColor,
-                      ),
-                    ),
-                  ],
-                ),
-              ),
-            ],
-          ),
-
-          if (folder.description != null && folder.description!.isNotEmpty) ...[
-            const SizedBox(height: 6),
-            Text(
-              folder.description!,
-              style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                    color: c.textSecondary,
-                    height: 1.4,
-                  ),
-              maxLines: 2,
-              overflow: TextOverflow.ellipsis,
-            ),
-          ],
-
-          const SizedBox(height: 14),
-          Divider(color: c.divider, height: 1),
-          const SizedBox(height: 12),
-
-          // Progreso + porcentaje inline
-          Row(
-            children: [
-              Expanded(
-                child: SacProgressBar(
-                  progress: folder.completionRatio,
-                  height: 5,
-                  trackColor: c.border,
-                  useGradient: false,
-                  color: AppColors.secondary,
-                  showShimmer: false,
-                ),
-              ),
-              const SizedBox(width: 10),
-              Text(
-                '$percentage%',
-                style: TextStyle(
-                  fontSize: 12,
-                  fontWeight: FontWeight.w700,
-                  color: folder.completionRatio > 0
-                      ? AppColors.secondary
-                      : c.textTertiary,
-                ),
-              ),
-            ],
-          ),
-
-          const SizedBox(height: 10),
-
-          // Puntos — inline, sutil
-          Row(
-            children: [
-              HugeIcon(
-                icon: HugeIcons.strokeRoundedStar,
-                size: 13,
-                color: AppColors.accent,
-              ),
-              const SizedBox(width: 5),
-              Text(
-                'evidence_folder.points_ratio'.tr(namedArgs: {
-                  'earned': '${folder.earnedPoints}',
-                  'max': '${folder.maxPoints}',
-                }),
-                style: TextStyle(
-                  fontSize: 12,
-                  fontWeight: FontWeight.w600,
-                  color: c.textSecondary,
-                ),
-              ),
-            ],
-          ),
-        ],
-      ),
-    );
-  }
-}
-
-// ── Fila resumen de secciones ──────────────────────────────────────────────────
-
-class _ProgressSummaryRow extends StatelessWidget {
-  final EvidenceFolder folder;
-
-  const _ProgressSummaryRow({required this.folder});
-
-  @override
-  Widget build(BuildContext context) {
-    final total = folder.sections.length;
-    final validated = folder.validatedCount;
-    final submitted = folder.submittedCount;
-    final pending = total - validated - submitted;
-
-    return Padding(
-      padding: const EdgeInsets.fromLTRB(16, 10, 16, 0),
-      child: Row(
-        children: [
-          _StatPill(
-            count: pending,
-            label: 'evidence_folder.stats.pending'.tr(),
-            color: AppColors.accent,
-          ),
-          const SizedBox(width: 8),
-          _StatPill(
-            count: submitted,
-            label: 'evidence_folder.stats.submitted'.tr(),
-            color: AppColors.info,
-          ),
-          const SizedBox(width: 8),
-          _StatPill(
-            count: validated,
-            label: 'evidence_folder.stats.validated'.tr(),
-            color: AppColors.secondary,
-          ),
-        ],
-      ),
-    );
-  }
-}
-
-class _StatPill extends StatelessWidget {
-  final int count;
-  final String label;
-  final Color color;
-
-  const _StatPill({
-    required this.count,
-    required this.label,
-    required this.color,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    final c = context.sac;
-    return Expanded(
-      child: Container(
-        padding: const EdgeInsets.symmetric(vertical: 8),
-        decoration: BoxDecoration(
-          color: c.surfaceVariant,
-          borderRadius: BorderRadius.circular(10),
-          border: Border.all(color: c.border),
-        ),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Text(
-              '$count',
-              style: TextStyle(
-                fontSize: 16,
-                fontWeight: FontWeight.w800,
-                color: color,
-              ),
-            ),
-            const SizedBox(height: 1),
-            Text(
-              label,
-              style: TextStyle(
-                fontSize: 10,
-                fontWeight: FontWeight.w500,
-                color: c.textSecondary,
-              ),
-            ),
-          ],
-        ),
       ),
     );
   }

--- a/lib/features/evidence_folder/presentation/widgets/evidence_folder_overview.dart
+++ b/lib/features/evidence_folder/presentation/widgets/evidence_folder_overview.dart
@@ -1,0 +1,490 @@
+import 'package:easy_localization/easy_localization.dart';
+import 'package:flutter/material.dart';
+import 'package:hugeicons/hugeicons.dart';
+
+import '../../../../core/theme/app_colors.dart';
+import '../../../../core/theme/sac_colors.dart';
+import '../../domain/entities/evidence_folder.dart';
+import '../../domain/entities/evidence_section.dart';
+
+/// Hero principal de la carpeta con progreso y estado operativo.
+class EvidenceFolderHero extends StatelessWidget {
+  final EvidenceFolder folder;
+
+  const EvidenceFolderHero({
+    super.key,
+    required this.folder,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final c = context.sac;
+    final progress = folder.completionRatio.clamp(0.0, 1.0).toDouble();
+    final percentage = (progress * 100).round();
+    final status = _folderStatus(folder);
+    final pointsLabel = 'evidence_folder.points_ratio'.tr(namedArgs: {
+      'earned': '${folder.earnedPoints}',
+      'max': '${folder.maxPoints}',
+    });
+
+    return Semantics(
+      key: const ValueKey('evidence-folder-hero'),
+      container: true,
+      label: 'AVANCE: $percentage%, $pointsLabel, ${status.label}',
+      child: Container(
+        margin: const EdgeInsets.fromLTRB(16, 12, 16, 0),
+        padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 18),
+        decoration: BoxDecoration(
+          color: c.surface,
+          borderRadius: BorderRadius.circular(20),
+          border: Border.all(
+            color: status.color.withValues(alpha: 0.2),
+          ),
+        ),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            Expanded(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    folder.name,
+                    maxLines: 2,
+                    overflow: TextOverflow.ellipsis,
+                    style: TextStyle(
+                      fontSize: 11,
+                      fontWeight: FontWeight.w600,
+                      color: c.textTertiary,
+                      letterSpacing: 0.88,
+                    ),
+                  ),
+                  const SizedBox(height: 2),
+                  Text(
+                    'AVANCE',
+                    style: TextStyle(
+                      fontSize: 10,
+                      fontWeight: FontWeight.w700,
+                      color: c.textTertiary,
+                      letterSpacing: 1.1,
+                    ),
+                  ),
+                  const SizedBox(height: 4),
+                  Text(
+                    '$percentage%',
+                    style: const TextStyle(
+                      fontSize: 44,
+                      fontWeight: FontWeight.w800,
+                      color: AppColors.coral500,
+                      height: 1,
+                      letterSpacing: -1.3,
+                      fontFeatures: [FontFeature.tabularFigures()],
+                    ),
+                  ),
+                  const SizedBox(height: 10),
+                  Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      const HugeIcon(
+                        icon: HugeIcons.strokeRoundedStar,
+                        size: 15,
+                        color: AppColors.accentDark,
+                      ),
+                      const SizedBox(width: 5),
+                      Flexible(
+                        child: Text(
+                          pointsLabel,
+                          style: TextStyle(
+                            fontSize: 12.5,
+                            fontWeight: FontWeight.w700,
+                            color: c.textSecondary,
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 8),
+                  _FolderStatusBadge(status: status),
+                ],
+              ),
+            ),
+            const SizedBox(width: 16),
+            SizedBox(
+              width: 64,
+              height: 64,
+              child: Stack(
+                alignment: Alignment.center,
+                children: [
+                  SizedBox.expand(
+                    child: CircularProgressIndicator(
+                      value: progress,
+                      strokeWidth: 6,
+                      strokeCap: StrokeCap.round,
+                      backgroundColor: c.borderLight,
+                      color: AppColors.coral500,
+                    ),
+                  ),
+                  Container(
+                    width: 40,
+                    height: 40,
+                    decoration: BoxDecoration(
+                      color: AppColors.coral50,
+                      borderRadius: BorderRadius.circular(12),
+                    ),
+                    alignment: Alignment.center,
+                    child: const HugeIcon(
+                      icon: HugeIcons.strokeRoundedFolder01,
+                      size: 23,
+                      color: AppColors.coral600,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _FolderStatusBadge extends StatelessWidget {
+  final _FolderStatus status;
+
+  const _FolderStatusBadge({required this.status});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 9, vertical: 5),
+      decoration: BoxDecoration(
+        color: status.color.withValues(alpha: 0.12),
+        borderRadius: BorderRadius.circular(20),
+        border: Border.all(color: status.color.withValues(alpha: 0.35)),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          HugeIcon(icon: status.icon, size: 13, color: status.color),
+          const SizedBox(width: 5),
+          Flexible(
+            child: Text(
+              status.label,
+              style: TextStyle(
+                fontSize: 11,
+                fontWeight: FontWeight.w700,
+                color: status.color,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Conteos independientes de secciones por cada estado del backend.
+class EvidenceStatusPills extends StatelessWidget {
+  final List<EvidenceSection> sections;
+
+  const EvidenceStatusPills({
+    super.key,
+    required this.sections,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final statuses = [
+      _SectionStatusPillData(
+        keyName: 'evidence-status-validated',
+        status: EvidenceSectionStatus.validated,
+        label: 'evidence_folder.status.validated'.tr(),
+        icon: HugeIcons.strokeRoundedCheckmarkCircle02,
+        color: context.sac.success,
+      ),
+      _SectionStatusPillData(
+        keyName: 'evidence-status-preapproved',
+        status: EvidenceSectionStatus.preapprovedLf,
+        label: 'evidence_folder.status.preapproved'.tr(),
+        icon: HugeIcons.strokeRoundedAnalytics01,
+        color: context.sac.warning,
+      ),
+      _SectionStatusPillData(
+        keyName: 'evidence-status-submitted',
+        status: EvidenceSectionStatus.submitted,
+        label: 'evidence_folder.status.submitted'.tr(),
+        icon: HugeIcons.strokeRoundedSent,
+        color: context.sac.info,
+      ),
+      _SectionStatusPillData(
+        keyName: 'evidence-status-rejected',
+        status: EvidenceSectionStatus.rejected,
+        label: 'evidence_folder.status.rejected'.tr(),
+        icon: HugeIcons.strokeRoundedCancelCircle,
+        color: context.sac.error,
+      ),
+      _SectionStatusPillData(
+        keyName: 'evidence-status-pending',
+        status: EvidenceSectionStatus.pending,
+        label: 'evidence_folder.status.pending'.tr(),
+        icon: HugeIcons.strokeRoundedClock01,
+        color: context.sac.textSecondary,
+      ),
+    ];
+
+    return SingleChildScrollView(
+      scrollDirection: Axis.horizontal,
+      padding: const EdgeInsets.fromLTRB(16, 10, 16, 0),
+      child: Row(
+        children: [
+          for (var index = 0; index < statuses.length; index++) ...[
+            _EvidenceStatusPill(
+              data: statuses[index],
+              count: sections
+                  .where((section) => section.status == statuses[index].status)
+                  .length,
+            ),
+            if (index != statuses.length - 1) const SizedBox(width: 8),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+class _EvidenceStatusPill extends StatelessWidget {
+  final _SectionStatusPillData data;
+  final int count;
+
+  const _EvidenceStatusPill({
+    required this.data,
+    required this.count,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      label: '${data.label}: $count',
+      child: Container(
+        key: ValueKey(data.keyName),
+        constraints: const BoxConstraints(minHeight: 42),
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+        decoration: BoxDecoration(
+          color: data.color.withValues(alpha: 0.1),
+          borderRadius: BorderRadius.circular(12),
+          border: Border.all(color: data.color.withValues(alpha: 0.28)),
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            HugeIcon(icon: data.icon, size: 15, color: data.color),
+            const SizedBox(width: 6),
+            Text(
+              '$count',
+              style: TextStyle(
+                fontSize: 15,
+                fontWeight: FontWeight.w800,
+                color: data.color,
+              ),
+            ),
+            const SizedBox(width: 5),
+            Text(
+              data.label,
+              style: TextStyle(
+                fontSize: 11.5,
+                fontWeight: FontWeight.w600,
+                color: context.sac.textSecondary,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// Campo de búsqueda controlado para filtrar las secciones visibles.
+class EvidenceSectionSearchField extends StatelessWidget {
+  final TextEditingController controller;
+  final FocusNode focusNode;
+  final String query;
+  final ValueChanged<String> onChanged;
+  final VoidCallback onClear;
+
+  const EvidenceSectionSearchField({
+    super.key,
+    required this.controller,
+    required this.focusNode,
+    required this.query,
+    required this.onChanged,
+    required this.onClear,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final c = context.sac;
+
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 6, 16, 6),
+      child: AnimatedBuilder(
+        animation: focusNode,
+        builder: (context, child) {
+          final isFocused = focusNode.hasFocus;
+          return TextField(
+            key: const ValueKey('evidence-section-search'),
+            controller: controller,
+            focusNode: focusNode,
+            onChanged: onChanged,
+            textInputAction: TextInputAction.search,
+            decoration: InputDecoration(
+              hintText: 'evidence_folder.search_hint'.tr(),
+              prefixIcon: HugeIcon(
+                icon: HugeIcons.strokeRoundedSearch01,
+                size: 20,
+                color: isFocused ? AppColors.coral600 : c.textTertiary,
+              ),
+              suffixIcon: query.isEmpty
+                  ? null
+                  : Semantics(
+                      button: true,
+                      label: 'common.clear'.tr(),
+                      child: SizedBox(
+                        width: 48,
+                        height: 48,
+                        child: IconButton(
+                          tooltip: 'common.clear'.tr(),
+                          onPressed: onClear,
+                          icon: HugeIcon(
+                            icon: HugeIcons.strokeRoundedCancel01,
+                            size: 19,
+                            color: c.textSecondary,
+                          ),
+                        ),
+                      ),
+                    ),
+              filled: true,
+              fillColor: c.surface,
+              contentPadding:
+                  const EdgeInsets.symmetric(horizontal: 14, vertical: 14),
+              enabledBorder: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(14),
+                borderSide: BorderSide(color: c.border),
+              ),
+              focusedBorder: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(14),
+                borderSide:
+                    const BorderSide(color: AppColors.coral500, width: 1.5),
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}
+
+/// Estado vacío cuando una consulta no coincide con ninguna sección.
+class EvidenceSearchEmpty extends StatelessWidget {
+  const EvidenceSearchEmpty({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final c = context.sac;
+    return Padding(
+      key: const ValueKey('evidence-search-empty'),
+      padding: const EdgeInsets.symmetric(horizontal: 40, vertical: 44),
+      child: Column(
+        children: [
+          HugeIcon(
+            icon: HugeIcons.strokeRoundedSearchRemove,
+            size: 48,
+            color: c.textTertiary,
+          ),
+          const SizedBox(height: 12),
+          Text(
+            'common.no_results'.tr(),
+            textAlign: TextAlign.center,
+            style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                  fontWeight: FontWeight.w700,
+                  color: c.text,
+                ),
+          ),
+          const SizedBox(height: 6),
+          Text(
+            'evidence_folder.search_empty_hint'.tr(),
+            textAlign: TextAlign.center,
+            style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                  color: c.textSecondary,
+                  height: 1.4,
+                ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _FolderStatus {
+  final String label;
+  final List<List<dynamic>> icon;
+  final Color color;
+
+  const _FolderStatus({
+    required this.label,
+    required this.icon,
+    required this.color,
+  });
+}
+
+_FolderStatus _folderStatus(EvidenceFolder folder) {
+  if (folder.isEvaluated) {
+    return _FolderStatus(
+      label: 'evidence_folder.status.validated'.tr(),
+      icon: HugeIcons.strokeRoundedCheckmarkCircle02,
+      color: AppColors.secondaryDark,
+    );
+  }
+  if (folder.isUnderEvaluation) {
+    return _FolderStatus(
+      label: 'evidence_folder.evaluation_banner.title'.tr(),
+      icon: HugeIcons.strokeRoundedAnalytics01,
+      color: AppColors.accentDark,
+    );
+  }
+  if (!folder.isOpen || folder.status == 'closed') {
+    return _FolderStatus(
+      label: 'evidence_folder.status.closed'.tr(),
+      icon: HugeIcons.strokeRoundedLocked,
+      color: AppColors.errorDark,
+    );
+  }
+  if (folder.status == 'submitted') {
+    return _FolderStatus(
+      label: 'evidence_folder.status.submitted'.tr(),
+      icon: HugeIcons.strokeRoundedSent,
+      color: AppColors.info,
+    );
+  }
+  return _FolderStatus(
+    label: 'evidence_folder.status.open'.tr(),
+    icon: HugeIcons.strokeRoundedLock,
+    color: AppColors.secondaryDark,
+  );
+}
+
+class _SectionStatusPillData {
+  final String keyName;
+  final EvidenceSectionStatus status;
+  final String label;
+  final List<List<dynamic>> icon;
+  final Color color;
+
+  const _SectionStatusPillData({
+    required this.keyName,
+    required this.status,
+    required this.label,
+    required this.icon,
+    required this.color,
+  });
+}

--- a/lib/features/evidence_folder/presentation/widgets/evidence_folder_overview.dart
+++ b/lib/features/evidence_folder/presentation/widgets/evidence_folder_overview.dart
@@ -26,11 +26,14 @@ class EvidenceFolderHero extends StatelessWidget {
       'earned': '${folder.earnedPoints}',
       'max': '${folder.maxPoints}',
     });
+    final overviewLabel = 'evidence_folder.overview_label'.tr(namedArgs: {
+      'name': folder.name,
+    });
 
     return Semantics(
       key: const ValueKey('evidence-folder-hero'),
       container: true,
-      label: 'AVANCE: $percentage%, $pointsLabel, ${status.label}',
+      label: '$overviewLabel: $percentage%, $pointsLabel, ${status.label}',
       child: Container(
         margin: const EdgeInsets.fromLTRB(16, 12, 16, 0),
         padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 18),
@@ -50,7 +53,7 @@ class EvidenceFolderHero extends StatelessWidget {
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
                   Text(
-                    folder.name,
+                    overviewLabel,
                     maxLines: 2,
                     overflow: TextOverflow.ellipsis,
                     style: TextStyle(
@@ -58,16 +61,6 @@ class EvidenceFolderHero extends StatelessWidget {
                       fontWeight: FontWeight.w600,
                       color: c.textTertiary,
                       letterSpacing: 0.88,
-                    ),
-                  ),
-                  const SizedBox(height: 2),
-                  Text(
-                    'AVANCE',
-                    style: TextStyle(
-                      fontSize: 10,
-                      fontWeight: FontWeight.w700,
-                      color: c.textTertiary,
-                      letterSpacing: 1.1,
                     ),
                   ),
                   const SizedBox(height: 4),
@@ -350,6 +343,9 @@ class EvidenceSectionSearchField extends StatelessWidget {
                       button: true,
                       label: 'common.clear'.tr(),
                       child: SizedBox(
+                        key: const ValueKey(
+                          'evidence-section-search-clear',
+                        ),
                         width: 48,
                         height: 48,
                         child: IconButton(
@@ -412,7 +408,7 @@ class EvidenceSearchEmpty extends StatelessWidget {
           ),
           const SizedBox(height: 6),
           Text(
-            'evidence_folder.search_empty_hint'.tr(),
+            'evidence_folder.no_results_body'.tr(),
             textAlign: TextAlign.center,
             style: Theme.of(context).textTheme.bodySmall?.copyWith(
                   color: c.textSecondary,

--- a/lib/features/evidence_folder/presentation/widgets/evidence_folder_overview.dart
+++ b/lib/features/evidence_folder/presentation/widgets/evidence_folder_overview.dart
@@ -452,18 +452,18 @@ _FolderStatus _folderStatus(EvidenceFolder folder) {
       color: AppColors.accentDark,
     );
   }
-  if (!folder.isOpen || folder.status == 'closed') {
-    return _FolderStatus(
-      label: 'evidence_folder.status.closed'.tr(),
-      icon: HugeIcons.strokeRoundedLocked,
-      color: AppColors.errorDark,
-    );
-  }
   if (folder.status == 'submitted') {
     return _FolderStatus(
       label: 'evidence_folder.status.submitted'.tr(),
       icon: HugeIcons.strokeRoundedSent,
       color: AppColors.info,
+    );
+  }
+  if (folder.status == 'closed' || !folder.isOpen) {
+    return _FolderStatus(
+      label: 'evidence_folder.status.closed'.tr(),
+      icon: HugeIcons.strokeRoundedLocked,
+      color: AppColors.errorDark,
     );
   }
   return _FolderStatus(

--- a/lib/features/evidence_folder/presentation/widgets/section_card.dart
+++ b/lib/features/evidence_folder/presentation/widgets/section_card.dart
@@ -7,25 +7,18 @@ import '../../../../core/theme/sac_colors.dart';
 import '../../domain/entities/evidence_section.dart';
 import 'section_status_badge.dart';
 
-/// Tarjeta que resume una [EvidenceSection] en la vista de carpeta.
-///
-/// Cuando [folderIsOpen] es true y la sección tiene [EvidenceSection.canSubmit]
-/// en true, muestra un botón "Enviar a validación" que invoca [onSubmit].
+/// Compact row that summarizes an [EvidenceSection] inside the grouped list.
 class SectionCard extends StatelessWidget {
   final EvidenceSection section;
   final VoidCallback onTap;
 
-  /// Si la carpeta está abierta. Controla visibilidad del botón de envío.
+  /// Whether the folder accepts mutations. Controls the submit action.
   final bool folderIsOpen;
 
-  /// Callback opcional para enviar la sección a validación.
-  ///
-  /// Si es null o [folderIsOpen] es false, el botón no se muestra.
+  /// Callback for submitting the section for validation.
   final VoidCallback? onSubmit;
 
-  /// Indica si el envío de esta sección está en progreso.
-  ///
-  /// Cuando es true, el botón muestra un estado de carga.
+  /// Whether this section is currently being submitted.
   final bool isSubmitting;
 
   const SectionCard({
@@ -41,288 +34,110 @@ class SectionCard extends StatelessWidget {
   Widget build(BuildContext context) {
     final c = context.sac;
     final dateFormat = DateFormat('d MMM yyyy, HH:mm', 'es');
+    final showSubmitAction =
+        folderIsOpen && section.canSubmit && onSubmit != null;
+    final textScaler = MediaQuery.textScalerOf(context).clamp(
+      maxScaleFactor: 1.3,
+    );
 
-    return GestureDetector(
-      onTap: onTap,
-      child: Container(
-        margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 6),
-        decoration: BoxDecoration(
-          color: c.surface,
-          borderRadius: BorderRadius.circular(16),
-          border: Border.all(color: c.border),
-          boxShadow: [
-            BoxShadow(
-              color: c.shadow,
-              blurRadius: 8,
-              offset: const Offset(0, 2),
-            ),
-          ],
-        ),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            // Header
-            Padding(
-              padding: const EdgeInsets.fromLTRB(16, 14, 16, 10),
-              child: Row(
-                crossAxisAlignment: CrossAxisAlignment.start,
+    return Material(
+      key: ValueKey('evidence-section-${section.id}'),
+      color: Colors.transparent,
+      child: InkWell(
+        onTap: onTap,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                crossAxisAlignment: CrossAxisAlignment.center,
                 children: [
+                  _SectionProgressIndicator(section: section),
+                  const SizedBox(width: 12),
                   Expanded(
                     child: Column(
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
                         Text(
                           section.name,
+                          maxLines: 2,
+                          overflow: TextOverflow.ellipsis,
+                          textScaler: textScaler,
                           style:
                               Theme.of(context).textTheme.titleSmall?.copyWith(
                                     fontWeight: FontWeight.w700,
                                     color: c.text,
+                                    height: 1.2,
                                   ),
                         ),
-                        if (section.description != null &&
-                            section.description!.isNotEmpty) ...[
+                        if (section.description case final description?
+                            when description.isNotEmpty) ...[
                           const SizedBox(height: 3),
                           Text(
-                            section.description!,
+                            description,
                             maxLines: 2,
                             overflow: TextOverflow.ellipsis,
+                            textScaler: textScaler,
                             style:
                                 Theme.of(context).textTheme.bodySmall?.copyWith(
                                       color: c.textSecondary,
-                                      height: 1.4,
+                                      height: 1.35,
                                     ),
                           ),
                         ],
+                        const SizedBox(height: 8),
+                        Wrap(
+                          spacing: 10,
+                          runSpacing: 6,
+                          crossAxisAlignment: WrapCrossAlignment.center,
+                          children: [
+                            SectionStatusBadge(status: section.status),
+                            _CompactMetric(
+                              icon: HugeIcons.strokeRoundedStar,
+                              label:
+                                  'evidence_folder.points_ratio'.tr(namedArgs: {
+                                'earned': '${section.earnedPoints}',
+                                'max': '${section.pointValue}',
+                              }),
+                            ),
+                            _CompactMetric(
+                              icon: HugeIcons.strokeRoundedFiles01,
+                              label:
+                                  'evidence_folder.files_ratio'.tr(namedArgs: {
+                                'current': '${section.files.length}',
+                                'max': '${section.maxFiles}',
+                              }),
+                            ),
+                          ],
+                        ),
                       ],
                     ),
                   ),
-                  const SizedBox(width: 10),
-                  SectionStatusBadge(status: section.status),
-                ],
-              ),
-            ),
-
-            Divider(height: 1, color: c.divider),
-
-            // Stats row
-            Padding(
-              padding: const EdgeInsets.fromLTRB(16, 10, 16, 10),
-              child: Row(
-                children: [
-                  _StatItem(
-                    icon: HugeIcons.strokeRoundedStar,
-                    label: 'evidence_folder.points_ratio'.tr(namedArgs: {
-                      'earned': '${section.earnedPoints}',
-                      'max': '${section.pointValue}',
-                    }),
-                    color: section.status == EvidenceSectionStatus.validated
-                        ? AppColors.secondary
-                        : c.textSecondary,
-                    context: context,
-                  ),
-                  const SizedBox(width: 16),
-                  _StatItem(
-                    icon: HugeIcons.strokeRoundedPercent,
-                    label: '${section.percentage.toStringAsFixed(1)}%',
-                    color: c.textSecondary,
-                    context: context,
-                  ),
-                  const SizedBox(width: 16),
-                  _StatItem(
-                    icon: HugeIcons.strokeRoundedFiles01,
-                    label: 'evidence_folder.files_ratio'.tr(namedArgs: {
-                      'current': '${section.files.length}',
-                      'max': '${section.maxFiles}',
-                    }),
-                    color: c.textSecondary,
-                    context: context,
-                  ),
-                  const Spacer(),
+                  const SizedBox(width: 8),
                   HugeIcon(
                     icon: HugeIcons.strokeRoundedArrowRight01,
-                    size: 18,
+                    size: 19,
                     color: c.textTertiary,
                   ),
                 ],
               ),
-            ),
-
-            // Trazabilidad (si aplica)
-            if (section.submittedByName != null ||
-                section.lfApproverName != null ||
-                section.unionApproverName != null) ...[
-              Divider(height: 1, color: c.divider),
-              Padding(
-                padding: const EdgeInsets.fromLTRB(16, 8, 16, 10),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    if (section.submittedByName != null)
-                      _TraceRow(
-                        icon: HugeIcons.strokeRoundedSent,
-                        color: Theme.of(context).brightness == Brightness.dark
-                            ? AppColors.statusInfoTextDark
-                            : AppColors.statusInfoText,
-                        text: 'evidence_folder.trace.sent_by'.tr(namedArgs: {
-                          'name': section.submittedByName!,
-                          'date': section.submittedAt != null
-                              ? ' · ${dateFormat.format(section.submittedAt!.toLocal())}'
-                              : '',
-                        }),
-                        context: context,
-                      ),
-                    if (section.lfApproverName != null) ...[
-                      if (section.submittedByName != null)
-                        const SizedBox(height: 4),
-                      _TraceRow(
-                        icon: HugeIcons.strokeRoundedAnalytics01,
-                        color: AppColors.accentDark,
-                        text: 'evidence_folder.trace.preapproved_by'
-                            .tr(namedArgs: {
-                          'name': section.lfApproverName!,
-                          'date': section.lfApprovedAt != null
-                              ? ' · ${dateFormat.format(section.lfApprovedAt!.toLocal())}'
-                              : '',
-                        }),
-                        context: context,
-                      ),
-                    ],
-                    if (section.unionApproverName != null) ...[
-                      if (section.submittedByName != null ||
-                          section.lfApproverName != null)
-                        const SizedBox(height: 4),
-                      _TraceRow(
-                        icon: HugeIcons.strokeRoundedCheckmarkCircle01,
-                        color: AppColors.secondaryDark,
-                        text:
-                            'evidence_folder.trace.validated_by'.tr(namedArgs: {
-                          'name': section.unionApproverName!,
-                          'date': section.unionApprovedAt != null
-                              ? ' · ${dateFormat.format(section.unionApprovedAt!.toLocal())}'
-                              : '',
-                        }),
-                        context: context,
-                      ),
-                    ],
-                    if (section.evaluationNotes != null &&
-                        section.evaluationNotes!.isNotEmpty) ...[
-                      const SizedBox(height: 6),
-                      Container(
-                        width: double.infinity,
-                        padding: const EdgeInsets.all(8),
-                        decoration: BoxDecoration(
-                          color: AppColors.secondaryLight,
-                          borderRadius: BorderRadius.circular(8),
-                        ),
-                        child: Text(
-                          section.evaluationNotes!,
-                          style:
-                              Theme.of(context).textTheme.labelSmall?.copyWith(
-                                    color: AppColors.secondaryDark,
-                                    height: 1.4,
-                                  ),
-                        ),
-                      ),
-                    ],
-                  ],
+              if (_hasTraceability(section)) ...[
+                const SizedBox(height: 10),
+                _TraceabilitySummary(
+                  section: section,
+                  dateFormat: dateFormat,
                 ),
-              ),
-            ],
-
-            // Botón de envío a validación (solo cuando la sección puede enviarse)
-            if (folderIsOpen && section.canSubmit && onSubmit != null) ...[
-              Divider(height: 1, color: c.divider),
-              Padding(
-                padding: const EdgeInsets.fromLTRB(12, 10, 12, 12),
-                child: _SubmitSectionButton(
+              ],
+              if (showSubmitAction) ...[
+                const SizedBox(height: 10),
+                _SubmitSectionButton(
+                  key: ValueKey('evidence-section-submit-${section.id}'),
                   isSubmitting: isSubmitting,
                   onSubmit: onSubmit!,
                 ),
-              ),
+              ],
             ],
-          ],
-        ),
-      ),
-    );
-  }
-}
-
-/// Botón de envío a validación dentro de la tarjeta de sección.
-///
-/// Muestra un estado de carga cuando [isSubmitting] es true y llama
-/// a [onSubmit] al ser presionado.
-class _SubmitSectionButton extends StatelessWidget {
-  final bool isSubmitting;
-  final VoidCallback onSubmit;
-
-  const _SubmitSectionButton({
-    required this.isSubmitting,
-    required this.onSubmit,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    return SizedBox(
-      width: double.infinity,
-      child: Material(
-        color: Colors.transparent,
-        child: InkWell(
-          onTap: isSubmitting ? null : onSubmit,
-          borderRadius: BorderRadius.circular(10),
-          child: Ink(
-            decoration: BoxDecoration(
-              color: isSubmitting
-                  ? AppColors.info.withValues(alpha: 0.08)
-                  : AppColors.info.withValues(alpha: 0.12),
-              borderRadius: BorderRadius.circular(10),
-              border: Border.all(
-                color: AppColors.info.withValues(alpha: 0.35),
-              ),
-            ),
-            child: Padding(
-              padding: const EdgeInsets.symmetric(vertical: 10, horizontal: 14),
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [
-                  if (isSubmitting) ...[
-                    SizedBox(
-                      width: 14,
-                      height: 14,
-                      child: CircularProgressIndicator(
-                        strokeWidth: 2,
-                        valueColor: AlwaysStoppedAnimation<Color>(
-                          AppColors.info,
-                        ),
-                      ),
-                    ),
-                    const SizedBox(width: 8),
-                    Text(
-                      'evidence_folder.sending'.tr(),
-                      style: TextStyle(
-                        fontSize: 13,
-                        fontWeight: FontWeight.w600,
-                        color: AppColors.info,
-                      ),
-                    ),
-                  ] else ...[
-                    HugeIcon(
-                      icon: HugeIcons.strokeRoundedSent,
-                      size: 15,
-                      color: AppColors.info,
-                    ),
-                    const SizedBox(width: 6),
-                    Text(
-                      'evidence_folder.send_to_validation'.tr(),
-                      style: TextStyle(
-                        fontSize: 13,
-                        fontWeight: FontWeight.w600,
-                        color: AppColors.info,
-                      ),
-                    ),
-                  ],
-                ],
-              ),
-            ),
           ),
         ),
       ),
@@ -330,30 +145,78 @@ class _SubmitSectionButton extends StatelessWidget {
   }
 }
 
-class _StatItem extends StatelessWidget {
-  final List<List<dynamic>> icon;
-  final String label;
-  final Color color;
-  final BuildContext context;
+class _SectionProgressIndicator extends StatelessWidget {
+  final EvidenceSection section;
 
-  const _StatItem({
-    required this.icon,
-    required this.label,
-    required this.color,
-    required this.context,
-  });
+  const _SectionProgressIndicator({required this.section});
 
   @override
-  Widget build(BuildContext _) {
+  Widget build(BuildContext context) {
+    final c = context.sac;
+    final filesProgress = section.maxFiles <= 0
+        ? 0.0
+        : (section.files.length / section.maxFiles).clamp(0.0, 1.0);
+    final statusLabel = _statusLabel(section.status);
+    final filesLabel = 'evidence_folder.files_ratio'.tr(namedArgs: {
+      'current': '${section.files.length}',
+      'max': '${section.maxFiles}',
+    });
+    final color = _statusColor(section.status);
+
+    return Semantics(
+      label:
+          '${'evidence_folder.section_status_label'.tr()}: $statusLabel. $filesLabel',
+      child: ExcludeSemantics(
+        child: SizedBox(
+          width: 40,
+          height: 40,
+          child: Stack(
+            alignment: Alignment.center,
+            children: [
+              SizedBox(
+                width: 40,
+                height: 40,
+                child: CircularProgressIndicator(
+                  value: filesProgress,
+                  strokeWidth: 3,
+                  backgroundColor: c.divider,
+                  valueColor: AlwaysStoppedAnimation<Color>(color),
+                ),
+              ),
+              HugeIcon(
+                icon: _statusIcon(section.status),
+                size: 17,
+                color: color,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _CompactMetric extends StatelessWidget {
+  final List<List<dynamic>> icon;
+  final String label;
+
+  const _CompactMetric({required this.icon, required this.label});
+
+  @override
+  Widget build(BuildContext context) {
+    final c = context.sac;
+
     return Row(
       mainAxisSize: MainAxisSize.min,
       children: [
-        HugeIcon(icon: icon, size: 13, color: color),
+        HugeIcon(icon: icon, size: 13, color: c.textSecondary),
         const SizedBox(width: 4),
         Text(
           label,
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
           style: Theme.of(context).textTheme.labelSmall?.copyWith(
-                color: color,
+                color: c.textSecondary,
                 fontWeight: FontWeight.w600,
               ),
         ),
@@ -362,21 +225,163 @@ class _StatItem extends StatelessWidget {
   }
 }
 
+class _TraceabilitySummary extends StatelessWidget {
+  final EvidenceSection section;
+  final DateFormat dateFormat;
+
+  const _TraceabilitySummary({
+    required this.section,
+    required this.dateFormat,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final rows = <Widget>[];
+
+    if (section.submittedByName != null) {
+      rows.add(
+        _TraceRow(
+          icon: HugeIcons.strokeRoundedSent,
+          color: AppColors.info,
+          text: 'evidence_folder.trace.sent_by'.tr(namedArgs: {
+            'name': section.submittedByName!,
+            'date': _formattedDate(section.submittedAt),
+          }),
+        ),
+      );
+    }
+    if (section.lfApproverName != null) {
+      rows.add(
+        _TraceRow(
+          icon: HugeIcons.strokeRoundedAnalytics01,
+          color: AppColors.accentDark,
+          text: 'evidence_folder.trace.preapproved_by'.tr(namedArgs: {
+            'name': section.lfApproverName!,
+            'date': _formattedDate(section.lfApprovedAt),
+          }),
+        ),
+      );
+    }
+    if (section.unionApproverName != null) {
+      rows.add(
+        _TraceRow(
+          icon: HugeIcons.strokeRoundedCheckmarkCircle01,
+          color: AppColors.secondaryDark,
+          text: 'evidence_folder.trace.validated_by'.tr(namedArgs: {
+            'name': section.unionApproverName!,
+            'date': _formattedDate(section.unionApprovedAt),
+          }),
+        ),
+      );
+    }
+    if (section.evaluationNotes case final notes? when notes.isNotEmpty) {
+      rows.add(
+        _TraceRow(
+          icon: HugeIcons.strokeRoundedNote,
+          color: context.sac.textSecondary,
+          text: notes,
+        ),
+      );
+    }
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        for (var index = 0; index < rows.length; index++) ...[
+          if (index > 0) const SizedBox(height: 4),
+          rows[index],
+        ],
+      ],
+    );
+  }
+
+  String _formattedDate(DateTime? date) =>
+      date == null ? '' : ' · ${dateFormat.format(date.toLocal())}';
+}
+
+class _SubmitSectionButton extends StatelessWidget {
+  final bool isSubmitting;
+  final VoidCallback onSubmit;
+
+  const _SubmitSectionButton({
+    super.key,
+    required this.isSubmitting,
+    required this.onSubmit,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      button: true,
+      enabled: !isSubmitting,
+      label: isSubmitting
+          ? 'evidence_folder.sending'.tr()
+          : 'evidence_folder.send_to_validation'.tr(),
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(minWidth: 48, minHeight: 48),
+        child: Material(
+          color: AppColors.info.withValues(alpha: 0.1),
+          borderRadius: BorderRadius.circular(12),
+          child: InkWell(
+            // Keep the nested action in the gesture arena while loading so a
+            // tap never falls through to the parent row navigation.
+            onTap: isSubmitting ? () {} : onSubmit,
+            borderRadius: BorderRadius.circular(12),
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 14),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  if (isSubmitting)
+                    SizedBox(
+                      width: 16,
+                      height: 16,
+                      child: CircularProgressIndicator(
+                        strokeWidth: 2,
+                        valueColor:
+                            AlwaysStoppedAnimation<Color>(AppColors.info),
+                      ),
+                    )
+                  else
+                    HugeIcon(
+                      icon: HugeIcons.strokeRoundedSent,
+                      size: 16,
+                      color: AppColors.info,
+                    ),
+                  const SizedBox(width: 8),
+                  Text(
+                    isSubmitting
+                        ? 'evidence_folder.sending'.tr()
+                        : 'evidence_folder.send_to_validation'.tr(),
+                    style: TextStyle(
+                      fontSize: 13,
+                      fontWeight: FontWeight.w700,
+                      color: AppColors.info,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
 class _TraceRow extends StatelessWidget {
   final List<List<dynamic>> icon;
   final Color color;
   final String text;
-  final BuildContext context;
 
   const _TraceRow({
     required this.icon,
     required this.color,
     required this.text,
-    required this.context,
   });
 
   @override
-  Widget build(BuildContext _) {
+  Widget build(BuildContext context) {
     return Row(
       children: [
         HugeIcon(icon: icon, size: 12, color: color),
@@ -384,14 +389,66 @@ class _TraceRow extends StatelessWidget {
         Expanded(
           child: Text(
             text,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
             style: Theme.of(context).textTheme.labelSmall?.copyWith(
                   color: color,
                   height: 1.3,
                 ),
-            overflow: TextOverflow.ellipsis,
           ),
         ),
       ],
     );
+  }
+}
+
+bool _hasTraceability(EvidenceSection section) =>
+    section.submittedByName != null ||
+    section.lfApproverName != null ||
+    section.unionApproverName != null ||
+    (section.evaluationNotes?.isNotEmpty ?? false);
+
+String _statusLabel(EvidenceSectionStatus status) {
+  switch (status) {
+    case EvidenceSectionStatus.pending:
+      return 'evidence_folder.status.pending'.tr();
+    case EvidenceSectionStatus.submitted:
+      return 'evidence_folder.status.submitted'.tr();
+    case EvidenceSectionStatus.preapprovedLf:
+      return 'evidence_folder.status.preapproved'.tr();
+    case EvidenceSectionStatus.validated:
+      return 'evidence_folder.status.validated'.tr();
+    case EvidenceSectionStatus.rejected:
+      return 'evidence_folder.status.rejected'.tr();
+  }
+}
+
+Color _statusColor(EvidenceSectionStatus status) {
+  switch (status) {
+    case EvidenceSectionStatus.pending:
+      return AppColors.accentDark;
+    case EvidenceSectionStatus.submitted:
+      return AppColors.info;
+    case EvidenceSectionStatus.preapprovedLf:
+      return AppColors.accent;
+    case EvidenceSectionStatus.validated:
+      return AppColors.secondary;
+    case EvidenceSectionStatus.rejected:
+      return AppColors.error;
+  }
+}
+
+List<List<dynamic>> _statusIcon(EvidenceSectionStatus status) {
+  switch (status) {
+    case EvidenceSectionStatus.pending:
+      return HugeIcons.strokeRoundedClock01;
+    case EvidenceSectionStatus.submitted:
+      return HugeIcons.strokeRoundedSent;
+    case EvidenceSectionStatus.preapprovedLf:
+      return HugeIcons.strokeRoundedAnalytics01;
+    case EvidenceSectionStatus.validated:
+      return HugeIcons.strokeRoundedCheckmarkCircle01;
+    case EvidenceSectionStatus.rejected:
+      return HugeIcons.strokeRoundedCancel01;
   }
 }

--- a/lib/features/evidence_folder/presentation/widgets/section_card.dart
+++ b/lib/features/evidence_folder/presentation/widgets/section_card.dart
@@ -5,7 +5,6 @@ import 'package:hugeicons/hugeicons.dart';
 import '../../../../core/theme/app_colors.dart';
 import '../../../../core/theme/sac_colors.dart';
 import '../../domain/entities/evidence_section.dart';
-import 'section_status_badge.dart';
 
 /// Compact row that summarizes an [EvidenceSection] inside the grouped list.
 class SectionCard extends StatelessWidget {
@@ -36,9 +35,6 @@ class SectionCard extends StatelessWidget {
     final dateFormat = DateFormat('d MMM yyyy, HH:mm', 'es');
     final showSubmitAction =
         folderIsOpen && section.canSubmit && onSubmit != null;
-    final textScaler = MediaQuery.textScalerOf(context).clamp(
-      maxScaleFactor: 1.3,
-    );
 
     return Material(
       key: ValueKey('evidence-section-${section.id}'),
@@ -63,7 +59,6 @@ class SectionCard extends StatelessWidget {
                           section.name,
                           maxLines: 2,
                           overflow: TextOverflow.ellipsis,
-                          textScaler: textScaler,
                           style:
                               Theme.of(context).textTheme.titleSmall?.copyWith(
                                     fontWeight: FontWeight.w700,
@@ -78,7 +73,6 @@ class SectionCard extends StatelessWidget {
                             description,
                             maxLines: 2,
                             overflow: TextOverflow.ellipsis,
-                            textScaler: textScaler,
                             style:
                                 Theme.of(context).textTheme.bodySmall?.copyWith(
                                       color: c.textSecondary,
@@ -92,7 +86,7 @@ class SectionCard extends StatelessWidget {
                           runSpacing: 6,
                           crossAxisAlignment: WrapCrossAlignment.center,
                           children: [
-                            SectionStatusBadge(status: section.status),
+                            _CompactStatusLabel(status: section.status),
                             _CompactMetric(
                               icon: HugeIcons.strokeRoundedStar,
                               label:
@@ -208,19 +202,54 @@ class _CompactMetric extends StatelessWidget {
 
     return Row(
       mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        HugeIcon(icon: icon, size: 13, color: c.textSecondary),
-        const SizedBox(width: 4),
-        Text(
-          label,
-          maxLines: 1,
-          overflow: TextOverflow.ellipsis,
-          style: Theme.of(context).textTheme.labelSmall?.copyWith(
-                color: c.textSecondary,
-                fontWeight: FontWeight.w600,
-              ),
+        Padding(
+          padding: const EdgeInsets.only(top: 2),
+          child: HugeIcon(icon: icon, size: 13, color: c.textSecondary),
+        ),
+        const SizedBox(width: 5),
+        Flexible(
+          child: Text(
+            label,
+            softWrap: true,
+            style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                  color: c.textSecondary,
+                  fontWeight: FontWeight.w600,
+                  height: 1.25,
+                ),
+          ),
         ),
       ],
+    );
+  }
+}
+
+class _CompactStatusLabel extends StatelessWidget {
+  final EvidenceSectionStatus status;
+
+  const _CompactStatusLabel({required this.status});
+
+  @override
+  Widget build(BuildContext context) {
+    final color = _statusColor(status);
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.1),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: color.withValues(alpha: 0.3)),
+      ),
+      child: Text(
+        _statusLabel(status),
+        softWrap: true,
+        style: Theme.of(context).textTheme.labelSmall?.copyWith(
+              color: color,
+              fontWeight: FontWeight.w700,
+              height: 1.2,
+            ),
+      ),
     );
   }
 }
@@ -328,9 +357,13 @@ class _SubmitSectionButton extends StatelessWidget {
             onTap: isSubmitting ? () {} : onSubmit,
             borderRadius: BorderRadius.circular(12),
             child: Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 14),
+              padding: const EdgeInsets.symmetric(
+                horizontal: 14,
+                vertical: 8,
+              ),
               child: Row(
                 mainAxisAlignment: MainAxisAlignment.center,
+                crossAxisAlignment: CrossAxisAlignment.center,
                 children: [
                   if (isSubmitting)
                     SizedBox(
@@ -349,14 +382,19 @@ class _SubmitSectionButton extends StatelessWidget {
                       color: AppColors.info,
                     ),
                   const SizedBox(width: 8),
-                  Text(
-                    isSubmitting
-                        ? 'evidence_folder.sending'.tr()
-                        : 'evidence_folder.send_to_validation'.tr(),
-                    style: TextStyle(
-                      fontSize: 13,
-                      fontWeight: FontWeight.w700,
-                      color: AppColors.info,
+                  Flexible(
+                    child: Text(
+                      isSubmitting
+                          ? 'evidence_folder.sending'.tr()
+                          : 'evidence_folder.send_to_validation'.tr(),
+                      textAlign: TextAlign.center,
+                      softWrap: true,
+                      style: TextStyle(
+                        fontSize: 13,
+                        fontWeight: FontWeight.w700,
+                        color: AppColors.info,
+                        height: 1.2,
+                      ),
                     ),
                   ),
                 ],

--- a/test/features/evidence_folder/evidence_folder_view_test.dart
+++ b/test/features/evidence_folder/evidence_folder_view_test.dart
@@ -26,13 +26,25 @@ void main() {
     translations = jsonDecode(
       await File('assets/translations/es.json').readAsString(),
     ) as Map<String, dynamic>;
+    final evidenceFolderTranslations = Map<String, dynamic>.from(
+      translations['evidence_folder'] as Map<String, dynamic>,
+    )..addAll({
+        'overview_label': '{name} · Avance',
+        'search_hint': 'Buscar sección de evidencia…',
+        'no_results_body': 'Intenta con otro nombre o descripción.',
+      });
+    translations = {
+      ...translations,
+      'evidence_folder': evidenceFolderTranslations,
+    };
   });
 
   Future<void> pumpEvidenceFolder(
     WidgetTester tester, {
     EvidenceFolder? folder,
+    double viewportHeight = 2000,
   }) async {
-    tester.view.physicalSize = const Size(1200, 2000);
+    tester.view.physicalSize = Size(1200, viewportHeight);
     tester.view.devicePixelRatio = 1;
     addTearDown(tester.view.resetPhysicalSize);
     addTearDown(tester.view.resetDevicePixelRatio);
@@ -71,11 +83,18 @@ void main() {
     final hero = find.byKey(const ValueKey('evidence-folder-hero'));
     expect(hero, findsOneWidget);
     expect(
-      find.descendant(of: hero, matching: find.text('Carpeta 2026')),
+      find.descendant(
+        of: hero,
+        matching: find.text('Carpeta 2026 · Avance'),
+      ),
       findsOneWidget,
     );
     expect(
       find.descendant(of: hero, matching: find.text('62%')),
+      findsOneWidget,
+    );
+    expect(
+      find.descendant(of: hero, matching: find.text('31 / 50 pts')),
       findsOneWidget,
     );
 
@@ -144,6 +163,33 @@ void main() {
     expect(find.text('Health and Safety'), findsNothing);
   });
 
+  testWidgets('clears the query and restores the complete section list',
+      (tester) async {
+    await pumpEvidenceFolder(tester, viewportHeight: 5000);
+
+    final searchField = find.byKey(const ValueKey('evidence-section-search'));
+    await tester.enterText(searchField, 'Administration Records');
+    await tester.pumpAndSettle();
+    expect(find.byType(SectionCard), findsOneWidget);
+
+    final clearAction =
+        find.byKey(const ValueKey('evidence-section-search-clear'));
+    expect(clearAction, findsOneWidget);
+    expect(tester.getSize(clearAction).width, greaterThanOrEqualTo(48));
+    expect(tester.getSize(clearAction).height, greaterThanOrEqualTo(48));
+
+    await tester.tap(clearAction);
+    await tester.pump();
+
+    final field = tester.widget<TextField>(searchField);
+    expect(field.controller?.text, isEmpty);
+    expect(
+      find.byType(SectionCard),
+      findsNWidgets(_evidenceFolderFixture.sections.length),
+    );
+    await tester.pumpAndSettle();
+  });
+
   testWidgets('shows a no-results state when no section matches',
       (tester) async {
     await pumpEvidenceFolder(tester);
@@ -157,6 +203,10 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('No se encontraron resultados'), findsOneWidget);
+    expect(
+      find.text('Intenta con otro nombre o descripción.'),
+      findsOneWidget,
+    );
     for (final section in _evidenceFolderFixture.sections) {
       expect(find.text(section.name), findsNothing);
     }

--- a/test/features/evidence_folder/evidence_folder_view_test.dart
+++ b/test/features/evidence_folder/evidence_folder_view_test.dart
@@ -1,0 +1,199 @@
+import 'package:easy_localization/easy_localization.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:intl/date_symbol_data_local.dart';
+import 'package:sacdia_app/features/evidence_folder/domain/entities/evidence_file.dart';
+import 'package:sacdia_app/features/evidence_folder/domain/entities/evidence_folder.dart';
+import 'package:sacdia_app/features/evidence_folder/domain/entities/evidence_section.dart';
+import 'package:sacdia_app/features/evidence_folder/presentation/providers/evidence_folder_providers.dart';
+import 'package:sacdia_app/features/evidence_folder/presentation/views/evidence_folder_view.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() async {
+    SharedPreferences.setMockInitialValues({});
+    await initializeDateFormatting('es');
+    await EasyLocalization.ensureInitialized();
+  });
+
+  Future<void> pumpEvidenceFolder(WidgetTester tester) async {
+    tester.view.physicalSize = const Size(1200, 2000);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          evidenceFolderProvider('2').overrideWith(
+            (ref) async => _evidenceFolderFixture,
+          ),
+        ],
+        child: EasyLocalization(
+          supportedLocales: const [Locale('es')],
+          path: 'assets/translations',
+          fallbackLocale: const Locale('es'),
+          child: Builder(
+            builder: (context) => MaterialApp(
+              localizationsDelegates: context.localizationDelegates,
+              supportedLocales: context.supportedLocales,
+              locale: context.locale,
+              home: const EvidenceFolderView(clubSectionId: '2'),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('shows the folder hero and one count for every section status',
+      (tester) async {
+    await pumpEvidenceFolder(tester);
+
+    expect(find.byKey(const ValueKey('evidence-folder-hero')), findsOneWidget);
+    expect(find.text('62%'), findsOneWidget);
+
+    _expectStatusCount('evidence-status-validated', 1);
+    _expectStatusCount('evidence-status-preapproved', 1);
+    _expectStatusCount('evidence-status-submitted', 1);
+    _expectStatusCount('evidence-status-rejected', 1);
+    _expectStatusCount('evidence-status-pending', 1);
+  });
+
+  testWidgets('filters sections by name', (tester) async {
+    await pumpEvidenceFolder(tester);
+
+    final searchField = find.byKey(const ValueKey('evidence-section-search'));
+    expect(searchField, findsOneWidget);
+    await tester.enterText(
+      searchField,
+      'Camporee Readiness',
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Camporee Readiness'), findsOneWidget);
+    expect(find.text('Administration Records'), findsNothing);
+    expect(find.text('Community Service'), findsNothing);
+    expect(find.text('Leadership Training'), findsNothing);
+    expect(find.text('Health and Safety'), findsNothing);
+  });
+
+  testWidgets('filters sections by description without matching case',
+      (tester) async {
+    await pumpEvidenceFolder(tester);
+
+    final searchField = find.byKey(const ValueKey('evidence-section-search'));
+    expect(searchField, findsOneWidget);
+    await tester.enterText(
+      searchField,
+      'mission archive',
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Community Service'), findsOneWidget);
+    expect(find.text('Administration Records'), findsNothing);
+    expect(find.text('Camporee Readiness'), findsNothing);
+    expect(find.text('Leadership Training'), findsNothing);
+    expect(find.text('Health and Safety'), findsNothing);
+  });
+
+  testWidgets('shows a no-results state when no section matches',
+      (tester) async {
+    await pumpEvidenceFolder(tester);
+
+    final searchField = find.byKey(const ValueKey('evidence-section-search'));
+    expect(searchField, findsOneWidget);
+    await tester.enterText(
+      searchField,
+      'missing section',
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('No se encontraron resultados'), findsOneWidget);
+    for (final section in _evidenceFolderFixture.sections) {
+      expect(find.text(section.name), findsNothing);
+    }
+  });
+}
+
+void _expectStatusCount(String key, int count) {
+  final statusPill = find.byKey(ValueKey(key));
+  expect(statusPill, findsOneWidget);
+  expect(
+    find.descendant(of: statusPill, matching: find.text('$count')),
+    findsOneWidget,
+  );
+}
+
+final _evidenceFolderFixture = EvidenceFolder(
+  folderId: 'folder-1',
+  id: 'template-1',
+  name: 'Carpeta 2026',
+  description: 'Evidencias anuales del club',
+  isOpen: true,
+  totalPoints: 100,
+  totalPercentage: 100,
+  totalEarnedPoints: 31,
+  totalMaxPoints: 50,
+  progressPercentage: 62,
+  status: 'open',
+  sections: [
+    EvidenceSection(
+      id: 'section-pending',
+      name: 'Administration Records',
+      description: 'Secretary documents for the annual record',
+      pointValue: 10,
+      percentage: 20,
+      maxFiles: 5,
+      status: EvidenceSectionStatus.pending,
+      files: [
+        EvidenceFile(
+          id: 'file-1',
+          url: 'https://example.com/evidence.pdf',
+          fileName: 'minutes.pdf',
+          type: EvidenceFileType.pdf,
+          uploadedByName: 'Ana Test',
+          uploadedAt: DateTime.utc(2026, 1, 15),
+        ),
+      ],
+    ),
+    const EvidenceSection(
+      id: 'section-submitted',
+      name: 'Community Service',
+      description: 'Unique MISSION Archive for neighborhood outreach',
+      pointValue: 10,
+      percentage: 20,
+      status: EvidenceSectionStatus.submitted,
+    ),
+    const EvidenceSection(
+      id: 'section-preapproved',
+      name: 'Camporee Readiness',
+      description: 'Equipment checklist verified by the local field',
+      pointValue: 10,
+      percentage: 20,
+      status: EvidenceSectionStatus.preapprovedLf,
+    ),
+    const EvidenceSection(
+      id: 'section-validated',
+      name: 'Leadership Training',
+      description: 'Mentor development attendance records',
+      pointValue: 10,
+      percentage: 20,
+      status: EvidenceSectionStatus.validated,
+      earnedPoints: 10,
+    ),
+    const EvidenceSection(
+      id: 'section-rejected',
+      name: 'Health and Safety',
+      description: 'First-aid procedure awaiting corrections',
+      pointValue: 10,
+      percentage: 20,
+      status: EvidenceSectionStatus.rejected,
+    ),
+  ],
+);

--- a/test/features/evidence_folder/evidence_folder_view_test.dart
+++ b/test/features/evidence_folder/evidence_folder_view_test.dart
@@ -43,9 +43,10 @@ void main() {
   Future<void> pumpEvidenceFolder(
     WidgetTester tester, {
     EvidenceFolder? folder,
+    double viewportWidth = 1200,
     double viewportHeight = 2000,
   }) async {
-    tester.view.physicalSize = Size(1200, viewportHeight);
+    tester.view.physicalSize = Size(viewportWidth, viewportHeight);
     tester.view.devicePixelRatio = 1;
     addTearDown(tester.view.resetPhysicalSize);
     addTearDown(tester.view.resetDevicePixelRatio);
@@ -253,6 +254,52 @@ void main() {
 
     expect(find.text('Enviar sección a validación'), findsOneWidget);
     expect(find.byType(EvidenceSectionDetailView), findsNothing);
+  });
+
+  testWidgets('compact rows honor large text without layout overflow',
+      (tester) async {
+    tester.platformDispatcher.textScaleFactorTestValue = 2;
+    addTearDown(
+      tester.platformDispatcher.clearTextScaleFactorTestValue,
+    );
+
+    await pumpEvidenceFolder(
+      tester,
+      viewportWidth: 320,
+      viewportHeight: 844,
+    );
+
+    final groupedCard = find.byKey(const ValueKey('evidence-sections-card'));
+    await tester.scrollUntilVisible(
+      groupedCard,
+      240,
+      scrollable: find.byType(Scrollable).first,
+    );
+    await tester.pumpAndSettle();
+
+    final pendingRow =
+        find.byKey(const ValueKey('evidence-section-section-pending'));
+    final pendingTitle = find.descendant(
+      of: pendingRow,
+      matching: find.text('Administration Records'),
+    );
+    final sendAction = find.descendant(
+      of: pendingRow,
+      matching: find.byKey(
+        const ValueKey('evidence-section-submit-section-pending'),
+      ),
+    );
+
+    expect(groupedCard, findsOneWidget);
+    expect(pendingRow, findsOneWidget);
+    expect(sendAction, findsOneWidget);
+    expect(tester.getSize(sendAction).height, greaterThanOrEqualTo(48));
+    expect(
+      MediaQuery.textScalerOf(tester.element(pendingTitle)).scale(10),
+      20,
+    );
+    expect(tester.widget<Text>(pendingTitle).textScaler, isNull);
+    expect(tester.takeException(), isNull);
   });
 
   testWidgets('filters sections by description without matching case',

--- a/test/features/evidence_folder/evidence_folder_view_test.dart
+++ b/test/features/evidence_folder/evidence_folder_view_test.dart
@@ -28,7 +28,10 @@ void main() {
     ) as Map<String, dynamic>;
   });
 
-  Future<void> pumpEvidenceFolder(WidgetTester tester) async {
+  Future<void> pumpEvidenceFolder(
+    WidgetTester tester, {
+    EvidenceFolder? folder,
+  }) async {
     tester.view.physicalSize = const Size(1200, 2000);
     tester.view.devicePixelRatio = 1;
     addTearDown(tester.view.resetPhysicalSize);
@@ -38,7 +41,7 @@ void main() {
       ProviderScope(
         overrides: [
           evidenceFolderProvider('2').overrideWith(
-            (ref) async => _evidenceFolderFixture,
+            (ref) async => folder ?? _evidenceFolderFixture,
           ),
         ],
         child: EasyLocalization(
@@ -81,6 +84,21 @@ void main() {
     _expectStatusCount('evidence-status-submitted', 2);
     _expectStatusCount('evidence-status-rejected', 5);
     _expectStatusCount('evidence-status-pending', 1);
+  });
+
+  testWidgets('shows submitted folder state before the closed fallback',
+      (tester) async {
+    await pumpEvidenceFolder(tester, folder: _submittedFolderFixture);
+
+    final hero = find.byKey(const ValueKey('evidence-folder-hero'));
+    expect(
+      find.descendant(of: hero, matching: find.text('Enviado')),
+      findsOneWidget,
+    );
+    expect(
+      find.descendant(of: hero, matching: find.text('Cerrada')),
+      findsNothing,
+    );
   });
 
   testWidgets('filters sections by name', (tester) async {
@@ -225,6 +243,20 @@ final _evidenceFolderFixture = EvidenceFolder(
       firstDescription: 'First-aid procedure awaiting corrections',
     ),
   ],
+);
+
+const _submittedFolderFixture = EvidenceFolder(
+  folderId: 'folder-submitted',
+  id: 'template-submitted',
+  name: 'Carpeta enviada',
+  isOpen: false,
+  totalPoints: 50,
+  totalPercentage: 100,
+  totalEarnedPoints: 20,
+  totalMaxPoints: 50,
+  progressPercentage: 40,
+  status: 'submitted',
+  sections: [],
 );
 
 List<EvidenceSection> _sectionsForStatus({

--- a/test/features/evidence_folder/evidence_folder_view_test.dart
+++ b/test/features/evidence_folder/evidence_folder_view_test.dart
@@ -11,6 +11,7 @@ import 'package:sacdia_app/features/evidence_folder/domain/entities/evidence_fol
 import 'package:sacdia_app/features/evidence_folder/domain/entities/evidence_section.dart';
 import 'package:sacdia_app/features/evidence_folder/presentation/providers/evidence_folder_providers.dart';
 import 'package:sacdia_app/features/evidence_folder/presentation/views/evidence_folder_view.dart';
+import 'package:sacdia_app/features/evidence_folder/presentation/views/evidence_section_detail_view.dart';
 import 'package:sacdia_app/features/evidence_folder/presentation/widgets/section_card.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -142,6 +143,116 @@ void main() {
     expect(find.text('Community Service'), findsNothing);
     expect(find.text('Leadership Training'), findsNothing);
     expect(find.text('Health and Safety'), findsNothing);
+  });
+
+  testWidgets('groups compact section rows and shows their summary',
+      (tester) async {
+    await pumpEvidenceFolder(tester, viewportHeight: 5000);
+
+    final groupedCard = find.byKey(const ValueKey('evidence-sections-card'));
+    final pendingRow =
+        find.byKey(const ValueKey('evidence-section-section-pending'));
+
+    expect(groupedCard, findsOneWidget);
+    for (final section in _evidenceFolderFixture.sections) {
+      expect(
+        find.descendant(
+          of: groupedCard,
+          matching: find.byKey(ValueKey('evidence-section-${section.id}')),
+        ),
+        findsOneWidget,
+      );
+    }
+    expect(
+      find.descendant(of: groupedCard, matching: pendingRow),
+      findsOneWidget,
+    );
+    expect(
+      find.descendant(
+        of: pendingRow,
+        matching: find.text('Administration Records'),
+      ),
+      findsOneWidget,
+    );
+    expect(
+      find.descendant(of: pendingRow, matching: find.text('Pendiente')),
+      findsOneWidget,
+    );
+    expect(
+      find.descendant(of: pendingRow, matching: find.text('0 / 10 pts')),
+      findsOneWidget,
+    );
+    expect(
+      find.descendant(of: pendingRow, matching: find.text('1 / 5 archivos')),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('opens section detail when a compact row is tapped',
+      (tester) async {
+    await pumpEvidenceFolder(tester);
+
+    final pendingRow =
+        find.byKey(const ValueKey('evidence-section-section-pending'));
+    expect(pendingRow, findsOneWidget);
+
+    await tester.tap(pendingRow);
+    await tester.pumpAndSettle();
+
+    expect(find.byType(EvidenceSectionDetailView), findsOneWidget);
+  });
+
+  testWidgets('shows send action for a submittable row in an open folder',
+      (tester) async {
+    await pumpEvidenceFolder(tester);
+
+    final pendingRow =
+        find.byKey(const ValueKey('evidence-section-section-pending'));
+    final pendingSendAction = find.descendant(
+      of: pendingRow,
+      matching: find.byKey(
+        const ValueKey('evidence-section-submit-section-pending'),
+      ),
+    );
+    expect(pendingSendAction, findsOneWidget);
+    expect(tester.getSize(pendingSendAction).width, greaterThanOrEqualTo(48));
+    expect(tester.getSize(pendingSendAction).height, greaterThanOrEqualTo(48));
+  });
+
+  testWidgets('hides send action when the folder is closed', (tester) async {
+    await pumpEvidenceFolder(tester, folder: _closedFolderFixture);
+
+    final closedPendingRow =
+        find.byKey(const ValueKey('evidence-section-section-pending'));
+    expect(closedPendingRow, findsOneWidget);
+    expect(
+      find.descendant(
+        of: closedPendingRow,
+        matching: find.text('Enviar a validación'),
+      ),
+      findsNothing,
+    );
+  });
+
+  testWidgets('send action confirms without opening section detail',
+      (tester) async {
+    await pumpEvidenceFolder(tester);
+
+    final pendingRow =
+        find.byKey(const ValueKey('evidence-section-section-pending'));
+    final sendAction = find.descendant(
+      of: pendingRow,
+      matching: find.byKey(
+        const ValueKey('evidence-section-submit-section-pending'),
+      ),
+    );
+    expect(sendAction, findsOneWidget);
+
+    await tester.tap(sendAction);
+    await tester.pumpAndSettle();
+
+    expect(find.text('Enviar sección a validación'), findsOneWidget);
+    expect(find.byType(EvidenceSectionDetailView), findsNothing);
   });
 
   testWidgets('filters sections by description without matching case',
@@ -307,6 +418,20 @@ const _submittedFolderFixture = EvidenceFolder(
   progressPercentage: 40,
   status: 'submitted',
   sections: [],
+);
+
+final _closedFolderFixture = EvidenceFolder(
+  folderId: 'folder-closed',
+  id: 'template-closed',
+  name: 'Carpeta cerrada',
+  isOpen: false,
+  totalPoints: 100,
+  totalPercentage: 100,
+  totalEarnedPoints: 31,
+  totalMaxPoints: 50,
+  progressPercentage: 62,
+  status: 'closed',
+  sections: _evidenceFolderFixture.sections,
 );
 
 List<EvidenceSection> _sectionsForStatus({

--- a/test/features/evidence_folder/evidence_folder_view_test.dart
+++ b/test/features/evidence_folder/evidence_folder_view_test.dart
@@ -55,13 +55,21 @@ void main() {
       (tester) async {
     await pumpEvidenceFolder(tester);
 
-    expect(find.byKey(const ValueKey('evidence-folder-hero')), findsOneWidget);
-    expect(find.text('62%'), findsOneWidget);
+    final hero = find.byKey(const ValueKey('evidence-folder-hero'));
+    expect(hero, findsOneWidget);
+    expect(
+      find.descendant(of: hero, matching: find.text('Carpeta 2026')),
+      findsOneWidget,
+    );
+    expect(
+      find.descendant(of: hero, matching: find.text('62%')),
+      findsOneWidget,
+    );
 
-    _expectStatusCount('evidence-status-validated', 1);
-    _expectStatusCount('evidence-status-preapproved', 1);
-    _expectStatusCount('evidence-status-submitted', 1);
-    _expectStatusCount('evidence-status-rejected', 1);
+    _expectStatusCount('evidence-status-validated', 4);
+    _expectStatusCount('evidence-status-preapproved', 3);
+    _expectStatusCount('evidence-status-submitted', 2);
+    _expectStatusCount('evidence-status-rejected', 5);
     _expectStatusCount('evidence-status-pending', 1);
   });
 
@@ -162,38 +170,55 @@ final _evidenceFolderFixture = EvidenceFolder(
         ),
       ],
     ),
-    const EvidenceSection(
-      id: 'section-submitted',
-      name: 'Community Service',
-      description: 'Unique MISSION Archive for neighborhood outreach',
-      pointValue: 10,
-      percentage: 20,
+    ..._sectionsForStatus(
       status: EvidenceSectionStatus.submitted,
+      count: 2,
+      idPrefix: 'submitted',
+      firstName: 'Community Service',
+      firstDescription: 'Unique MISSION Archive for neighborhood outreach',
     ),
-    const EvidenceSection(
-      id: 'section-preapproved',
-      name: 'Camporee Readiness',
-      description: 'Equipment checklist verified by the local field',
-      pointValue: 10,
-      percentage: 20,
+    ..._sectionsForStatus(
       status: EvidenceSectionStatus.preapprovedLf,
+      count: 3,
+      idPrefix: 'preapproved',
+      firstName: 'Camporee Readiness',
+      firstDescription: 'Equipment checklist verified by the local field',
     ),
-    const EvidenceSection(
-      id: 'section-validated',
-      name: 'Leadership Training',
-      description: 'Mentor development attendance records',
-      pointValue: 10,
-      percentage: 20,
+    ..._sectionsForStatus(
       status: EvidenceSectionStatus.validated,
-      earnedPoints: 10,
+      count: 4,
+      idPrefix: 'validated',
+      firstName: 'Leadership Training',
+      firstDescription: 'Mentor development attendance records',
     ),
-    const EvidenceSection(
-      id: 'section-rejected',
-      name: 'Health and Safety',
-      description: 'First-aid procedure awaiting corrections',
-      pointValue: 10,
-      percentage: 20,
+    ..._sectionsForStatus(
       status: EvidenceSectionStatus.rejected,
+      count: 5,
+      idPrefix: 'rejected',
+      firstName: 'Health and Safety',
+      firstDescription: 'First-aid procedure awaiting corrections',
     ),
   ],
 );
+
+List<EvidenceSection> _sectionsForStatus({
+  required EvidenceSectionStatus status,
+  required int count,
+  required String idPrefix,
+  required String firstName,
+  required String firstDescription,
+}) {
+  return List.generate(
+    count,
+    (index) => EvidenceSection(
+      id: 'section-$idPrefix-${index + 1}',
+      name: index == 0 ? firstName : '$firstName ${index + 1}',
+      description:
+          index == 0 ? firstDescription : '$firstDescription ${index + 1}',
+      pointValue: 10,
+      percentage: 20,
+      status: status,
+      earnedPoints: status == EvidenceSectionStatus.validated ? 10 : 0,
+    ),
+  );
+}

--- a/test/features/evidence_folder/evidence_folder_view_test.dart
+++ b/test/features/evidence_folder/evidence_folder_view_test.dart
@@ -1,3 +1,6 @@
+import 'dart:convert';
+import 'dart:io';
+
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -8,15 +11,21 @@ import 'package:sacdia_app/features/evidence_folder/domain/entities/evidence_fol
 import 'package:sacdia_app/features/evidence_folder/domain/entities/evidence_section.dart';
 import 'package:sacdia_app/features/evidence_folder/presentation/providers/evidence_folder_providers.dart';
 import 'package:sacdia_app/features/evidence_folder/presentation/views/evidence_folder_view.dart';
+import 'package:sacdia_app/features/evidence_folder/presentation/widgets/section_card.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
+  late Map<String, dynamic> translations;
+
   setUpAll(() async {
     SharedPreferences.setMockInitialValues({});
     await initializeDateFormatting('es');
     await EasyLocalization.ensureInitialized();
+    translations = jsonDecode(
+      await File('assets/translations/es.json').readAsString(),
+    ) as Map<String, dynamic>;
   });
 
   Future<void> pumpEvidenceFolder(WidgetTester tester) async {
@@ -36,6 +45,7 @@ void main() {
           supportedLocales: const [Locale('es')],
           path: 'assets/translations',
           fallbackLocale: const Locale('es'),
+          assetLoader: _TestAssetLoader(translations),
           child: Builder(
             builder: (context) => MaterialApp(
               localizationsDelegates: context.localizationDelegates,
@@ -84,7 +94,13 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    expect(find.text('Camporee Readiness'), findsOneWidget);
+    expect(
+      find.descendant(
+        of: find.byType(SectionCard),
+        matching: find.text('Camporee Readiness'),
+      ),
+      findsOneWidget,
+    );
     expect(find.text('Administration Records'), findsNothing);
     expect(find.text('Community Service'), findsNothing);
     expect(find.text('Leadership Training'), findsNothing);
@@ -127,6 +143,16 @@ void main() {
       expect(find.text(section.name), findsNothing);
     }
   });
+}
+
+class _TestAssetLoader extends AssetLoader {
+  final Map<String, dynamic> translations;
+
+  const _TestAssetLoader(this.translations);
+
+  @override
+  Future<Map<String, dynamic>?> load(String path, Locale locale) async =>
+      translations;
 }
 
 void _expectStatusCount(String key, int count) {


### PR DESCRIPTION
## Resumen
- Rediseña la Carpeta Anual de Evidencias con hero de avance, estados, búsqueda y filas compactas.
- Mantiene los contratos de annual-folders, envío de secciones y trazabilidad.
- Incluye traducciones y soporte para texto ampliado en pantallas compactas.

## Validación
- [x] `flutter test test/features/evidence_folder` (39 pruebas)
- [x] `flutter analyze`
- [x] Validación JSON de traducciones
