### PR TITLE
chore(ci): restore Flutter validation baseline

### DIFF
--- a/lib/features/classes/presentation/views/class_counselor_assignments_view.dart
+++ b/lib/features/classes/presentation/views/class_counselor_assignments_view.dart
@@ -183,22 +183,22 @@ class ClassCounselorAssignmentsView extends ConsumerWidget {
           },
           onAdd: canAssign
               ? () => _openAssignmentSheet(
-                  context,
-                  ref,
-                  query,
-                  classesAsync: classesAsync,
-                  membersAsync: membersAsync,
-                )
+                    context,
+                    ref,
+                    query,
+                    classesAsync: classesAsync,
+                    membersAsync: membersAsync,
+                  )
               : null,
           onEdit: canAssign
               ? (assignment) => _openAssignmentSheet(
-                  context,
-                  ref,
-                  query,
-                  classesAsync: classesAsync,
-                  membersAsync: membersAsync,
-                  initialAssignment: assignment,
-                )
+                    context,
+                    ref,
+                    query,
+                    classesAsync: classesAsync,
+                    membersAsync: membersAsync,
+                    initialAssignment: assignment,
+                  )
               : null,
           onRevoke: canRevoke
               ? (assignment) => _confirmRevoke(context, ref, query, assignment)
@@ -218,11 +218,11 @@ class ClassCounselorAssignmentsView extends ConsumerWidget {
   }) async {
     final isEditing = initialAssignment != null;
     final classes = classesAsync?.valueOrNull ?? const <ProgressiveClass>[];
-    final candidates =
-        (membersAsync.valueOrNull?.members ?? const <ClubMember>[])
-            .where(_isAssignableResponsible)
-            .toList()
-          ..sort((a, b) => a.fullName.compareTo(b.fullName));
+    final candidates = (membersAsync.valueOrNull?.members ??
+            const <ClubMember>[])
+        .where(_isAssignableResponsible)
+        .toList()
+      ..sort((a, b) => a.fullName.compareTo(b.fullName));
 
     if (!isEditing) {
       if (clubTypeId == null) {
@@ -445,10 +445,10 @@ class _ClassGroupHeader extends StatelessWidget {
           Text(
             className,
             style: Theme.of(context).textTheme.titleSmall?.copyWith(
-              fontWeight: FontWeight.w800,
-              color: AppColors.ink900,
-              letterSpacing: -0.2,
-            ),
+                  fontWeight: FontWeight.w800,
+                  color: AppColors.ink900,
+                  letterSpacing: -0.2,
+                ),
           ),
         ],
       ),
@@ -480,9 +480,9 @@ class _AssignmentsHeader extends StatelessWidget {
                   ? 'classes.class_assignments.header_body'.tr()
                   : 'classes.class_assignments.readonly_body'.tr(),
               style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                color: AppColors.ink600,
-                height: 1.35,
-              ),
+                    color: AppColors.ink600,
+                    height: 1.35,
+                  ),
             ),
           ),
           if (canAssign && onAdd != null) ...[
@@ -565,9 +565,9 @@ class _AssignmentAddActionState extends State<_AssignmentAddAction> {
                 Text(
                   'classes.class_assignments.add_button'.tr(),
                   style: Theme.of(context).textTheme.labelLarge?.copyWith(
-                    color: color,
-                    fontWeight: FontWeight.w800,
-                  ),
+                        color: color,
+                        fontWeight: FontWeight.w800,
+                      ),
                 ),
               ],
             ),
@@ -628,10 +628,10 @@ class _AssignmentTile extends StatelessWidget {
                     maxLines: 1,
                     overflow: TextOverflow.ellipsis,
                     style: Theme.of(context).textTheme.titleSmall?.copyWith(
-                      fontWeight: FontWeight.w700,
-                      color: AppColors.ink900,
-                      letterSpacing: -0.2,
-                    ),
+                          fontWeight: FontWeight.w700,
+                          color: AppColors.ink900,
+                          letterSpacing: -0.2,
+                        ),
                   ),
                   const SizedBox(height: 3),
                   Row(
@@ -641,15 +641,17 @@ class _AssignmentTile extends StatelessWidget {
                           subtitleParts.join(' · '),
                           maxLines: 1,
                           overflow: TextOverflow.ellipsis,
-                          style: Theme.of(context).textTheme.bodySmall
+                          style: Theme.of(context)
+                              .textTheme
+                              .bodySmall
                               ?.copyWith(color: AppColors.ink600),
                         ),
                       ),
                       if (assignment.exceptional) ...[
                         const SizedBox(width: 6),
                         _AssignmentChip(
-                          label: 'classes.class_assignments.exceptional_chip'
-                              .tr(),
+                          label:
+                              'classes.class_assignments.exceptional_chip'.tr(),
                           color: AppColors.accentDark,
                         ),
                       ],
@@ -674,12 +676,12 @@ class _AssignmentTile extends StatelessWidget {
                             exceptionReason,
                             maxLines: 2,
                             overflow: TextOverflow.ellipsis,
-                            style: Theme.of(context).textTheme.bodySmall
-                                ?.copyWith(
-                                  color: AppColors.accentDark,
-                                  fontSize: 11.5,
-                                  height: 1.3,
-                                ),
+                            style:
+                                Theme.of(context).textTheme.bodySmall?.copyWith(
+                                      color: AppColors.accentDark,
+                                      fontSize: 11.5,
+                                      height: 1.3,
+                                    ),
                           ),
                         ),
                       ],
@@ -764,7 +766,9 @@ class _AssignmentTile extends StatelessWidget {
                           personName,
                           maxLines: 1,
                           overflow: TextOverflow.ellipsis,
-                          style: Theme.of(sheetContext).textTheme.titleMedium
+                          style: Theme.of(sheetContext)
+                              .textTheme
+                              .titleMedium
                               ?.copyWith(
                                 fontWeight: FontWeight.w800,
                                 color: AppColors.ink900,
@@ -860,7 +864,9 @@ class _AssignmentTile extends StatelessWidget {
                     child: Center(
                       child: Text(
                         'common.cancel'.tr(),
-                        style: Theme.of(sheetContext).textTheme.bodyMedium
+                        style: Theme.of(sheetContext)
+                            .textTheme
+                            .bodyMedium
                             ?.copyWith(
                               color: AppColors.ink600,
                               fontWeight: FontWeight.w700,
@@ -946,10 +952,10 @@ class _SheetActionState extends State<_SheetAction> {
                 child: Text(
                   widget.label,
                   style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                    color: widget.labelColor,
-                    fontWeight: FontWeight.w700,
-                    letterSpacing: -0.1,
-                  ),
+                        color: widget.labelColor,
+                        fontWeight: FontWeight.w700,
+                        letterSpacing: -0.1,
+                      ),
                 ),
               ),
               HugeIcon(
@@ -996,10 +1002,10 @@ class _PersonIdentityMark extends StatelessWidget {
           ? Text(
               initials.isEmpty ? '?' : initials,
               style: Theme.of(context).textTheme.titleSmall?.copyWith(
-                color: accent,
-                fontWeight: FontWeight.w800,
-                letterSpacing: -0.3,
-              ),
+                    color: accent,
+                    fontWeight: FontWeight.w800,
+                    letterSpacing: -0.3,
+                  ),
             )
           : CachedNetworkImage(
               imageUrl: image,
@@ -1011,9 +1017,9 @@ class _PersonIdentityMark extends StatelessWidget {
               errorWidget: (_, __, ___) => Text(
                 initials.isEmpty ? '?' : initials,
                 style: Theme.of(context).textTheme.titleSmall?.copyWith(
-                  color: accent,
-                  fontWeight: FontWeight.w800,
-                ),
+                      color: accent,
+                      fontWeight: FontWeight.w800,
+                    ),
               ),
             ),
     );
@@ -1037,9 +1043,9 @@ class _AssignmentChip extends StatelessWidget {
       child: Text(
         label,
         style: Theme.of(context).textTheme.labelSmall?.copyWith(
-          color: color,
-          fontWeight: FontWeight.w800,
-        ),
+              color: color,
+              fontWeight: FontWeight.w800,
+            ),
       ),
     );
   }
@@ -1105,16 +1111,14 @@ class _ClassCounselorAssignmentSheetState
   void initState() {
     super.initState();
     final initial = widget.initialAssignment;
-    _selectedClassId =
-        initial?.classId ??
+    _selectedClassId = initial?.classId ??
         (widget.classes.isNotEmpty ? widget.classes.first.id : null);
-    _selectedUserId =
-        initial?.userId ??
+    _selectedUserId = initial?.userId ??
         (widget.candidates.isNotEmpty ? widget.candidates.first.userId : null);
     _selectedResponsibilityType =
         _responsibilityTypes.contains(initial?.responsibilityType)
-        ? initial!.responsibilityType
-        : 'primary';
+            ? initial!.responsibilityType
+            : 'primary';
     _exceptional = initial?.exceptional ?? false;
     _reasonController = TextEditingController(
       text: initial?.exceptionReason ?? '',
@@ -1160,17 +1164,17 @@ class _ClassCounselorAssignmentSheetState
                     ? 'classes.class_assignments.edit_title'.tr()
                     : 'classes.class_assignments.create_title'.tr(),
                 style: Theme.of(context).textTheme.titleLarge?.copyWith(
-                  fontWeight: FontWeight.w800,
-                  color: AppColors.ink900,
-                ),
+                      fontWeight: FontWeight.w800,
+                      color: AppColors.ink900,
+                    ),
               ),
               const SizedBox(height: 6),
               Text(
                 'classes.class_assignments.form_body'.tr(),
                 style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                  color: AppColors.ink600,
-                  height: 1.35,
-                ),
+                      color: AppColors.ink600,
+                      height: 1.35,
+                    ),
               ),
               const SizedBox(height: 18),
               if (_isEditing) ...[
@@ -1214,8 +1218,8 @@ class _ClassCounselorAssignmentSheetState
                   initialValue: _selectedUserId,
                   isExpanded: true,
                   decoration: InputDecoration(
-                    labelText: 'classes.class_assignments.responsible_label'
-                        .tr(),
+                    labelText:
+                        'classes.class_assignments.responsible_label'.tr(),
                     border: const OutlineInputBorder(),
                   ),
                   items: widget.candidates
@@ -1241,8 +1245,8 @@ class _ClassCounselorAssignmentSheetState
               DropdownButtonFormField<String>(
                 initialValue: _selectedResponsibilityType,
                 decoration: InputDecoration(
-                  labelText: 'classes.class_assignments.responsibility_label'
-                      .tr(),
+                  labelText:
+                      'classes.class_assignments.responsibility_label'.tr(),
                   border: const OutlineInputBorder(),
                 ),
                 items: _responsibilityTypes
@@ -1256,8 +1260,9 @@ class _ClassCounselorAssignmentSheetState
                 onChanged: actionState.isLoading
                     ? null
                     : (value) => setState(
-                        () => _selectedResponsibilityType = value ?? 'primary',
-                      ),
+                          () =>
+                              _selectedResponsibilityType = value ?? 'primary',
+                        ),
               ),
               const SizedBox(height: 12),
               SwitchListTile.adaptive(
@@ -1386,17 +1391,17 @@ class _ReadOnlyField extends StatelessWidget {
           Text(
             label,
             style: Theme.of(context).textTheme.labelSmall?.copyWith(
-              color: AppColors.ink500,
-              fontWeight: FontWeight.w700,
-            ),
+                  color: AppColors.ink500,
+                  fontWeight: FontWeight.w700,
+                ),
           ),
           const SizedBox(height: 4),
           Text(
             value,
             style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-              color: AppColors.ink900,
-              fontWeight: FontWeight.w700,
-            ),
+                  color: AppColors.ink900,
+                  fontWeight: FontWeight.w700,
+                ),
           ),
         ],
       ),

