### PR TITLE
fix(classes): hide teaching scope header

### DIFF
--- a/lib/features/classes/presentation/views/teaching_scope_view.dart
+++ b/lib/features/classes/presentation/views/teaching_scope_view.dart
@@ -175,7 +175,7 @@ class _TeachingScopeBody extends StatelessWidget {
             index == 0 ? const SizedBox(height: 12) : const SizedBox(height: 8),
         itemBuilder: (context, index) {
           if (index == 0) {
-            return _ScopeHeader(scope: scope);
+            return const SizedBox();
           }
 
           final progressiveClass = scope.classes[index - 1];


### PR DESCRIPTION
Closes #116

## Resumen
- Oculta el encabezado redundante del alcance de enseñanza sin alterar la lista de clases.

## Validación
- 15 pruebas aprobadas con test/features/classes.
