### PR TITLE
fix(auth): use canonical password reset endpoint

### DIFF
--- a/lib/core/network/interceptors/auth_interceptor.dart
+++ b/lib/core/network/interceptors/auth_interceptor.dart
@@ -46,7 +46,7 @@ class AuthInterceptor extends QueuedInterceptor {
     '/auth/register',
     '/auth/refresh',
     '/auth/oauth',
-    '/auth/request-password-reset',
+    '/auth/password/reset-request',
     '/auth/reset-password',
   ];
 

--- a/lib/features/auth/data/datasources/auth_remote_data_source.dart
+++ b/lib/features/auth/data/datasources/auth_remote_data_source.dart
@@ -603,7 +603,7 @@ class AuthRemoteDataSourceImpl implements AuthRemoteDataSource {
       AppLogger.i('Recuperación de contraseña solicitada', tag: _tag);
 
       final response = await _dio.post(
-        '$_baseUrl${ApiEndpoints.auth}/request-password-reset',
+        '$_baseUrl${ApiEndpoints.auth}/password/reset-request',
         data: {'email': email},
       );
 

--- a/test/features/auth/data/delete_account_test.dart
+++ b/test/features/auth/data/delete_account_test.dart
@@ -46,6 +46,7 @@ MockAdapter _adapterReturning(int statusCode, [Map<String, dynamic>? body]) {
 class MockAdapter implements HttpClientAdapter {
   final int statusCode;
   final Map<String, dynamic>? body;
+  RequestOptions? lastRequest;
 
   MockAdapter({required this.statusCode, this.body});
 
@@ -55,6 +56,7 @@ class MockAdapter implements HttpClientAdapter {
     Stream<List<int>>? requestStream,
     Future<void>? cancelFuture,
   ) async {
+    lastRequest = options;
     final responseBody = body != null
         ? body!.entries.map((e) => '"${e.key}":"${e.value}"').join(',')
         : '';
@@ -137,6 +139,26 @@ void main() {
       // Token must be cleared after successful deletion.
       final tokenAfter = await storage.read(AppConstants.tokenKey);
       expect(tokenAfter, isNull);
+    });
+  });
+
+  group('AuthRemoteDataSourceImpl.resetPassword', () {
+    test('should use the canonical password reset request endpoint', () async {
+      final adapter = _adapterReturning(200);
+      dio.httpClientAdapter = adapter;
+      dataSource = AuthRemoteDataSourceImpl(
+        dio: dio,
+        baseUrl: 'http://localhost:3000',
+        secureStorage: storage,
+      );
+
+      await dataSource.resetPassword('admin@example.com');
+
+      expect(
+        adapter.lastRequest?.uri.path,
+        '/auth/password/reset-request',
+      );
+      expect(adapter.lastRequest?.data, {'email': 'admin@example.com'});
     });
   });
 }


### PR DESCRIPTION
Closes #123

## Tipo
- [x] Bug fix

## Resumen
- Sustituye el endpoint obsoleto de recuperación por `/auth/password/reset-request`.
- Mantiene la ruta canónica como pública en el interceptor.
- Agrega una prueba focalizada para ruta y payload.
- Integra el baseline de validación aprobado en #125.

## Cambios
| Archivo | Cambio |
|---|---|
| `auth_interceptor.dart` | Ruta pública canónica |
| `auth_remote_data_source.dart` | Endpoint publicado por backend |
| `delete_account_test.dart` | Regresión de ruta y payload |

## Test plan
- [x] `dart format --set-exit-if-changed --output=none .` — 1119 archivos, 0 cambios.
- [x] `flutter analyze` — sin issues.
- [x] `flutter test` — 666/666 pruebas verdes.

## Contributor checklist
- [x] Issue aprobado enlazado.
- [x] Exactamente una etiqueta `type:*`.
- [x] No se modificaron scripts; shellcheck no aplica.
- [x] Contrato documentado en el workspace canónico.
- [x] Commit convencional y sin `Co-Authored-By`.