--- a/lib/features/enrollment/presentation/views/enrollment_form_view.dart
+++ b/lib/features/enrollment/presentation/views/enrollment_form_view.dart
@@ -243,8 +243,7 @@ class _EnrollmentFormViewState extends ConsumerState<EnrollmentFormView> {
     }
 
     final deputyChanged = !_listsEqual(newDeputyIds, _deputyDirectorIds);
-    final changed =
-        deputyChanged ||
+    final changed = deputyChanged ||
         newSecretaryId != _secretaryId ||
         newTreasurerId != _treasurerId ||
         newSecretaryTreasurerId != _secretaryTreasurerId;
@@ -396,9 +395,8 @@ class _EnrollmentFormViewState extends ConsumerState<EnrollmentFormView> {
         deputyDirectorIds: _deputyDirectorIds,
         secretaryId: _useSecretaryTreasurer ? null : _secretaryId,
         treasurerId: _useSecretaryTreasurer ? null : _treasurerId,
-        secretaryTreasurerId: widget.hasSecretaryTreasurerRole
-            ? _secretaryTreasurerId
-            : null,
+        secretaryTreasurerId:
+            widget.hasSecretaryTreasurerRole ? _secretaryTreasurerId : null,
       );
     } else {
       success = await notifier.create(
@@ -415,9 +413,8 @@ class _EnrollmentFormViewState extends ConsumerState<EnrollmentFormView> {
         deputyDirectorIds: _deputyDirectorIds,
         secretaryId: _useSecretaryTreasurer ? null : _secretaryId,
         treasurerId: _useSecretaryTreasurer ? null : _treasurerId,
-        secretaryTreasurerId: widget.hasSecretaryTreasurerRole
-            ? _secretaryTreasurerId
-            : null,
+        secretaryTreasurerId:
+            widget.hasSecretaryTreasurerRole ? _secretaryTreasurerId : null,
       );
     }
 
@@ -468,14 +465,14 @@ class _EnrollmentFormViewState extends ConsumerState<EnrollmentFormView> {
     // El director es el usuario actual con rol director (display-only)
     final directorMember = currentUserCtx?.isDirector == true
         ? members
-              .where(
-                (m) =>
-                    m.clubRole?.toLowerCase().contains('director') == true &&
-                    !m.clubRole!.toLowerCase().contains('sub') &&
-                    !m.clubRole!.toLowerCase().contains('vice') &&
-                    !m.clubRole!.toLowerCase().contains('deputy'),
-              )
-              .firstOrNull
+            .where(
+              (m) =>
+                  m.clubRole?.toLowerCase().contains('director') == true &&
+                  !m.clubRole!.toLowerCase().contains('sub') &&
+                  !m.clubRole!.toLowerCase().contains('vice') &&
+                  !m.clubRole!.toLowerCase().contains('deputy'),
+            )
+            .firstOrNull
         : null;
 
     return Scaffold(
@@ -500,9 +497,8 @@ class _EnrollmentFormViewState extends ConsumerState<EnrollmentFormView> {
             color: c.text,
             size: 22,
           ),
-          onPressed: formState.isLoading
-              ? null
-              : () => Navigator.of(context).pop(),
+          onPressed:
+              formState.isLoading ? null : () => Navigator.of(context).pop(),
         ),
         bottom: PreferredSize(
           preferredSize: const Size.fromHeight(1),
@@ -675,8 +671,8 @@ class _EnrollmentFormViewState extends ConsumerState<EnrollmentFormView> {
               _ToggleRow(
                 icon: HugeIcons.strokeRoundedUserShield01,
                 label: 'enrollment.form.label_use_secretary_treasurer'.tr(),
-                subtitle: 'enrollment.form.subtitle_use_secretary_treasurer'
-                    .tr(),
+                subtitle:
+                    'enrollment.form.subtitle_use_secretary_treasurer'.tr(),
                 value: _secretaryTreasurerId != null,
                 enabled: !formState.isLoading,
                 onChanged: (v) => setState(() {
@@ -735,8 +731,8 @@ class _EnrollmentFormViewState extends ConsumerState<EnrollmentFormView> {
                     ? null
                     : _secretaryTreasurerId,
                 members: members,
-                placeholder: 'enrollment.form.placeholder_secretary_treasurer'
-                    .tr(),
+                placeholder:
+                    'enrollment.form.placeholder_secretary_treasurer'.tr(),
                 emptyMessage: 'enrollment.form.empty_members'.tr(),
                 enabled: !formState.isLoading && members.isNotEmpty,
                 onChanged: (id) => setState(() => _secretaryTreasurerId = id),
@@ -901,8 +897,8 @@ class _LocationPickerField extends StatelessWidget {
             color: hasError
                 ? AppColors.error
                 : hasResult
-                ? AppColors.primary
-                : c.border,
+                    ? AppColors.primary
+                    : c.border,
             width: hasResult || hasError ? 1.5 : 1,
           ),
         ),
@@ -913,8 +909,8 @@ class _LocationPickerField extends StatelessWidget {
               color: hasError
                   ? AppColors.error
                   : hasResult
-                  ? AppColors.primary
-                  : c.textTertiary,
+                      ? AppColors.primary
+                      : c.textTertiary,
               size: 20,
             ),
             const SizedBox(width: 12),
@@ -1369,9 +1365,8 @@ class _MultiMemberSelector extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final c = context.sac;
-    final selectedMembers = members
-        .where((m) => selectedIds.contains(m.userId))
-        .toList();
+    final selectedMembers =
+        members.where((m) => selectedIds.contains(m.userId)).toList();
 
     return GestureDetector(
       onTap: enabled && members.isNotEmpty
@@ -1661,8 +1656,7 @@ class _MemberPickerSheetState extends State<_MemberPickerSheet> {
                     itemBuilder: (_, i) {
                       final member = filtered[i];
                       final isSelected = _selected.contains(member.userId);
-                      final canSelect =
-                          isSelected ||
+                      final canSelect = isSelected ||
                           !widget.multiSelect ||
                           _selected.length < widget.maxSelect;
 

--- a/lib/features/evidence_folder/presentation/views/evidence_section_detail_view.dart
+++ b/lib/features/evidence_folder/presentation/views/evidence_section_detail_view.dart
@@ -58,8 +58,7 @@ class _EvidenceSectionDetailViewState
       evidenceSectionNotifierProvider(widget.clubSectionId),
     );
 
-    final canModify =
-        (widget.section.status == EvidenceSectionStatus.pending ||
+    final canModify = (widget.section.status == EvidenceSectionStatus.pending ||
             widget.section.status == EvidenceSectionStatus.rejected) &&
         widget.folderIsOpen;
 
@@ -99,9 +98,9 @@ class _EvidenceSectionDetailViewState
           title: Text(
             'evidence_folder.section_title'.tr(),
             style: Theme.of(context).textTheme.titleLarge?.copyWith(
-              fontWeight: FontWeight.w700,
-              color: c.text,
-            ),
+                  fontWeight: FontWeight.w700,
+                  color: c.text,
+                ),
             overflow: TextOverflow.ellipsis,
           ),
           backgroundColor: c.background,
@@ -123,8 +122,7 @@ class _EvidenceSectionDetailViewState
                   _stagingManagerKey.currentState?.submitForValidation();
                 },
                 canSubmit: _canSubmitFromStagingManager(canModify),
-                isLoading:
-                    notifierState.isLoading ||
+                isLoading: notifierState.isLoading ||
                     (_stagingManagerKey.currentState?.isLoadingForActionBar ??
                         false),
               )
@@ -144,21 +142,21 @@ class _EvidenceSectionDetailViewState
                       children: [
                         Text(
                           'evidence_folder.section_detail_label'.tr(),
-                          style: Theme.of(context).textTheme.labelSmall
-                              ?.copyWith(
-                                color: c.textSecondary,
-                                letterSpacing: 0.8,
-                              ),
+                          style:
+                              Theme.of(context).textTheme.labelSmall?.copyWith(
+                                    color: c.textSecondary,
+                                    letterSpacing: 0.8,
+                                  ),
                         ),
                         const SizedBox(height: 4),
                         Text(
                           widget.section.name,
-                          style: Theme.of(context).textTheme.titleMedium
-                              ?.copyWith(
-                                fontWeight: FontWeight.w700,
-                                color: c.text,
-                                height: 1.25,
-                              ),
+                          style:
+                              Theme.of(context).textTheme.titleMedium?.copyWith(
+                                    fontWeight: FontWeight.w700,
+                                    color: c.text,
+                                    height: 1.25,
+                                  ),
                         ),
                       ],
                     ),
@@ -177,9 +175,9 @@ class _EvidenceSectionDetailViewState
                     child: Text(
                       'evidence_folder.section_status_label'.tr(),
                       style: Theme.of(context).textTheme.labelSmall?.copyWith(
-                        color: c.textSecondary,
-                        letterSpacing: 0.8,
-                      ),
+                            color: c.textSecondary,
+                            letterSpacing: 0.8,
+                          ),
                     ),
                   ),
                   const SizedBox(height: 8),
@@ -205,9 +203,9 @@ class _EvidenceSectionDetailViewState
                       child: Text(
                         'evidence_folder.evaluation_result_title'.tr(),
                         style: Theme.of(context).textTheme.titleSmall?.copyWith(
-                          fontWeight: FontWeight.w700,
-                          color: c.text,
-                        ),
+                              fontWeight: FontWeight.w700,
+                              color: c.text,
+                            ),
                       ),
                     ),
                     const SizedBox(height: 12),
@@ -225,9 +223,9 @@ class _EvidenceSectionDetailViewState
                     child: Text(
                       'evidence_folder.evidence_files_title'.tr(),
                       style: Theme.of(context).textTheme.titleSmall?.copyWith(
-                        fontWeight: FontWeight.w700,
-                        color: c.text,
-                      ),
+                            fontWeight: FontWeight.w700,
+                            color: c.text,
+                          ),
                     ),
                   ),
 
@@ -417,9 +415,9 @@ class _SectionMetaCard extends StatelessWidget {
             Text(
               section.description!,
               style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                color: c.textSecondary,
-                height: 1.5,
-              ),
+                    color: c.textSecondary,
+                    height: 1.5,
+                  ),
             ),
             const SizedBox(height: 14),
             Divider(color: c.divider),
@@ -745,10 +743,10 @@ class _EvaluationResultCard extends StatelessWidget {
                         },
                       ),
                       style: Theme.of(context).textTheme.labelSmall?.copyWith(
-                        color: AppColors.accentDark,
-                        fontWeight: FontWeight.w600,
-                        height: 1.3,
-                      ),
+                            color: AppColors.accentDark,
+                            fontWeight: FontWeight.w600,
+                            height: 1.3,
+                          ),
                     ),
                   ),
                 ],
@@ -776,10 +774,10 @@ class _EvaluationResultCard extends StatelessWidget {
                         },
                       ),
                       style: Theme.of(context).textTheme.labelSmall?.copyWith(
-                        color: AppColors.secondaryDark,
-                        fontWeight: FontWeight.w600,
-                        height: 1.3,
-                      ),
+                            color: AppColors.secondaryDark,
+                            fontWeight: FontWeight.w600,
+                            height: 1.3,
+                          ),
                     ),
                   ),
                 ],
@@ -803,9 +801,9 @@ class _EvaluationResultCard extends StatelessWidget {
             Text(
               section.evaluationNotes!,
               style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                color: AppColors.secondaryDark,
-                height: 1.5,
-              ),
+                    color: AppColors.secondaryDark,
+                    height: 1.5,
+                  ),
             ),
           ],
         ],
@@ -841,9 +839,9 @@ class _ReviewerNotesBlock extends StatelessWidget {
           Text(
             'evidence_folder.reviewer_comments'.tr(),
             style: Theme.of(context).textTheme.labelSmall?.copyWith(
-              color: context.sac.textSecondary,
-              letterSpacing: 0.8,
-            ),
+                  color: context.sac.textSecondary,
+                  letterSpacing: 0.8,
+                ),
           ),
           const SizedBox(height: 8),
           ...filesWithNotes.map(
@@ -881,13 +879,11 @@ class _ReviewerNoteCalloutState extends State<_ReviewerNoteCallout> {
 
     // Colores info (azul suave) — dark-mode aware, reutiliza los tokens de
     // AppColors.statusInfoBg* que ya existen para el estado "enviado".
-    final bgColor = isDark
-        ? AppColors.statusInfoBgDark
-        : AppColors.statusInfoBgLight;
+    final bgColor =
+        isDark ? AppColors.statusInfoBgDark : AppColors.statusInfoBgLight;
     final borderColor = AppColors.info.withValues(alpha: isDark ? 0.3 : 0.35);
-    final noteColor = isDark
-        ? AppColors.statusInfoTextDark
-        : AppColors.statusInfoText;
+    final noteColor =
+        isDark ? AppColors.statusInfoTextDark : AppColors.statusInfoText;
     final labelColor = isDark
         ? AppColors.statusInfoTextDark.withValues(alpha: 0.7)
         : AppColors.statusInfoText.withValues(alpha: 0.75);

--- a/lib/features/finances/presentation/views/add_transaction_sheet.dart
+++ b/lib/features/finances/presentation/views/add_transaction_sheet.dart
@@ -105,8 +105,8 @@ class _AddTransactionSheetState extends ConsumerState<AddTransactionSheet> {
                       ? 'finances.add_transaction.edit_title'.tr()
                       : 'finances.add_transaction.new_title'.tr(),
                   style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                    fontWeight: FontWeight.w700,
-                  ),
+                        fontWeight: FontWeight.w700,
+                      ),
                 ),
                 IconButton(
                   onPressed: () => Navigator.pop(context),
@@ -195,8 +195,7 @@ class _AddTransactionSheetState extends ConsumerState<AddTransactionSheet> {
                               : c.appliesToExpense;
                         }).toList();
 
-                        final dropdownValue =
-                            _selectedCategory != null &&
+                        final dropdownValue = _selectedCategory != null &&
                                 filtered.any(
                                   (c) => c.id == _selectedCategory!.id,
                                 )
@@ -212,7 +211,7 @@ class _AddTransactionSheetState extends ConsumerState<AddTransactionSheet> {
                           initialValue: dropdownValue,
                           validator: (v) => v == null
                               ? 'finances.add_transaction.category_required'
-                                    .tr()
+                                  .tr()
                               : null,
                           builder: (field) => _CategoryPickerField(
                             value: field.value,
@@ -329,9 +328,9 @@ class _AddTransactionSheetState extends ConsumerState<AddTransactionSheet> {
                             : Text(
                                 _isEditing
                                     ? 'finances.add_transaction.save_button'
-                                          .tr()
+                                        .tr()
                                     : 'finances.add_transaction.register_button'
-                                          .tr(),
+                                        .tr(),
                                 style: const TextStyle(
                                   fontWeight: FontWeight.w700,
                                   fontSize: 16,
@@ -366,24 +365,23 @@ class _AddTransactionSheetState extends ConsumerState<AddTransactionSheet> {
     final clubIdAsync = await ref.read(currentClubIdProvider.future);
     if (clubIdAsync == null) return;
 
-    final success = await ref
-        .read(transactionFormNotifierProvider.notifier)
-        .save(
-          clubId: clubIdAsync,
-          categoryId: _selectedCategory!.id,
-          amount: amount,
-          description: _descController.text.trim(),
-          date: _selectedDate,
-          year: selectedMonth.year,
-          month: selectedMonth.month,
-          existingId: _isEditing ? widget.existing!.id : null,
-        );
+    final success =
+        await ref.read(transactionFormNotifierProvider.notifier).save(
+              clubId: clubIdAsync,
+              categoryId: _selectedCategory!.id,
+              amount: amount,
+              description: _descController.text.trim(),
+              date: _selectedDate,
+              year: selectedMonth.year,
+              month: selectedMonth.month,
+              existingId: _isEditing ? widget.existing!.id : null,
+            );
 
     if (!success || !mounted) return;
 
     final savedTransaction =
         ref.read(transactionFormNotifierProvider).savedTransaction ??
-        widget.existing;
+            widget.existing;
     final financeId = savedTransaction?.id;
     if (financeId == null) return;
 
@@ -478,7 +476,7 @@ class _AddTransactionSheetState extends ConsumerState<AddTransactionSheet> {
         setState(() {
           _evidenceError =
               ref.read(transactionFormNotifierProvider).errorMessage ??
-              'finances.errors.upload_evidence'.tr();
+                  'finances.errors.upload_evidence'.tr();
         });
         return false;
       }
@@ -602,7 +600,9 @@ class _EvidenceTile extends StatelessWidget {
   final XFile? file;
   final VoidCallback? onRemove;
 
-  const _EvidenceTile.network(this.url) : file = null, onRemove = null;
+  const _EvidenceTile.network(this.url)
+      : file = null,
+        onRemove = null;
 
   const _EvidenceTile.file(this.file, {required this.onRemove}) : url = null;
 
@@ -726,13 +726,12 @@ class _CategoryPickerField extends StatelessWidget {
                         maxLines: 1,
                         overflow: TextOverflow.ellipsis,
                         style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                          fontWeight: hasValue
-                              ? FontWeight.w600
-                              : FontWeight.w500,
-                          color: hasValue
-                              ? context.sac.text
-                              : context.sac.textTertiary,
-                        ),
+                              fontWeight:
+                                  hasValue ? FontWeight.w600 : FontWeight.w500,
+                              color: hasValue
+                                  ? context.sac.text
+                                  : context.sac.textTertiary,
+                            ),
                       ),
                     ),
                     const SizedBox(width: 8),
@@ -830,8 +829,8 @@ class _CategoryPickerSheet extends StatelessWidget {
                     child: Text(
                       'finances.add_transaction.category_label'.tr(),
                       style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                        fontWeight: FontWeight.w800,
-                      ),
+                            fontWeight: FontWeight.w800,
+                          ),
                     ),
                   ),
                 ],
@@ -928,11 +927,10 @@ class _CategoryPickerOption extends StatelessWidget {
                   child: Text(
                     category.name,
                     style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                      color: foreground,
-                      fontWeight: isSelected
-                          ? FontWeight.w700
-                          : FontWeight.w500,
-                    ),
+                          color: foreground,
+                          fontWeight:
+                              isSelected ? FontWeight.w700 : FontWeight.w500,
+                        ),
                   ),
                 ),
                 if (isSelected)
@@ -1009,9 +1007,8 @@ class _TypeChip extends StatelessWidget {
         duration: const Duration(milliseconds: 200),
         padding: const EdgeInsets.symmetric(vertical: 14),
         decoration: BoxDecoration(
-          color: isSelected
-              ? color.withValues(alpha: 0.12)
-              : Colors.transparent,
+          color:
+              isSelected ? color.withValues(alpha: 0.12) : Colors.transparent,
           borderRadius: BorderRadius.circular(14),
           border: Border.all(
             color: isSelected ? color : Theme.of(context).dividerColor,
@@ -1122,9 +1119,9 @@ class _SectionLabel extends StatelessWidget {
     return Text(
       text,
       style: Theme.of(context).textTheme.bodySmall?.copyWith(
-        fontWeight: FontWeight.w700,
-        color: Theme.of(context).colorScheme.onSurfaceVariant,
-      ),
+            fontWeight: FontWeight.w700,
+            color: Theme.of(context).colorScheme.onSurfaceVariant,
+          ),
     );
   }
 }

--- a/lib/features/insurance/presentation/views/insurance_form_sheet.dart
+++ b/lib/features/insurance/presentation/views/insurance_form_sheet.dart
@@ -103,8 +103,8 @@ class _InsuranceFormSheetState extends ConsumerState<InsuranceFormSheet> {
                       ? 'insurance.form.title_edit'.tr()
                       : 'insurance.form.title_create'.tr(),
                   style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                    fontWeight: FontWeight.w700,
-                  ),
+                        fontWeight: FontWeight.w700,
+                      ),
                 ),
                 IconButton(
                   onPressed: () => Navigator.pop(context),
@@ -219,9 +219,8 @@ class _InsuranceFormSheetState extends ConsumerState<InsuranceFormSheet> {
                     ),
                     const SizedBox(height: 6),
                     _EvidenceUploader(
-                      currentFile: ref
-                          .watch(insuranceFormNotifierProvider)
-                          .selectedFile,
+                      currentFile:
+                          ref.watch(insuranceFormNotifierProvider).selectedFile,
                       existingFileUrl: _isEditing
                           ? widget.existingInsurance?.evidenceFileUrl
                           : null,
@@ -352,9 +351,7 @@ class _InsuranceFormSheetState extends ConsumerState<InsuranceFormSheet> {
         ? double.tryParse(_amountController.text)
         : null;
 
-    final success = await ref
-        .read(insuranceFormNotifierProvider.notifier)
-        .save(
+    final success = await ref.read(insuranceFormNotifierProvider.notifier).save(
           memberId: _memberId,
           insuranceType: _insuranceType,
           startDate: _startDate!,
@@ -366,9 +363,8 @@ class _InsuranceFormSheetState extends ConsumerState<InsuranceFormSheet> {
               ? null
               : _providerController.text.trim(),
           coverageAmount: amount,
-          existingInsuranceId: _isEditing
-              ? widget.existingInsurance!.insuranceId
-              : null,
+          existingInsuranceId:
+              _isEditing ? widget.existingInsurance!.insuranceId : null,
         );
 
     if (success && mounted) {
@@ -413,9 +409,8 @@ class _InsuranceTypeSelector extends StatelessWidget {
               duration: const Duration(milliseconds: 150),
               padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
               decoration: BoxDecoration(
-                color: isSelected
-                    ? AppColors.primarySurface
-                    : Colors.transparent,
+                color:
+                    isSelected ? AppColors.primarySurface : Colors.transparent,
                 borderRadius: BorderRadius.circular(12),
                 border: Border.all(
                   color: isSelected
@@ -443,11 +438,10 @@ class _InsuranceTypeSelector extends StatelessWidget {
                   Text(
                     t.label,
                     style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                      fontWeight: isSelected
-                          ? FontWeight.w700
-                          : FontWeight.w400,
-                      color: isSelected ? AppColors.primaryDark : null,
-                    ),
+                          fontWeight:
+                              isSelected ? FontWeight.w700 : FontWeight.w400,
+                          color: isSelected ? AppColors.primaryDark : null,
+                        ),
                   ),
                 ],
               ),
@@ -510,11 +504,11 @@ class _DatePickerField extends StatelessWidget {
               child: Text(
                 formatted,
                 style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                  fontWeight: FontWeight.w500,
-                  color: selectedDate != null
-                      ? null
-                      : Theme.of(context).hintColor,
-                ),
+                      fontWeight: FontWeight.w500,
+                      color: selectedDate != null
+                          ? null
+                          : Theme.of(context).hintColor,
+                    ),
               ),
             ),
             if (selectedDate != null)
@@ -946,9 +940,9 @@ class _SectionLabel extends StatelessWidget {
     return Text(
       text,
       style: Theme.of(context).textTheme.bodySmall?.copyWith(
-        fontWeight: FontWeight.w700,
-        color: Theme.of(context).colorScheme.onSurfaceVariant,
-      ),
+            fontWeight: FontWeight.w700,
+            color: Theme.of(context).colorScheme.onSurfaceVariant,
+          ),
     );
   }
 }

--- a/lib/features/insurance/presentation/views/insurance_view.dart
+++ b/lib/features/insurance/presentation/views/insurance_view.dart
@@ -48,9 +48,8 @@ class _InsuranceViewState extends ConsumerState<InsuranceView> {
 
     return Scaffold(
       backgroundColor: context.sac.background,
-      floatingActionButton: canManage
-          ? _AddFab(onTap: () => _openAddSheet(context, null))
-          : null,
+      floatingActionButton:
+          canManage ? _AddFab(onTap: () => _openAddSheet(context, null)) : null,
       body: SafeArea(
         child: RefreshIndicator(
           color: AppColors.primary,
@@ -74,10 +73,10 @@ class _InsuranceViewState extends ConsumerState<InsuranceView> {
                 title: Text(
                   'insurance.view.title'.tr(),
                   style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                    fontWeight: FontWeight.w700,
-                    color: context.sac.text,
-                    letterSpacing: -0.2,
-                  ),
+                        fontWeight: FontWeight.w700,
+                        color: context.sac.text,
+                        letterSpacing: -0.2,
+                      ),
                 ),
                 centerTitle: false,
               ),
@@ -218,18 +217,18 @@ class _InsuranceBody extends ConsumerWidget {
           )
         else
           ...items.asMap().entries.map(
-            (entry) => StaggeredListItem(
-              index: entry.key,
-              staggerDelay: const Duration(milliseconds: 36),
-              duration: const Duration(milliseconds: 200),
-              slideOffset: 8,
-              child: MemberInsuranceCard(
-                insurance: entry.value,
-                canManage: canManage,
-                onTap: () => onItemTap(entry.value),
+                (entry) => StaggeredListItem(
+                  index: entry.key,
+                  staggerDelay: const Duration(milliseconds: 36),
+                  duration: const Duration(milliseconds: 200),
+                  slideOffset: 8,
+                  child: MemberInsuranceCard(
+                    insurance: entry.value,
+                    canManage: canManage,
+                    onTap: () => onItemTap(entry.value),
+                  ),
+                ),
               ),
-            ),
-          ),
 
         const SizedBox(height: 80), // FAB clearance
       ],
@@ -420,9 +419,9 @@ class _SortCountRow extends StatelessWidget {
           Text(
             key.tr(namedArgs: {'count': '$count'}),
             style: Theme.of(context).textTheme.bodySmall?.copyWith(
-              color: Theme.of(context).colorScheme.onSurfaceVariant,
-              fontWeight: FontWeight.w500,
-            ),
+                  color: Theme.of(context).colorScheme.onSurfaceVariant,
+                  fontWeight: FontWeight.w500,
+                ),
           ),
           const Spacer(),
           // Sort dropdown
@@ -451,9 +450,9 @@ class _SortCountRow extends StatelessWidget {
                   Text(
                     sortOrder.label,
                     style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                      fontWeight: FontWeight.w600,
-                      fontSize: 11,
-                    ),
+                          fontWeight: FontWeight.w600,
+                          fontSize: 11,
+                        ),
                   ),
                 ],
               ),
@@ -583,8 +582,8 @@ class _ErrorBody extends StatelessWidget {
           Text(
             message,
             style: Theme.of(context).textTheme.bodySmall?.copyWith(
-              color: Theme.of(context).colorScheme.onSurfaceVariant,
-            ),
+                  color: Theme.of(context).colorScheme.onSurfaceVariant,
+                ),
             textAlign: TextAlign.center,
           ),
           const SizedBox(height: 24),
@@ -631,9 +630,9 @@ class _EmptyState extends StatelessWidget {
                 ? 'insurance.view.empty_filtered_title'.tr()
                 : 'insurance.view.empty_title'.tr(),
             style: Theme.of(context).textTheme.titleSmall?.copyWith(
-              color: Theme.of(context).colorScheme.onSurfaceVariant,
-              fontWeight: FontWeight.w600,
-            ),
+                  color: Theme.of(context).colorScheme.onSurfaceVariant,
+                  fontWeight: FontWeight.w600,
+                ),
             textAlign: TextAlign.center,
           ),
           const SizedBox(height: 8),
@@ -641,13 +640,13 @@ class _EmptyState extends StatelessWidget {
             hasFilters
                 ? 'insurance.view.empty_filtered_subtitle'.tr()
                 : canManage
-                ? 'insurance.view.empty_subtitle_manager'.tr()
-                : 'insurance.view.empty_subtitle_member'.tr(),
+                    ? 'insurance.view.empty_subtitle_manager'.tr()
+                    : 'insurance.view.empty_subtitle_member'.tr(),
             style: Theme.of(context).textTheme.bodySmall?.copyWith(
-              color: Theme.of(
-                context,
-              ).colorScheme.onSurfaceVariant.withValues(alpha: 0.7),
-            ),
+                  color: Theme.of(
+                    context,
+                  ).colorScheme.onSurfaceVariant.withValues(alpha: 0.7),
+                ),
             textAlign: TextAlign.center,
           ),
         ],

--- a/lib/features/insurance/presentation/widgets/member_insurance_card.dart
+++ b/lib/features/insurance/presentation/widgets/member_insurance_card.dart
@@ -74,9 +74,9 @@ class _MemberInsuranceCardState extends State<MemberInsuranceCard> {
                       Text(
                         insurance.memberName,
                         style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                          fontWeight: FontWeight.w700,
-                          color: c.text,
-                        ),
+                              fontWeight: FontWeight.w700,
+                              color: c.text,
+                            ),
                         maxLines: 1,
                         overflow: TextOverflow.ellipsis,
                       ),
@@ -84,7 +84,9 @@ class _MemberInsuranceCardState extends State<MemberInsuranceCard> {
                         const SizedBox(height: 2),
                         Text(
                           insurance.memberClass!,
-                          style: Theme.of(context).textTheme.bodySmall
+                          style: Theme.of(context)
+                              .textTheme
+                              .bodySmall
                               ?.copyWith(color: c.textSecondary, fontSize: 11),
                         ),
                       ],
@@ -100,7 +102,9 @@ class _MemberInsuranceCardState extends State<MemberInsuranceCard> {
                             Flexible(
                               child: Text(
                                 _expiryText(insurance),
-                                style: Theme.of(context).textTheme.bodySmall
+                                style: Theme.of(context)
+                                    .textTheme
+                                    .bodySmall
                                     ?.copyWith(
                                       color: _expiryColor(insurance),
                                       fontSize: 10.5,

--- a/lib/features/inventory/presentation/views/add_inventory_item_sheet.dart
+++ b/lib/features/inventory/presentation/views/add_inventory_item_sheet.dart
@@ -120,9 +120,9 @@ class _AddInventoryItemSheetState extends ConsumerState<AddInventoryItemSheet> {
                         ? 'inventory.form.title_edit'.tr()
                         : 'inventory.form.title_new'.tr(),
                     style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                      fontWeight: FontWeight.w700,
-                      color: c.text,
-                    ),
+                          fontWeight: FontWeight.w700,
+                          color: c.text,
+                        ),
                   ),
                 ),
                 IconButton(
@@ -182,8 +182,7 @@ class _AddInventoryItemSheetState extends ConsumerState<AddInventoryItemSheet> {
                             ref.invalidate(inventoryCategoriesProvider),
                       ),
                       data: (cats) {
-                        final pickerValue =
-                            _selectedCategory != null &&
+                        final pickerValue = _selectedCategory != null &&
                                 cats.any((c) => c.id == _selectedCategory!.id)
                             ? cats.firstWhere(
                                 (c) => c.id == _selectedCategory!.id,
@@ -471,39 +470,37 @@ class _AddInventoryItemSheetState extends ConsumerState<AddInventoryItemSheet> {
         ? double.tryParse(_valueController.text)
         : null;
 
-    final success = await ref
-        .read(inventoryItemFormNotifierProvider.notifier)
-        .save(
-          clubId: clubId,
-          instanceType: instanceType,
-          name: _nameController.text.trim(),
-          categoryId: _selectedCategory!.id,
-          quantity: quantity,
-          condition: _condition,
-          description: _descController.text.trim().isEmpty
-              ? null
-              : _descController.text.trim(),
-          serialNumber: _serialController.text.trim().isEmpty
-              ? null
-              : _serialController.text.trim(),
-          purchaseDate: _purchaseDate,
-          estimatedValue: value,
-          location: _locationController.text.trim().isEmpty
-              ? null
-              : _locationController.text.trim(),
-          assignedTo: _assignedToController.text.trim().isEmpty
-              ? null
-              : _assignedToController.text.trim(),
-          notes: _notesController.text.trim().isEmpty
-              ? null
-              : _notesController.text.trim(),
-          existingId: _isEditing ? widget.existing!.id : null,
-        );
+    final success =
+        await ref.read(inventoryItemFormNotifierProvider.notifier).save(
+              clubId: clubId,
+              instanceType: instanceType,
+              name: _nameController.text.trim(),
+              categoryId: _selectedCategory!.id,
+              quantity: quantity,
+              condition: _condition,
+              description: _descController.text.trim().isEmpty
+                  ? null
+                  : _descController.text.trim(),
+              serialNumber: _serialController.text.trim().isEmpty
+                  ? null
+                  : _serialController.text.trim(),
+              purchaseDate: _purchaseDate,
+              estimatedValue: value,
+              location: _locationController.text.trim().isEmpty
+                  ? null
+                  : _locationController.text.trim(),
+              assignedTo: _assignedToController.text.trim().isEmpty
+                  ? null
+                  : _assignedToController.text.trim(),
+              notes: _notesController.text.trim().isEmpty
+                  ? null
+                  : _notesController.text.trim(),
+              existingId: _isEditing ? widget.existing!.id : null,
+            );
 
     if (!success || !mounted) return;
 
-    final savedItem =
-        ref.read(inventoryItemFormNotifierProvider).savedItem ??
+    final savedItem = ref.read(inventoryItemFormNotifierProvider).savedItem ??
         widget.existing;
     final itemId = savedItem?.id;
     if (itemId == null) return;
@@ -586,7 +583,7 @@ class _AddInventoryItemSheetState extends ConsumerState<AddInventoryItemSheet> {
         setState(() {
           _evidenceError =
               ref.read(inventoryItemFormNotifierProvider).errorMessage ??
-              'inventory.errors.upload_evidence'.tr();
+                  'inventory.errors.upload_evidence'.tr();
         });
         return false;
       }
@@ -626,9 +623,9 @@ class _SectionHeader extends StatelessWidget {
         Text(
           title,
           style: Theme.of(context).textTheme.labelLarge?.copyWith(
-            color: context.sac.text,
-            fontWeight: FontWeight.w700,
-          ),
+                color: context.sac.text,
+                fontWeight: FontWeight.w700,
+              ),
         ),
         const SizedBox(width: 8),
         Expanded(child: Divider(color: context.sac.border, thickness: 1)),
@@ -649,9 +646,9 @@ class _SectionLabel extends StatelessWidget {
     return Text(
       text,
       style: Theme.of(context).textTheme.bodySmall?.copyWith(
-        fontWeight: FontWeight.w700,
-        color: context.sac.textSecondary,
-      ),
+            fontWeight: FontWeight.w700,
+            color: context.sac.textSecondary,
+          ),
     );
   }
 }
@@ -778,11 +775,11 @@ class _DatePickerField extends StatelessWidget {
               child: Text(
                 formatted,
                 style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                  fontWeight: FontWeight.w500,
-                  color: selectedDate != null
-                      ? null
-                      : Theme.of(context).hintColor,
-                ),
+                      fontWeight: FontWeight.w500,
+                      color: selectedDate != null
+                          ? null
+                          : Theme.of(context).hintColor,
+                    ),
               ),
             ),
             if (selectedDate != null)
@@ -882,13 +879,12 @@ class _CategoryPickerField extends StatelessWidget {
                         maxLines: 1,
                         overflow: TextOverflow.ellipsis,
                         style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                          fontWeight: hasValue
-                              ? FontWeight.w600
-                              : FontWeight.w500,
-                          color: hasValue
-                              ? context.sac.text
-                              : context.sac.textTertiary,
-                        ),
+                              fontWeight:
+                                  hasValue ? FontWeight.w600 : FontWeight.w500,
+                              color: hasValue
+                                  ? context.sac.text
+                                  : context.sac.textTertiary,
+                            ),
                       ),
                     ),
                     const SizedBox(width: 8),
@@ -986,8 +982,8 @@ class _CategoryPickerSheet extends StatelessWidget {
                     child: Text(
                       'inventory.form.category_label'.tr(),
                       style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                        fontWeight: FontWeight.w800,
-                      ),
+                            fontWeight: FontWeight.w800,
+                          ),
                     ),
                   ),
                 ],
@@ -1084,11 +1080,10 @@ class _CategoryPickerOption extends StatelessWidget {
                   child: Text(
                     category.name,
                     style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                      color: foreground,
-                      fontWeight: isSelected
-                          ? FontWeight.w700
-                          : FontWeight.w500,
-                    ),
+                          color: foreground,
+                          fontWeight:
+                              isSelected ? FontWeight.w700 : FontWeight.w500,
+                        ),
                   ),
                 ),
                 if (isSelected)
@@ -1215,7 +1210,9 @@ class _EvidenceTile extends StatelessWidget {
   final XFile? file;
   final VoidCallback? onRemove;
 
-  const _EvidenceTile.network(this.url) : file = null, onRemove = null;
+  const _EvidenceTile.network(this.url)
+      : file = null,
+        onRemove = null;
 
   const _EvidenceTile.file(this.file, {required this.onRemove}) : url = null;
 

--- a/lib/features/materials/presentation/views/catalog_view.dart
+++ b/lib/features/materials/presentation/views/catalog_view.dart
@@ -35,10 +35,10 @@ class _CatalogViewState extends ConsumerState<CatalogView> {
   String? _searchQ;
 
   CatalogQuery get _query => CatalogQuery(
-    cat: _selectedCat,
-    programaId: _selectedProgramaId,
-    q: _searchQ,
-  );
+        cat: _selectedCat,
+        programaId: _selectedProgramaId,
+        q: _searchQ,
+      );
 
   @override
   void dispose() {

--- a/lib/features/materials/presentation/widgets/order_card.dart
+++ b/lib/features/materials/presentation/widgets/order_card.dart
@@ -19,12 +19,10 @@ class OrderCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final c = context.sac;
-    final hasFolio =
-        order.folioReferencia != null &&
+    final hasFolio = order.folioReferencia != null &&
         order.folioReferencia!.trim().isNotEmpty;
-    final folio = hasFolio
-        ? order.folioReferencia!
-        : 'materials.history.no_folio'.tr();
+    final folio =
+        hasFolio ? order.folioReferencia! : 'materials.history.no_folio'.tr();
 
     return MaterialsPressable(
       onTap: onTap,

--- a/lib/features/monthly_reports/presentation/views/monthly_report_detail_view.dart
+++ b/lib/features/monthly_reports/presentation/views/monthly_report_detail_view.dart
@@ -260,8 +260,8 @@ class _ReportDetail extends ConsumerWidget {
                         value: _yesNo(manual?.literatureDistributed),
                       ),
                       _InfoRow(
-                        label: 'monthly_reports.detail.baptized_this_month'
-                            .tr(),
+                        label:
+                            'monthly_reports.detail.baptized_this_month'.tr(),
                         value: _dash(manual?.baptizedThisMonth),
                       ),
                       _InfoRow(
@@ -271,8 +271,8 @@ class _ReportDetail extends ConsumerWidget {
                       if (manual?.clubParticipationDescription?.isNotEmpty ==
                           true)
                         _Paragraph(
-                          label: 'monthly_reports.detail.club_participation'
-                              .tr(),
+                          label:
+                              'monthly_reports.detail.club_participation'.tr(),
                           value: manual!.clubParticipationDescription!,
                         ),
                     ],
@@ -397,8 +397,8 @@ class _StickyActionBarState extends ConsumerState<_StickyActionBar> {
           text: widget.report.canEditManualData
               ? 'monthly_reports.detail.edit_manual_data'.tr()
               : (_isOpeningPdf
-                    ? 'monthly_reports.detail.downloading_pdf'.tr()
-                    : 'monthly_reports.detail.view_pdf_button'.tr()),
+                  ? 'monthly_reports.detail.downloading_pdf'.tr()
+                  : 'monthly_reports.detail.view_pdf_button'.tr()),
           icon: widget.report.canEditManualData
               ? HugeIcons.strokeRoundedNoteEdit
               : HugeIcons.strokeRoundedPdf01,

--- a/lib/features/monthly_reports/presentation/views/monthly_report_manual_data_form_view.dart
+++ b/lib/features/monthly_reports/presentation/views/monthly_report_manual_data_form_view.dart
@@ -136,41 +136,41 @@ class _MonthlyReportManualDataFormViewState
   }
 
   List<TextEditingController> get _textControllers => [
-    _planning,
-    _parents,
-    _youth,
-    _church,
-    _soulTarget,
-    _unbaptized,
-    _studies,
-    _baptizedMonth,
-    _baptizedTotal,
-    _participation,
-    _service,
-  ];
+        _planning,
+        _parents,
+        _youth,
+        _church,
+        _soulTarget,
+        _unbaptized,
+        _studies,
+        _baptizedMonth,
+        _baptizedTotal,
+        _participation,
+        _service,
+      ];
 
   TextEditingController _intController(int? value) =>
       TextEditingController(text: value?.toString() ?? '');
 
   String _fingerprint() => [
-    _planning.text,
-    _parents.text,
-    _youth.text,
-    _church.text,
-    _soulTarget.text,
-    _unbaptized.text,
-    _studies.text,
-    _baptizedMonth.text,
-    _baptizedTotal.text,
-    _participation.text,
-    _service.text,
-    _weeklyInstruction,
-    _studiesGiven,
-    _literature,
-    _certificates,
-    _booklets,
-    _bookletsSigned,
-  ].join('|');
+        _planning.text,
+        _parents.text,
+        _youth.text,
+        _church.text,
+        _soulTarget.text,
+        _unbaptized.text,
+        _studies.text,
+        _baptizedMonth.text,
+        _baptizedTotal.text,
+        _participation.text,
+        _service.text,
+        _weeklyInstruction,
+        _studiesGiven,
+        _literature,
+        _certificates,
+        _booklets,
+        _bookletsSigned,
+      ].join('|');
 
   void _recomputeDirty() {
     final next = _fingerprint() != _initialFingerprint;
@@ -198,28 +198,27 @@ class _MonthlyReportManualDataFormViewState
   }
 
   MonthlyReportManualData _buildData() => MonthlyReportManualData(
-    planningMeetings: _intFrom(_planning),
-    parentMeetings: _intFrom(_parents),
-    youthCouncilAttendance: _intFrom(_youth),
-    churchBoardAttendance: _intFrom(_church),
-    soulTarget: _intFrom(_soulTarget),
-    unbaptizedMembers: _intFrom(_unbaptized),
-    bibleStudiesReceiving: _intFrom(_studies),
-    hasWeeklyBibleInstruction: _weeklyInstruction,
-    bibleStudiesGiven: _studiesGiven,
-    literatureDistributed: _literature,
-    baptizedThisMonth: _intFrom(_baptizedMonth),
-    totalBaptized: _intFrom(_baptizedTotal),
-    clubParticipationDescription: _participation.text.trim().isEmpty
-        ? null
-        : _participation.text.trim(),
-    communityServiceDescription: _service.text.trim().isEmpty
-        ? null
-        : _service.text.trim(),
-    certificatesDelivered: _certificates,
-    membersHaveBooklet: _booklets,
-    bookletRequirementsSigned: _bookletsSigned,
-  );
+        planningMeetings: _intFrom(_planning),
+        parentMeetings: _intFrom(_parents),
+        youthCouncilAttendance: _intFrom(_youth),
+        churchBoardAttendance: _intFrom(_church),
+        soulTarget: _intFrom(_soulTarget),
+        unbaptizedMembers: _intFrom(_unbaptized),
+        bibleStudiesReceiving: _intFrom(_studies),
+        hasWeeklyBibleInstruction: _weeklyInstruction,
+        bibleStudiesGiven: _studiesGiven,
+        literatureDistributed: _literature,
+        baptizedThisMonth: _intFrom(_baptizedMonth),
+        totalBaptized: _intFrom(_baptizedTotal),
+        clubParticipationDescription: _participation.text.trim().isEmpty
+            ? null
+            : _participation.text.trim(),
+        communityServiceDescription:
+            _service.text.trim().isEmpty ? null : _service.text.trim(),
+        certificatesDelivered: _certificates,
+        membersHaveBooklet: _booklets,
+        bookletRequirementsSigned: _bookletsSigned,
+      );
 
   Future<bool> _confirmDiscard() async {
     if (!_dirty) return true;
@@ -331,14 +330,14 @@ class _MonthlyReportManualDataFormViewState
                       child: _FormSection(
                         title: 'monthly_reports.form.meetings_title'.tr(),
                         eyebrow: 'monthly_reports.form.meetings_eyebrow'.tr(),
-                        description: 'monthly_reports.form.meetings_description'
-                            .tr(),
+                        description:
+                            'monthly_reports.form.meetings_description'.tr(),
                         icon: HugeIcons.strokeRoundedCalendar01,
                         children: [
                           _NumberField(
                             controller: _planning,
-                            label: 'monthly_reports.form.planning_meetings'
-                                .tr(),
+                            label:
+                                'monthly_reports.form.planning_meetings'.tr(),
                           ),
                           _NumberField(
                             controller: _parents,
@@ -365,8 +364,8 @@ class _MonthlyReportManualDataFormViewState
                       child: _FormSection(
                         title: 'monthly_reports.form.mission_title'.tr(),
                         eyebrow: 'monthly_reports.form.mission_eyebrow'.tr(),
-                        description: 'monthly_reports.form.mission_description'
-                            .tr(),
+                        description:
+                            'monthly_reports.form.mission_description'.tr(),
                         icon: HugeIcons.strokeRoundedUserMultiple,
                         children: [
                           _NumberField(
@@ -375,8 +374,8 @@ class _MonthlyReportManualDataFormViewState
                           ),
                           _NumberField(
                             controller: _unbaptized,
-                            label: 'monthly_reports.form.unbaptized_members'
-                                .tr(),
+                            label:
+                                'monthly_reports.form.unbaptized_members'.tr(),
                           ),
                           _NumberField(
                             controller: _studies,
@@ -385,8 +384,8 @@ class _MonthlyReportManualDataFormViewState
                                     .tr(),
                           ),
                           _ReportSwitch(
-                            title: 'monthly_reports.form.weekly_instruction'
-                                .tr(),
+                            title:
+                                'monthly_reports.form.weekly_instruction'.tr(),
                             subtitle:
                                 'monthly_reports.form.weekly_instruction_helper'
                                     .tr(),
@@ -404,15 +403,15 @@ class _MonthlyReportManualDataFormViewState
                           ),
                           _ReportSwitch(
                             title: 'monthly_reports.form.literature'.tr(),
-                            subtitle: 'monthly_reports.form.literature_helper'
-                                .tr(),
+                            subtitle:
+                                'monthly_reports.form.literature_helper'.tr(),
                             value: _literature,
                             onChanged: (v) => _setBool(() => _literature = v),
                           ),
                           _NumberField(
                             controller: _baptizedMonth,
-                            label: 'monthly_reports.form.baptized_this_month'
-                                .tr(),
+                            label:
+                                'monthly_reports.form.baptized_this_month'.tr(),
                           ),
                           _NumberField(
                             controller: _baptizedTotal,
@@ -427,21 +426,21 @@ class _MonthlyReportManualDataFormViewState
                       child: _FormSection(
                         title: 'monthly_reports.form.service_title'.tr(),
                         eyebrow: 'monthly_reports.form.service_eyebrow'.tr(),
-                        description: 'monthly_reports.form.service_description'
-                            .tr(),
+                        description:
+                            'monthly_reports.form.service_description'.tr(),
                         icon: HugeIcons.strokeRoundedNoteEdit,
                         children: [
                           _LongTextField(
                             controller: _participation,
-                            label: 'monthly_reports.form.club_participation'
-                                .tr(),
+                            label:
+                                'monthly_reports.form.club_participation'.tr(),
                             hint: 'monthly_reports.form.club_participation_hint'
                                 .tr(),
                           ),
                           _LongTextField(
                             controller: _service,
-                            label: 'monthly_reports.form.community_service'
-                                .tr(),
+                            label:
+                                'monthly_reports.form.community_service'.tr(),
                             hint: 'monthly_reports.form.community_service_hint'
                                 .tr(),
                           ),
@@ -460,15 +459,15 @@ class _MonthlyReportManualDataFormViewState
                         children: [
                           _ReportSwitch(
                             title: 'monthly_reports.form.certificates'.tr(),
-                            subtitle: 'monthly_reports.form.certificates_helper'
-                                .tr(),
+                            subtitle:
+                                'monthly_reports.form.certificates_helper'.tr(),
                             value: _certificates,
                             onChanged: (v) => _setBool(() => _certificates = v),
                           ),
                           _ReportSwitch(
                             title: 'monthly_reports.form.booklets'.tr(),
-                            subtitle: 'monthly_reports.form.booklets_helper'
-                                .tr(),
+                            subtitle:
+                                'monthly_reports.form.booklets_helper'.tr(),
                             value: _booklets,
                             onChanged: (v) => _setBool(() => _booklets = v),
                           ),
@@ -496,8 +495,8 @@ class _MonthlyReportManualDataFormViewState
                   text: state.isLoading
                       ? 'common.saving'.tr()
                       : (!_dirty
-                            ? 'monthly_reports.form.save_disabled_hint'.tr()
-                            : 'monthly_reports.form.save'.tr()),
+                          ? 'monthly_reports.form.save_disabled_hint'.tr()
+                          : 'monthly_reports.form.save'.tr()),
                   icon: HugeIcons.strokeRoundedNoteEdit,
                   onPressed: state.isLoading || !_dirty ? null : _save,
                 ),

--- a/lib/features/monthly_reports/presentation/views/monthly_reports_visible_list_view.dart
+++ b/lib/features/monthly_reports/presentation/views/monthly_reports_visible_list_view.dart
@@ -157,15 +157,14 @@ class _NextActionBar extends ConsumerWidget {
     }
 
     final target = MonthlyReportPeriod.forPreparation();
-    final report = await ref
-        .read(monthlyReportMutationProvider.notifier)
-        .getOrCreateDraft(
-          MonthlyReportDraftParams(
-            enrollmentId: enrollmentId,
-            month: target.month,
-            year: target.year,
-          ),
-        );
+    final report =
+        await ref.read(monthlyReportMutationProvider.notifier).getOrCreateDraft(
+              MonthlyReportDraftParams(
+                enrollmentId: enrollmentId,
+                month: target.month,
+                year: target.year,
+              ),
+            );
     if (!context.mounted) return;
     if (report == null) {
       final state = ref.read(monthlyReportMutationProvider);

--- a/lib/features/post_registration/presentation/views/legal_representative_view.dart
+++ b/lib/features/post_registration/presentation/views/legal_representative_view.dart
@@ -154,8 +154,8 @@ class _LegalRepresentativeViewState
             IconButton(
               icon: HugeIcon(icon: HugeIcons.strokeRoundedTick02, size: 24),
               onPressed: _handleSave,
-              tooltip: 'post_registration.legal_representative.save_tooltip'
-                  .tr(),
+              tooltip:
+                  'post_registration.legal_representative.save_tooltip'.tr(),
             ),
         ],
       ),
@@ -270,8 +270,8 @@ class _LegalRepresentativeViewState
               controller: _nameController,
               label: 'post_registration.legal_representative.first_name_label'
                   .tr(),
-              hint: 'post_registration.legal_representative.first_name_hint'
-                  .tr(),
+              hint:
+                  'post_registration.legal_representative.first_name_hint'.tr(),
               prefixIcon: HugeIcons.strokeRoundedUser,
               textCapitalization: TextCapitalization.words,
               validator: (value) {

--- a/lib/features/rankings/presentation/screens/club_rankings_screen.dart
+++ b/lib/features/rankings/presentation/screens/club_rankings_screen.dart
@@ -50,10 +50,10 @@ class ClubRankingsScreen extends ConsumerWidget {
         title: Text(
           tr('rankings.annual_progress.title'),
           style: Theme.of(context).textTheme.titleLarge?.copyWith(
-            fontWeight: FontWeight.w800,
-            color: c.text,
-            letterSpacing: -0.2,
-          ),
+                fontWeight: FontWeight.w800,
+                color: c.text,
+                letterSpacing: -0.2,
+              ),
         ),
         centerTitle: true,
         elevation: 0,
@@ -221,7 +221,11 @@ class _ProgressHeroCard extends StatelessWidget {
 
     return Semantics(
       label:
-          '${tr('rankings.annual_progress.header_title')}, ${_formatPoints(progress.currentPoints)} ${tr('rankings.annual_progress.points_of_total', namedArgs: {'total': _formatPoints(progress.maxPoints)})}, ${tr('rankings.annual_progress.progress_percentage', namedArgs: {'percent': progress.progressPercentage.toStringAsFixed(0)})}',
+          '${tr('rankings.annual_progress.header_title')}, ${_formatPoints(progress.currentPoints)} ${tr('rankings.annual_progress.points_of_total', namedArgs: {
+            'total': _formatPoints(progress.maxPoints)
+          })}, ${tr('rankings.annual_progress.progress_percentage', namedArgs: {
+            'percent': progress.progressPercentage.toStringAsFixed(0)
+          })}',
       child: Container(
         width: double.infinity,
         padding: const EdgeInsets.fromLTRB(18, 18, 18, 16),
@@ -492,9 +496,8 @@ class _NextTierCard extends StatelessWidget {
     final pointsToReach = tier.pointsToReach;
     final palette = _tierPaletteFor(context, tier);
     final threshold = tier.fromPoints > 0 ? tier.fromPoints : tier.toPoints;
-    final toward = threshold > 0
-        ? (currentPoints / threshold).clamp(0.0, 1.0)
-        : 0.0;
+    final toward =
+        threshold > 0 ? (currentPoints / threshold).clamp(0.0, 1.0) : 0.0;
 
     return Container(
       width: double.infinity,
@@ -672,9 +675,8 @@ class _TierMedal extends StatelessWidget {
             ? HugeIcons.strokeRoundedLock
             : HugeIcons.strokeRoundedAward01,
         size: size * 0.48,
-        color: locked
-            ? palette.foreground
-            : Colors.white.withValues(alpha: 0.95),
+        color:
+            locked ? palette.foreground : Colors.white.withValues(alpha: 0.95),
       ),
     );
   }

--- a/test/core/notifications/push_notification_service_achievement_test.dart
+++ b/test/core/notifications/push_notification_service_achievement_test.dart
@@ -113,7 +113,7 @@ void main() {
 
       expect(find.byKey(const Key('achievement-unlocked-snackbar')),
           findsOneWidget);
-      expect(find.text('Logro desbloqueado'), findsOneWidget);
+      expect(find.text('Nuevo logro en tu camino'), findsOneWidget);
       expect(find.text('Primer Paso'), findsOneWidget);
       expect(find.text('GOLD · 25 pts'), findsOneWidget);
       expect(find.text('Ver logro'), findsOneWidget);

--- a/test/core/notifications/push_notification_service_master_honor_test.dart
+++ b/test/core/notifications/push_notification_service_master_honor_test.dart
@@ -129,7 +129,7 @@ void main() {
           queue.single.masterHonorNames,
           ['Maestría en Acuática', 'Maestría en Artesanía'],
         );
-        expect(find.text('Maestrías marcadas como No vigente'), findsOneWidget);
+        expect(find.text('Maestrías para revisar'), findsOneWidget);
 
         await tester.tap(find.text('Entendido'));
         await tester.pumpAndSettle();

--- a/test/features/certificate_import/presentation/views/certificate_import_flow_views_test.dart
+++ b/test/features/certificate_import/presentation/views/certificate_import_flow_views_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:sacdia_app/core/config/route_names.dart';
 import 'package:sacdia_app/core/config/router.dart';
 import 'package:sacdia_app/core/theme/app_theme.dart';
+import 'package:sacdia_app/core/widgets/sac_text_field.dart';
 import 'package:sacdia_app/features/certificate_import/domain/entities/certificate_import_batch.dart';
 import 'package:sacdia_app/features/certificate_import/domain/entities/certificate_import_file.dart';
 import 'package:sacdia_app/features/certificate_import/domain/entities/certificate_import_item.dart';
@@ -195,9 +196,18 @@ void main() {
       await tester.tap(find.text('Corregir').first);
       await tester.pumpAndSettle();
 
-      await tester.enterText(find.bySemanticsLabel('ID catálogo'), '10');
+      Finder inputWithLabel(String label) => find.descendant(
+            of: find.byWidgetPredicate(
+              (widget) => widget is SacTextField && widget.label == label,
+            ),
+            matching: find.byType(TextFormField),
+          );
+
+      await tester.enterText(inputWithLabel('ID catálogo'), '10');
       await tester.enterText(
-          find.bySemanticsLabel('Fecha completada'), '2026-04-12');
+        inputWithLabel('Fecha completada'),
+        '2026-04-12',
+      );
       await tester.tap(find.text('Guardar corrección'));
       await tester.pumpAndSettle();
 

--- a/test/features/finances/presentation/views/add_transaction_sheet_test.dart
+++ b/test/features/finances/presentation/views/add_transaction_sheet_test.dart
@@ -55,7 +55,7 @@ void main() {
   }
 
   testWidgets(
-    'shows a money icon and only categories compatible with the movement type',
+    'shows a category icon and only compatible movement categories',
     (tester) async {
       await pumpSheet(tester, const [
         FinanceCategory(id: 1, name: 'Cuotas', typeCode: 0),
@@ -65,8 +65,7 @@ void main() {
       expect(
         find.byWidgetPredicate(
           (widget) =>
-              widget is HugeIcon &&
-              widget.icon == HugeIcons.strokeRoundedMoney01,
+              widget is HugeIcon && widget.icon == HugeIcons.strokeRoundedTag01,
         ),
         findsOneWidget,
       );

--- a/test/features/master_honors/master_honor_change_modal_test.dart
+++ b/test/features/master_honors/master_honor_change_modal_test.dart
@@ -24,9 +24,9 @@ void main() {
       ),
     );
 
-    expect(find.text('¡Nueva maestría obtenida!'), findsOneWidget);
+    expect(find.text('¡Nueva maestría para tu banda!'), findsOneWidget);
     expect(
-      find.text('Has obtenido la maestría Maestría en Acuática.'),
+      find.text('Tu banda suma la maestría Maestría en Acuática.'),
       findsOneWidget,
     );
   });
@@ -48,10 +48,10 @@ void main() {
       ),
     );
 
-    expect(find.text('Maestrías marcadas como No vigente'), findsOneWidget);
+    expect(find.text('Maestrías para revisar'), findsOneWidget);
     expect(
       find.text(
-        'Las validaciones requeridas para estas maestrías cambiaron. Actualmente no cumples con los requisitos, por lo que quedaron marcadas como No vigente.',
+        'Estas maestrías necesitan ajustes para volver a estar vigentes.',
       ),
       findsOneWidget,
     );


### PR DESCRIPTION
Closes #121

## Tipo
- [x] Maintenance/tooling

## Resumen
- Aplica Dart 3.11.4 al baseline completo exigido por CI.
- Actualiza seis expectativas UI obsoletas para reflejar copy, iconografía y estructura vigentes.
- Mantiene el saneamiento separado del fix contractual de autenticación.

## Root cause
CI ejecuta `dart format --set-exit-if-changed --output=none .`; `development` contenía 15 archivos que el formatter estable modificaba. Después de corregir formato, seis pruebas reproducibles seguían validando copy/iconos/finders anteriores a la UI vigente.

## Test plan
- [x] `dart format --set-exit-if-changed --output=none .`
- [x] `flutter analyze`
- [x] `flutter test` — 665/665.

## Contributor checklist
- [x] Issue aprobado enlazado.
- [x] Exactamente una etiqueta `type:*`.
- [x] No se modificaron scripts; shellcheck no aplica.
- [x] Commit convencional y sin `Co-Authored-By`.
