### PR TITLE
feat(achievements): redesign logros screen and detail sheet

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -1313,7 +1313,10 @@
       "clear_button": "Clear",
       "bulk_categories_title": "Apply one category to all",
       "max_button": "Max",
-      "boolean_category_hint": "All or nothing"
+      "boolean_category_hint": "All or nothing",
+      "bulk_action_button": "To all",
+      "min_button": "Min",
+      "bulk_done_button": "Done"
     },
     "member_of_month": {
       "history_title": "Miembro del Mes — Historial",
@@ -2901,6 +2904,13 @@
       "retry": "Retry",
       "profile_summary_label": "Achievements",
       "profile_summary_empty": "You haven't earned any achievements yet.",
+      "summary_of": "of {total}",
+      "summary_points": "{points} pts",
+      "filter_all": "All",
+      "filter_unlocked": "Earned",
+      "filter_in_progress": "In progress",
+      "filter_locked": "Locked",
+      "filter_empty": "Nothing in this filter",
       "unlock_tap_to_close": "Tap to close",
       "detail_repeatable": "Repeatable",
       "detail_times_completed": "Times completed",
@@ -2908,7 +2918,9 @@
       "detail_progress": "Progress",
       "detail_collection": "Collection",
       "detail_streak": "Streak",
-      "detail_prerequisite": "Requires: Achievement #{id}"
+      "detail_prerequisite": "Requires: Achievement #{id}",
+      "detail_streak_unit": "days",
+      "detail_secret_hint": "Keep participating to discover this achievement."
     },
     "tiers": {
       "bronze": "Bronze",

--- a/assets/translations/es.json
+++ b/assets/translations/es.json
@@ -1313,7 +1313,10 @@
       "clear_button": "Limpiar",
       "bulk_categories_title": "Aplicar una categoría a todos",
       "max_button": "Máx.",
-      "boolean_category_hint": "Todo o nada"
+      "boolean_category_hint": "Todo o nada",
+      "bulk_action_button": "A todos",
+      "min_button": "Mín.",
+      "bulk_done_button": "Listo"
     },
     "member_of_month": {
       "history_title": "Miembro del Mes — Historial",
@@ -2901,6 +2904,13 @@
       "retry": "Reintentar",
       "profile_summary_label": "Logros",
       "profile_summary_empty": "Aún no has obtenido logros.",
+      "summary_of": "de {total}",
+      "summary_points": "{points} pts",
+      "filter_all": "Todos",
+      "filter_unlocked": "Obtenidos",
+      "filter_in_progress": "En curso",
+      "filter_locked": "Bloqueados",
+      "filter_empty": "Nada en este filtro",
       "unlock_tap_to_close": "Toca para cerrar",
       "detail_repeatable": "Repetible",
       "detail_times_completed": "Veces completado",
@@ -2908,7 +2918,9 @@
       "detail_progress": "Progreso",
       "detail_collection": "Colección",
       "detail_streak": "Racha",
-      "detail_prerequisite": "Requiere: Logro #{id}"
+      "detail_prerequisite": "Requiere: Logro #{id}",
+      "detail_streak_unit": "días",
+      "detail_secret_hint": "Sigue participando para descubrir este logro."
     },
     "tiers": {
       "bronze": "Bronce",

--- a/assets/translations/fr.json
+++ b/assets/translations/fr.json
@@ -1313,7 +1313,10 @@
       "clear_button": "Effacer",
       "bulk_categories_title": "Appliquer une catégorie à tous",
       "max_button": "Max.",
-      "boolean_category_hint": "Tout ou rien"
+      "boolean_category_hint": "Tout ou rien",
+      "bulk_action_button": "À tous",
+      "min_button": "Min.",
+      "bulk_done_button": "OK"
     },
     "member_of_month": {
       "history_title": "Miembro del Mes — Historial",
@@ -2901,6 +2904,13 @@
       "retry": "Réessayer",
       "profile_summary_label": "Réalisations",
       "profile_summary_empty": "Vous n'avez pas encore obtenu de réalisations.",
+      "summary_of": "sur {total}",
+      "summary_points": "{points} pts",
+      "filter_all": "Tous",
+      "filter_unlocked": "Obtenus",
+      "filter_in_progress": "En cours",
+      "filter_locked": "Verrouillés",
+      "filter_empty": "Rien dans ce filtre",
       "unlock_tap_to_close": "Appuyer pour fermer",
       "detail_repeatable": "Répétable",
       "detail_times_completed": "Fois complété",
@@ -2908,7 +2918,9 @@
       "detail_progress": "Progression",
       "detail_collection": "Collection",
       "detail_streak": "Série",
-      "detail_prerequisite": "Nécessite : Réalisation #{id}"
+      "detail_prerequisite": "Nécessite : Réalisation #{id}",
+      "detail_streak_unit": "jours",
+      "detail_secret_hint": "Continuez à participer pour découvrir cette réalisation."
     },
     "tiers": {
       "bronze": "Bronze",

--- a/assets/translations/pt-BR.json
+++ b/assets/translations/pt-BR.json
@@ -1313,7 +1313,10 @@
       "clear_button": "Limpar",
       "bulk_categories_title": "Aplicar uma categoria a todos",
       "max_button": "Máx.",
-      "boolean_category_hint": "Tudo ou nada"
+      "boolean_category_hint": "Tudo ou nada",
+      "bulk_action_button": "A todos",
+      "min_button": "Mín.",
+      "bulk_done_button": "Pronto"
     },
     "member_of_month": {
       "history_title": "Miembro del Mes — Historial",
@@ -2901,6 +2904,13 @@
       "retry": "Tentar novamente",
       "profile_summary_label": "Conquistas",
       "profile_summary_empty": "Você ainda não obteve conquistas.",
+      "summary_of": "de {total}",
+      "summary_points": "{points} pts",
+      "filter_all": "Todos",
+      "filter_unlocked": "Obtidos",
+      "filter_in_progress": "Em curso",
+      "filter_locked": "Bloqueados",
+      "filter_empty": "Nada neste filtro",
       "unlock_tap_to_close": "Toque para fechar",
       "detail_repeatable": "Repetível",
       "detail_times_completed": "Vezes concluído",
@@ -2908,7 +2918,9 @@
       "detail_progress": "Progresso",
       "detail_collection": "Coleção",
       "detail_streak": "Sequência",
-      "detail_prerequisite": "Requer: Conquista #{id}"
+      "detail_prerequisite": "Requer: Conquista #{id}",
+      "detail_streak_unit": "dias",
+      "detail_secret_hint": "Continue participando para descobrir esta conquista."
     },
     "tiers": {
       "bronze": "Bronze",

--- a/lib/core/utils/network_image_url.dart
+++ b/lib/core/utils/network_image_url.dart
@@ -1,0 +1,9 @@
+/// Returns true when [url] points to an SVG resource.
+///
+/// Uses the URL path (ignoring query/fragment) so signed R2 URLs like
+/// `https://…/badge.svg?X-Amz-Signature=…` still detect as SVG.
+bool isSvgNetworkUrl(String url) {
+  final uri = Uri.tryParse(url);
+  final path = (uri?.path.isNotEmpty == true ? uri!.path : url).toLowerCase();
+  return path.endsWith('.svg');
+}

--- a/lib/core/widgets/sac_network_image.dart
+++ b/lib/core/widgets/sac_network_image.dart
@@ -1,0 +1,61 @@
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:sacdia_app/core/utils/network_image_url.dart';
+
+/// Network image that supports raster (png/jpg/webp) and SVG URLs.
+///
+/// Raster URLs use [CachedNetworkImage]. SVG URLs use [SvgPicture.network]
+/// (detected via [isSvgNetworkUrl]).
+class SacNetworkImage extends StatelessWidget {
+  final String imageUrl;
+  final double? width;
+  final double? height;
+  final BoxFit fit;
+  final int? memCacheWidth;
+  final int? memCacheHeight;
+  final PlaceholderWidgetBuilder? placeholder;
+  final LoadingErrorWidgetBuilder? errorWidget;
+
+  const SacNetworkImage({
+    super.key,
+    required this.imageUrl,
+    this.width,
+    this.height,
+    this.fit = BoxFit.cover,
+    this.memCacheWidth,
+    this.memCacheHeight,
+    this.placeholder,
+    this.errorWidget,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    if (isSvgNetworkUrl(imageUrl)) {
+      return SvgPicture.network(
+        imageUrl,
+        width: width,
+        height: height,
+        fit: fit,
+        placeholderBuilder: placeholder == null
+            ? null
+            : (context) => placeholder!(context, imageUrl),
+        errorBuilder: errorWidget == null
+            ? null
+            : (context, error, stackTrace) =>
+                errorWidget!(context, imageUrl, error),
+      );
+    }
+
+    return CachedNetworkImage(
+      imageUrl: imageUrl,
+      width: width,
+      height: height,
+      fit: fit,
+      memCacheWidth: memCacheWidth,
+      memCacheHeight: memCacheHeight,
+      placeholder: placeholder,
+      errorWidget: errorWidget,
+    );
+  }
+}

--- a/lib/core/widgets/sac_widgets.dart
+++ b/lib/core/widgets/sac_widgets.dart
@@ -14,6 +14,7 @@ export 'sac_card.dart';
 export 'sac_dialog.dart';
 export 'sac_dropdown_field.dart';
 export 'sac_loading.dart';
+export 'sac_network_image.dart';
 export 'sac_pdf_viewer.dart';
 export 'sac_progress_bar.dart';
 export 'sac_progress_ring.dart';

--- a/lib/features/achievements/domain/entities/achievement.dart
+++ b/lib/features/achievements/domain/entities/achievement.dart
@@ -3,8 +3,9 @@ import 'package:equatable/equatable.dart';
 
 /// Base URL for achievement badge images stored in Cloudflare R2 via backend.
 ///
-/// The backend stores only the key (e.g. "badges/achievement-42.webp").
-/// This prefix is prepended when the key doesn't already start with "http".
+/// The backend stores only the key (e.g. "badges/achievement-42.svg").
+/// Supported formats: svg, png, webp, jpg. This prefix is prepended when the
+/// key doesn't already start with "http".
 const String _achievementBadgeBase =
     'https://sacdia-files.r2.dev/achievements/';
 

--- a/lib/features/achievements/presentation/views/achievement_detail_sheet.dart
+++ b/lib/features/achievements/presentation/views/achievement_detail_sheet.dart
@@ -1,10 +1,9 @@
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:hugeicons/hugeicons.dart';
+import 'package:sacdia_app/core/animations/motion_tokens.dart';
 import 'package:sacdia_app/core/theme/app_colors.dart';
 import 'package:sacdia_app/core/theme/sac_colors.dart';
-import 'package:sacdia_app/core/utils/icon_helper.dart';
-import 'package:sacdia_app/core/widgets/sac_badge.dart';
 
 import '../../domain/entities/achievement.dart';
 import '../../domain/entities/user_achievement.dart';
@@ -12,18 +11,8 @@ import '../../domain/repositories/achievements_repository.dart';
 import '../widgets/achievement_badge.dart';
 import '../widgets/achievement_progress_bar.dart';
 
-/// Bottom sheet de detalle de un logro.
-///
-/// Contenido:
-/// - AchievementBadge grande (96px) centrado
-/// - Nombre, descripción, badges de tier y puntos
-/// - Barra de progreso (si no está completado)
-/// - Para COLLECTION: checklist de items coleccionados/faltantes
-/// - Para STREAK: contador de racha
-/// - Cadena de prerequisito (si aplica)
-/// - Contador de veces completado (si repeatable)
-/// - Fecha de completado (si completado)
-class AchievementDetailSheet extends StatelessWidget {
+/// Detail sheet v2 — badge hero, status meta, inset groups, SacMotion enter.
+class AchievementDetailSheet extends StatefulWidget {
   final AchievementWithProgress achievementWithProgress;
 
   const AchievementDetailSheet({
@@ -32,199 +21,521 @@ class AchievementDetailSheet extends StatelessWidget {
   });
 
   @override
+  State<AchievementDetailSheet> createState() => _AchievementDetailSheetState();
+}
+
+class _AchievementDetailSheetState extends State<AchievementDetailSheet>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _enter;
+  late final Animation<double> _fade;
+  late final Animation<double> _scale;
+
+  @override
+  void initState() {
+    super.initState();
+    _enter = AnimationController(vsync: this, duration: SacMotion.modal);
+    _fade = CurvedAnimation(parent: _enter, curve: SacMotion.easeOut);
+    _scale = Tween<double>(begin: SacMotion.enterScale, end: 1).animate(
+      CurvedAnimation(parent: _enter, curve: SacMotion.easeOut),
+    );
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (SacMotion.reduceMotionOf(context)) {
+      _enter.value = 1;
+    } else if (!_enter.isAnimating && _enter.value == 0) {
+      _enter.forward();
+    }
+  }
+
+  @override
+  void dispose() {
+    _enter.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
-    final achievement = achievementWithProgress.achievement;
-    final userAchievement = achievementWithProgress.userAchievement;
+    final achievement = widget.achievementWithProgress.achievement;
+    final userAchievement = widget.achievementWithProgress.userAchievement;
 
     final isCompleted = userAchievement?.isCompleted ?? false;
     final isSecret = achievement.secret && !isCompleted;
     final visualState =
         userAchievement?.visualState ?? AchievementVisualState.locked;
     final tierColor = achievementTierColor(achievement.tier);
+    final tierInk = achievementTierInkColor(achievement.tier);
+    final tierChipBg = achievementTierChipBackground(
+      achievement.tier,
+      Theme.of(context).brightness,
+    );
+    final c = context.sac;
+    final bottomInset = MediaQuery.paddingOf(context).bottom;
+
+    final wash = _tierSheetWash(
+      tier: achievement.tier,
+      unlocked: isCompleted,
+      isSecret: isSecret,
+      surface: c.surface,
+    );
 
     return DraggableScrollableSheet(
-      initialChildSize: 0.65,
+      initialChildSize: 0.72,
       minChildSize: 0.45,
-      maxChildSize: 0.95,
+      maxChildSize: 0.94,
       builder: (context, scrollController) {
         return Container(
           decoration: BoxDecoration(
-            color: context.sac.surface,
-            borderRadius: const BorderRadius.vertical(top: Radius.circular(24)),
-          ),
-          child: Column(
-            children: [
-              // Drag handle
-              const SizedBox(height: 12),
-              Center(
-                child: Container(
-                  width: 40,
-                  height: 4,
-                  decoration: BoxDecoration(
-                    color: context.sac.border,
-                    borderRadius: BorderRadius.circular(2),
-                  ),
-                ),
-              ),
-              const SizedBox(height: 16),
-
-              // Scrollable content
-              Expanded(
-                child: SingleChildScrollView(
-                  controller: scrollController,
-                  padding:
-                      const EdgeInsets.symmetric(horizontal: 24, vertical: 8),
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.center,
-                    children: [
-                      const SizedBox(height: 16),
-
-                      // Badge large
-                      AchievementBadge(
-                        badgeImageUrl: achievement.badgeImageUrl,
-                        tier: achievement.tier,
-                        visualState: visualState,
-                        isSecret: achievement.secret,
-                        size: 146,
-                        progress: userAchievement?.progressPercentage ?? 0.0,
-                      ),
-                      const SizedBox(height: 16),
-
-                      // Name
-                      Text(
-                        isSecret ? '???' : achievement.name,
-                        style: Theme.of(context)
-                            .textTheme
-                            .headlineMedium
-                            ?.copyWith(fontWeight: FontWeight.w700),
-                        textAlign: TextAlign.center,
-                      ),
-                      const SizedBox(height: 15),
-
-                      // Tier + Points badges
-                      Row(
-                        mainAxisAlignment: MainAxisAlignment.center,
-                        children: [
-                          // Tier badge
-                          Container(
-                            padding: const EdgeInsets.symmetric(
-                                horizontal: 10, vertical: 4),
-                            decoration: BoxDecoration(
-                              color: tierColor.withValues(alpha: 0.15),
-                              borderRadius: BorderRadius.circular(20),
-                            ),
-                            child: Row(
-                              mainAxisSize: MainAxisSize.min,
-                              children: [
-                                HugeIcon(
-                                    icon: HugeIcons.strokeRoundedCircle,
-                                    size: 8,
-                                    color: tierColor),
-                                const SizedBox(width: 4),
-                                Text(
-                                  achievement.tier.displayName,
-                                  style: TextStyle(
-                                    fontSize: 12,
-                                    fontWeight: FontWeight.w600,
-                                    color: tierColor,
-                                  ),
-                                ),
-                              ],
-                            ),
-                          ),
-                          const SizedBox(width: 8),
-                          // Points badge
-                          SacBadge.warning(
-                            label: '${achievement.points} pts',
-                            icon: HugeIcons.strokeRoundedFlash,
-                          ),
-                          if (achievement.repeatable) ...[
-                            const SizedBox(width: 8),
-                            SacBadge(
-                              label:
-                                  'achievements.views.detail_repeatable'.tr(),
-                              variant: SacBadgeVariant.secondary,
-                            ),
-                          ],
-                        ],
-                      ),
-                      const SizedBox(height: 16),
-
-                      // Description
-                      if (!isSecret && achievement.description != null) ...[
-                        Text(
-                          achievement.description!,
-                          style: Theme.of(context)
-                              .textTheme
-                              .bodyMedium
-                              ?.copyWith(
-                                  color: context.sac.textSecondary,
-                                  height: 1.5),
-                          textAlign: TextAlign.center,
-                        ),
-                        const SizedBox(height: 20),
-                      ],
-
-                      // Progress bar (if not completed)
-                      if (userAchievement != null && !isCompleted) ...[
-                        _ProgressSection(
-                          userAchievement: userAchievement,
-                          achievement: achievement,
-                        ),
-                        const SizedBox(height: 20),
-                      ],
-
-                      const Divider(),
-                      const SizedBox(height: 12),
-
-                      // Type-specific content
-                      if (!isSecret) ...[
-                        _TypeSpecificContent(
-                          achievement: achievement,
-                          userAchievement: userAchievement,
-                        ),
-                      ],
-
-                      // Prerequisite
-                      if (achievement.prerequisiteId != null) ...[
-                        _PrerequisiteChip(
-                            prerequisiteId: achievement.prerequisiteId!),
-                        const SizedBox(height: 12),
-                      ],
-
-                      // Times completed (repeatable)
-                      if (achievement.repeatable &&
-                          userAchievement != null &&
-                          userAchievement.timesCompleted > 0) ...[
-                        _InfoRow(
-                          icon: HugeIcons.strokeRoundedRefresh,
-                          label:
-                              'achievements.views.detail_times_completed'.tr(),
-                          value: userAchievement.timesCompleted.toString(),
-                        ),
-                        const SizedBox(height: 8),
-                      ],
-
-                      // Completed date
-                      if (isCompleted &&
-                          userAchievement?.completedAt != null) ...[
-                        _InfoRow(
-                          icon: HugeIcons.strokeRoundedCalendar01,
-                          label: 'achievements.views.detail_completed_on'.tr(),
-                          value: _formatDate(userAchievement!.completedAt!),
-                        ),
-                        const SizedBox(height: 12),
-                      ],
-
-                      const SizedBox(height: 32),
-                    ],
-                  ),
-                ),
+            color: c.surface,
+            borderRadius: const BorderRadius.vertical(top: Radius.circular(28)),
+            boxShadow: [
+              BoxShadow(
+                color: c.shadow,
+                blurRadius: 24,
+                offset: const Offset(0, -4),
               ),
             ],
           ),
+          child: ClipRRect(
+            borderRadius: const BorderRadius.vertical(top: Radius.circular(28)),
+            child: Stack(
+              children: [
+                // Tier wash — reads bronze/silver/gold/… without fighting content.
+                Positioned(
+                  top: 0,
+                  left: 0,
+                  right: 0,
+                  height: 320,
+                  child: DecoratedBox(
+                    decoration: BoxDecoration(
+                      gradient: LinearGradient(
+                        begin: Alignment.topCenter,
+                        end: Alignment.bottomCenter,
+                        colors: [
+                          wash,
+                          wash.withValues(alpha: 0.45),
+                          c.surface.withValues(alpha: 0),
+                        ],
+                        stops: const [0.0, 0.45, 1.0],
+                      ),
+                    ),
+                  ),
+                ),
+                Column(
+                  children: [
+                    const SizedBox(height: 10),
+                    Container(
+                      width: 36,
+                      height: 4,
+                      decoration: BoxDecoration(
+                        color: c.border.withValues(alpha: 0.9),
+                        borderRadius: BorderRadius.circular(2),
+                      ),
+                    ),
+                    Expanded(
+                      child: SingleChildScrollView(
+                        controller: scrollController,
+                        padding:
+                            EdgeInsets.fromLTRB(20, 16, 20, 28 + bottomInset),
+                        child: FadeTransition(
+                          opacity: _fade,
+                          // Full-width column so Wrap/text always center in the sheet.
+                          child: SizedBox(
+                            width: double.infinity,
+                            child: Column(
+                              crossAxisAlignment: CrossAxisAlignment.center,
+                              children: [
+                                Center(
+                                  child: ScaleTransition(
+                                    scale: _scale,
+                                    child: _BadgeHero(
+                                      achievement: achievement,
+                                      visualState: visualState,
+                                      isSecret: isSecret,
+                                      tier: achievement.tier,
+                                      tierColor: tierColor,
+                                      progress: userAchievement
+                                              ?.progressPercentage ??
+                                          0.0,
+                                    ),
+                                  ),
+                                ),
+                                const SizedBox(height: 18),
+                                Text(
+                                  isSecret ? '???' : achievement.name,
+                                  style: TextStyle(
+                                    fontSize: 24,
+                                    fontWeight: FontWeight.w800,
+                                    letterSpacing: -0.4,
+                                    height: 1.15,
+                                    color: c.text,
+                                  ),
+                                  textAlign: TextAlign.center,
+                                ),
+                                const SizedBox(height: 12),
+                                SizedBox(
+                                  width: double.infinity,
+                                  child: Wrap(
+                                    alignment: WrapAlignment.center,
+                                    crossAxisAlignment:
+                                        WrapCrossAlignment.center,
+                                    spacing: 8,
+                                    runSpacing: 8,
+                                    children: [
+                                      _StatusChip(visualState: visualState),
+                                      if (!isSecret) ...[
+                                        _MetaChip(
+                                          icon: HugeIcons.strokeRoundedAward01,
+                                          label: achievement.tier.displayName,
+                                          foreground: tierInk,
+                                          background: tierChipBg,
+                                        ),
+                                        _MetaChip(
+                                          icon: HugeIcons.strokeRoundedFlash,
+                                          label: '${achievement.points} pts',
+                                          foreground: AppColors.primary,
+                                          background: AppColors.primary
+                                              .withValues(alpha: 0.12),
+                                        ),
+                                        if (achievement.repeatable)
+                                          _MetaChip(
+                                            icon:
+                                                HugeIcons.strokeRoundedRefresh,
+                                            label: 'achievements.views.detail_repeatable'
+                                                .tr(),
+                                            foreground: c.textSecondary,
+                                            background: c.surfaceVariant,
+                                          ),
+                                      ],
+                                    ],
+                                  ),
+                                ),
+                                if (isSecret) ...[
+                                  const SizedBox(height: 16),
+                                  SizedBox(
+                                    width: double.infinity,
+                                    child: Text(
+                                      'achievements.views.detail_secret_hint'
+                                          .tr(),
+                                      style: TextStyle(
+                                        fontSize: 15,
+                                        height: 1.45,
+                                        color: c.textSecondary,
+                                        fontWeight: FontWeight.w400,
+                                      ),
+                                      textAlign: TextAlign.center,
+                                    ),
+                                  ),
+                                ] else if (achievement
+                                        .description?.isNotEmpty ==
+                                    true) ...[
+                                  const SizedBox(height: 16),
+                                  SizedBox(
+                                    width: double.infinity,
+                                    child: Text(
+                                      achievement.description!,
+                                      style: TextStyle(
+                                        fontSize: 15,
+                                        height: 1.45,
+                                        color: c.textSecondary,
+                                        fontWeight: FontWeight.w400,
+                                      ),
+                                      textAlign: TextAlign.center,
+                                    ),
+                                  ),
+                                ],
+                                if (isCompleted &&
+                                    (userAchievement?.completedAt != null ||
+                                        (achievement.repeatable &&
+                                            (userAchievement?.timesCompleted ??
+                                                    0) >
+                                                0))) ...[
+                                  const SizedBox(height: 14),
+                                  SizedBox(
+                                    width: double.infinity,
+                                    child: _CompletedCaption(
+                                      completedAt:
+                                          userAchievement?.completedAt,
+                                      timesCompleted: achievement.repeatable
+                                          ? userAchievement?.timesCompleted
+                                          : null,
+                                    ),
+                                  ),
+                                ],
+                                if (!isSecret &&
+                                    userAchievement != null &&
+                                    !isCompleted) ...[
+                                  const SizedBox(height: 20),
+                                  _InsetCard(
+                                    child: _ProgressSection(
+                                      userAchievement: userAchievement,
+                                      achievement: achievement,
+                                    ),
+                                  ),
+                                ],
+                                if (!isSecret) ...[
+                                  const SizedBox(height: 12),
+                                  _TypeSpecificContent(
+                                    achievement: achievement,
+                                    userAchievement: userAchievement,
+                                  ),
+                                ],
+                                if (achievement.prerequisiteId != null) ...[
+                                  const SizedBox(height: 4),
+                                  _PrerequisiteCard(
+                                    prerequisiteId:
+                                        achievement.prerequisiteId!,
+                                  ),
+                                ],
+                              ],
+                            ),
+                          ),
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
         );
       },
+    );
+  }
+}
+
+/// Soft sheet wash keyed to achievement tier.
+Color _tierSheetWash({
+  required AchievementTier tier,
+  required bool unlocked,
+  required bool isSecret,
+  required Color surface,
+}) {
+  if (isSecret) {
+    return Colors.black.withValues(alpha: 0.04);
+  }
+
+  final base = switch (tier) {
+    AchievementTier.bronze => const Color(0xFFB87333),
+    AchievementTier.silver => const Color(0xFF8E959D),
+    AchievementTier.gold => const Color(0xFFE0B400),
+    AchievementTier.platinum => const Color(0xFF9BA3AE),
+    AchievementTier.diamond => const Color(0xFF5EC8E8),
+    AchievementTier.unknown => Colors.grey,
+  };
+
+  final alpha = unlocked ? 0.22 : 0.10;
+  return Color.alphaBlend(base.withValues(alpha: alpha), surface);
+}
+
+// ── Badge hero ─────────────────────────────────────────────────────────────────
+
+class _BadgeHero extends StatelessWidget {
+  final Achievement achievement;
+  final AchievementVisualState visualState;
+  final bool isSecret;
+  final AchievementTier tier;
+  final Color tierColor;
+  final double progress;
+
+  const _BadgeHero({
+    required this.achievement,
+    required this.visualState,
+    required this.isSecret,
+    required this.tier,
+    required this.tierColor,
+    required this.progress,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final unlocked = visualState == AchievementVisualState.unlocked;
+    final c = context.sac;
+    final glowCore = unlocked
+        ? tierColor.withValues(alpha: 0.42)
+        : c.border.withValues(alpha: 0.28);
+    final glowMid = unlocked
+        ? tierColor.withValues(alpha: 0.18)
+        : c.border.withValues(alpha: 0.12);
+
+    return SizedBox(
+      width: 255,
+      height: 255,
+      child: Stack(
+        alignment: Alignment.center,
+        children: [
+          // Soft disc so tier reads even on locked badges.
+          Container(
+            width: 240,
+            height: 240,
+            decoration: BoxDecoration(
+              shape: BoxShape.circle,
+              gradient: RadialGradient(
+                colors: [
+                  glowCore,
+                  glowMid,
+                  glowMid.withValues(alpha: 0),
+                ],
+                stops: const [0.0, 0.55, 1.0],
+              ),
+            ),
+          ),
+          AchievementBadge(
+            badgeImageUrl: achievement.badgeImageUrl,
+            tier: tier,
+            visualState: visualState,
+            isSecret: isSecret,
+            size: 203,
+            progress: progress,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+// ── Status / meta chips ────────────────────────────────────────────────────────
+
+class _StatusChip extends StatelessWidget {
+  final AchievementVisualState visualState;
+
+  const _StatusChip({required this.visualState});
+
+  @override
+  Widget build(BuildContext context) {
+    final (label, fg, bg, icon) = switch (visualState) {
+      AchievementVisualState.unlocked => (
+          'achievements.views.filter_unlocked'.tr(),
+          AppColors.secondaryDark,
+          AppColors.secondaryLight,
+          HugeIcons.strokeRoundedCheckmarkCircle02,
+        ),
+      AchievementVisualState.inProgress => (
+          'achievements.views.filter_in_progress'.tr(),
+          AppColors.primaryDark,
+          AppColors.primaryLight,
+          HugeIcons.strokeRoundedLoading03,
+        ),
+      AchievementVisualState.locked => (
+          'achievements.views.filter_locked'.tr(),
+          context.sac.textSecondary,
+          context.sac.surfaceVariant,
+          HugeIcons.strokeRoundedLock,
+        ),
+    };
+
+    return _MetaChip(
+      icon: icon,
+      label: label,
+      foreground: fg,
+      background: bg,
+    );
+  }
+}
+
+class _MetaChip extends StatelessWidget {
+  final dynamic icon;
+  final String label;
+  final Color foreground;
+  final Color background;
+
+  const _MetaChip({
+    required this.icon,
+    required this.label,
+    required this.foreground,
+    required this.background,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+      decoration: BoxDecoration(
+        color: background,
+        borderRadius: BorderRadius.circular(20),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          HugeIcon(icon: icon, size: 13, color: foreground),
+          const SizedBox(width: 5),
+          Text(
+            label,
+            style: TextStyle(
+              fontSize: 12,
+              fontWeight: FontWeight.w700,
+              color: foreground,
+              height: 1.1,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+// ── Inset card shell ───────────────────────────────────────────────────────────
+
+class _InsetCard extends StatelessWidget {
+  final Widget child;
+
+  const _InsetCard({required this.child});
+
+  @override
+  Widget build(BuildContext context) {
+    final c = context.sac;
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: c.surfaceVariant.withValues(alpha: 0.65),
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(color: c.border.withValues(alpha: 0.55)),
+      ),
+      child: child,
+    );
+  }
+}
+
+// ── Completed caption (quiet metadata) ─────────────────────────────────────────
+
+class _CompletedCaption extends StatelessWidget {
+  final DateTime? completedAt;
+  final int? timesCompleted;
+
+  const _CompletedCaption({
+    required this.completedAt,
+    required this.timesCompleted,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final c = context.sac;
+    final parts = <String>[];
+    if (completedAt != null) {
+      parts.add(
+        '${'achievements.views.detail_completed_on'.tr()} ${_formatDate(completedAt!)}',
+      );
+    }
+    if (timesCompleted != null && timesCompleted! > 0) {
+      parts.add(
+        '${'achievements.views.detail_times_completed'.tr()} · $timesCompleted',
+      );
+    }
+    if (parts.isEmpty) return const SizedBox.shrink();
+
+    return Text(
+      parts.join('  ·  '),
+      style: TextStyle(
+        fontSize: 13,
+        fontWeight: FontWeight.w500,
+        color: c.textTertiary,
+        height: 1.3,
+        letterSpacing: 0.1,
+      ),
+      textAlign: TextAlign.center,
     );
   }
 
@@ -235,7 +546,7 @@ class AchievementDetailSheet extends StatelessWidget {
   }
 }
 
-// ── Progress Section ────────────��──────────────────────────────────────────────
+// ── Progress Section ───────────────────────────────────────────────────────────
 
 class _ProgressSection extends StatelessWidget {
   final UserAchievement userAchievement;
@@ -248,40 +559,44 @@ class _ProgressSection extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final tierColor = achievementTierColor(achievement.tier);
+
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         Row(
-          mainAxisAlignment: MainAxisAlignment.spaceBetween,
           children: [
             Text(
               'achievements.views.detail_progress'.tr(),
-              style: Theme.of(context).textTheme.titleSmall?.copyWith(
-                    fontWeight: FontWeight.w700,
-                  ),
+              style: TextStyle(
+                fontSize: 13,
+                fontWeight: FontWeight.w700,
+                color: context.sac.text,
+              ),
             ),
+            const Spacer(),
             Text(
               '${userAchievement.progressValue}/${userAchievement.progressTarget}',
               style: TextStyle(
                 fontSize: 13,
-                fontWeight: FontWeight.w600,
-                color: achievementTierColor(achievement.tier),
+                fontWeight: FontWeight.w700,
+                color: tierColor,
               ),
             ),
           ],
         ),
-        const SizedBox(height: 8),
+        const SizedBox(height: 10),
         AchievementProgressBar(
           progress: userAchievement.progressPercentage,
           tier: achievement.tier,
-          height: 8,
+          height: 7,
         ),
       ],
     );
   }
 }
 
-// ── Type-Specific Content ─────────────────────────────────────────────────────��
+// ── Type-Specific Content ──────────────────────────────────────────────────────
 
 class _TypeSpecificContent extends StatelessWidget {
   final Achievement achievement;
@@ -301,9 +616,14 @@ class _TypeSpecificContent extends StatelessWidget {
           userAchievement: userAchievement,
         );
       case AchievementType.streak:
-        return _StreakContent(
-          achievement: achievement,
-          userAchievement: userAchievement,
+        return Padding(
+          padding: const EdgeInsets.only(bottom: 12),
+          child: _InsetCard(
+            child: _StreakContent(
+              achievement: achievement,
+              userAchievement: userAchievement,
+            ),
+          ),
         );
       default:
         return const SizedBox.shrink();
@@ -322,7 +642,6 @@ class _CollectionContent extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    // Extract items from criteria and collected from progress_metadata
     final requiredItems =
         (achievement.criteria['items'] as List<dynamic>?)?.cast<String>() ?? [];
     final collectedItems =
@@ -332,51 +651,57 @@ class _CollectionContent extends StatelessWidget {
 
     if (requiredItems.isEmpty) return const SizedBox.shrink();
 
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Text(
-          'achievements.views.detail_collection'.tr(),
-          style: Theme.of(context)
-              .textTheme
-              .titleSmall
-              ?.copyWith(fontWeight: FontWeight.w700),
-        ),
-        const SizedBox(height: 8),
-        ...requiredItems.map((item) {
-          final isCollected = collectedItems.contains(item);
-          return Padding(
-            padding: const EdgeInsets.symmetric(vertical: 3),
-            child: Row(
-              children: [
-                HugeIcon(
-                  icon: isCollected
-                      ? HugeIcons.strokeRoundedCheckmarkCircle02
-                      : HugeIcons.strokeRoundedCircle,
-                  size: 18,
-                  color: isCollected
-                      ? AppColors.secondary
-                      : context.sac.textTertiary,
-                ),
-                const SizedBox(width: 10),
-                Expanded(
-                  child: Text(
-                    item,
-                    style: TextStyle(
-                      fontSize: 13,
-                      color: isCollected
-                          ? context.sac.text
-                          : context.sac.textSecondary,
-                      decoration: isCollected ? TextDecoration.none : null,
-                    ),
-                  ),
-                ),
-              ],
+    final c = context.sac;
+
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 12),
+      child: _InsetCard(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              'achievements.views.detail_collection'.tr(),
+              style: TextStyle(
+                fontSize: 13,
+                fontWeight: FontWeight.w700,
+                color: c.text,
+              ),
             ),
-          );
-        }),
-        const SizedBox(height: 12),
-      ],
+            const SizedBox(height: 10),
+            ...requiredItems.map((item) {
+              final isCollected = collectedItems.contains(item);
+              return Padding(
+                padding: const EdgeInsets.symmetric(vertical: 4),
+                child: Row(
+                  children: [
+                    HugeIcon(
+                      icon: isCollected
+                          ? HugeIcons.strokeRoundedCheckmarkCircle02
+                          : HugeIcons.strokeRoundedCircle,
+                      size: 18,
+                      color: isCollected
+                          ? AppColors.secondary
+                          : c.textTertiary,
+                    ),
+                    const SizedBox(width: 10),
+                    Expanded(
+                      child: Text(
+                        item,
+                        style: TextStyle(
+                          fontSize: 14,
+                          fontWeight:
+                              isCollected ? FontWeight.w600 : FontWeight.w400,
+                          color: isCollected ? c.text : c.textSecondary,
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              );
+            }),
+          ],
+        ),
+      ),
     );
   }
 }
@@ -396,121 +721,94 @@ class _StreakContent extends StatelessWidget {
     final requiredStreak = userAchievement?.progressTarget ??
         (achievement.criteria['streak'] as int? ?? 0);
     final tierColor = achievementTierColor(achievement.tier);
+    final c = context.sac;
 
     return Column(
-      crossAxisAlignment: CrossAxisAlignment.center,
       children: [
         Text(
           'achievements.views.detail_streak'.tr(),
-          style: Theme.of(context)
-              .textTheme
-              .titleSmall
-              ?.copyWith(fontWeight: FontWeight.w700),
+          style: TextStyle(
+            fontSize: 13,
+            fontWeight: FontWeight.w700,
+            color: c.text,
+          ),
         ),
-        const SizedBox(height: 12),
+        const SizedBox(height: 10),
         Row(
           mainAxisAlignment: MainAxisAlignment.center,
+          crossAxisAlignment: CrossAxisAlignment.baseline,
+          textBaseline: TextBaseline.alphabetic,
           children: [
-            HugeIcon(
-              icon: HugeIcons.strokeRoundedAward01,
-              size: 32,
-              color: tierColor,
-            ),
-            const SizedBox(width: 8),
             Text(
               '$currentStreak',
               style: TextStyle(
-                fontSize: 36,
+                fontSize: 40,
                 fontWeight: FontWeight.w900,
+                letterSpacing: -1.2,
+                height: 1,
                 color: tierColor,
               ),
             ),
             if (requiredStreak > 0) ...[
               Text(
-                ' / $requiredStreak días',
-                style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                      color: context.sac.textSecondary,
-                    ),
+                ' / $requiredStreak',
+                style: TextStyle(
+                  fontSize: 18,
+                  fontWeight: FontWeight.w600,
+                  color: c.textSecondary,
+                ),
+              ),
+              const SizedBox(width: 4),
+              Text(
+                'achievements.views.detail_streak_unit'.tr(),
+                style: TextStyle(
+                  fontSize: 13,
+                  fontWeight: FontWeight.w500,
+                  color: c.textTertiary,
+                ),
               ),
             ],
           ],
         ),
-        const SizedBox(height: 12),
       ],
     );
   }
 }
 
-// ── Helper Widgets ─────────────────────────────────────────────────────────────
+// ── Prerequisite ───────────────────────────────────────────────────────────────
 
-class _PrerequisiteChip extends StatelessWidget {
+class _PrerequisiteCard extends StatelessWidget {
   final int prerequisiteId;
-  const _PrerequisiteChip({required this.prerequisiteId});
+
+  const _PrerequisiteCard({required this.prerequisiteId});
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-      decoration: BoxDecoration(
-        color: AppColors.primaryLight,
-        borderRadius: BorderRadius.circular(10),
-      ),
+    final c = context.sac;
+
+    return _InsetCard(
       child: Row(
         children: [
-          const HugeIcon(
+          HugeIcon(
             icon: HugeIcons.strokeRoundedLink01,
             size: 16,
-            color: AppColors.primaryDark,
+            color: AppColors.primary,
           ),
-          const SizedBox(width: 8),
-          Text(
-            'achievements.views.detail_prerequisite'
-                .tr(namedArgs: {'id': '$prerequisiteId'}),
-            style: const TextStyle(
-              fontSize: 13,
-              fontWeight: FontWeight.w500,
-              color: AppColors.primaryDark,
+          const SizedBox(width: 10),
+          Expanded(
+            child: Text(
+              'achievements.views.detail_prerequisite'.tr(
+                namedArgs: {'id': '$prerequisiteId'},
+              ),
+              style: TextStyle(
+                fontSize: 13,
+                fontWeight: FontWeight.w500,
+                color: c.text,
+              ),
             ),
           ),
         ],
       ),
-    );
-  }
-}
-
-class _InfoRow extends StatelessWidget {
-  final HugeIconData icon;
-  final String label;
-  final String value;
-
-  const _InfoRow({
-    required this.icon,
-    required this.label,
-    required this.value,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    return Row(
-      children: [
-        HugeIcon(icon: icon, size: 16, color: context.sac.textSecondary),
-        const SizedBox(width: 8),
-        Text(
-          '$label: ',
-          style: TextStyle(
-            fontSize: 13,
-            color: context.sac.textSecondary,
-          ),
-        ),
-        Text(
-          value,
-          style: TextStyle(
-            fontSize: 13,
-            fontWeight: FontWeight.w600,
-            color: context.sac.text,
-          ),
-        ),
-      ],
     );
   }
 }

--- a/lib/features/achievements/presentation/views/achievements_view.dart
+++ b/lib/features/achievements/presentation/views/achievements_view.dart
@@ -1,98 +1,152 @@
+import 'dart:ui';
+
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:hugeicons/hugeicons.dart';
+import 'package:sacdia_app/core/animations/motion_tokens.dart';
 import 'package:sacdia_app/core/theme/app_colors.dart';
 import 'package:sacdia_app/core/theme/sac_colors.dart';
 import 'package:sacdia_app/core/widgets/sac_button.dart';
 import 'package:sacdia_app/core/widgets/sac_loading.dart';
 
+import '../../domain/entities/user_achievement.dart';
 import '../../domain/repositories/achievements_repository.dart';
 import '../providers/achievements_providers.dart';
 import '../widgets/achievement_grid_card.dart';
 import 'achievement_detail_sheet.dart';
 
-/// Full achievements screen — YouVersion badge grid layout.
-///
-/// - Dark scaffold background
-/// - AppBar: back arrow + "Logros" centered
-/// - Body: flat 3-column GridView of all achievements (no category grouping)
-/// - Pull-to-refresh
-/// - Loading / error / empty states
-class AchievementsView extends ConsumerWidget {
+enum _AchievementFilter { all, unlocked, inProgress, locked }
+
+/// Achievements screen v2 — summary hero, filters, badge grid with motion.
+class AchievementsView extends ConsumerStatefulWidget {
   const AchievementsView({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<AchievementsView> createState() => _AchievementsViewState();
+}
+
+class _AchievementsViewState extends ConsumerState<AchievementsView> {
+  _AchievementFilter _filter = _AchievementFilter.all;
+  bool _entrancePlayed = false;
+
+  @override
+  Widget build(BuildContext context) {
     final responseAsync = ref.watch(userAchievementsProvider);
+    final c = context.sac;
 
     return Scaffold(
-      appBar: AppBar(
-        backgroundColor: Colors.transparent,
-        elevation: 0,
-        surfaceTintColor: Colors.transparent,
-        systemOverlayStyle: SystemUiOverlayStyle.dark,
-        foregroundColor: context.sac.text,
-        centerTitle: true,
-        title: Text(
-          'achievements.views.title'.tr(),
-          style: TextStyle(
-            color: context.sac.text,
-            fontSize: 17,
-            fontWeight: FontWeight.w700,
-          ),
-        ),
-        leading: IconButton(
-          icon: HugeIcon(
-            icon: HugeIcons.strokeRoundedArrowLeft01,
-            color: context.sac.text,
-            size: 22,
-          ),
-          onPressed: () => Navigator.of(context).pop(),
-        ),
-      ),
+      backgroundColor: c.background,
       body: responseAsync.when(
-        loading: () => const Center(
-          child: SacLoading(),
-        ),
-        error: (error, stack) => _ErrorState(
-          onRetry: () => ref.invalidate(userAchievementsProvider),
+        loading: () => const Center(child: SacLoading()),
+        error: (error, stack) => CustomScrollView(
+          physics: const AlwaysScrollableScrollPhysics(),
+          slivers: [
+            _buildAppBar(context),
+            SliverFillRemaining(
+              hasScrollBody: false,
+              child: _ErrorState(
+                onRetry: () => ref.invalidate(userAchievementsProvider),
+              ),
+            ),
+          ],
         ),
         data: (response) {
-          // Flatten all achievements from all categories into a single list
-          final allAchievements = response.categories
-              .expand((group) => group.achievements)
-              .toList();
+          final all = _flattenSorted(response);
+          if (all.isEmpty) {
+            return CustomScrollView(
+              physics: const AlwaysScrollableScrollPhysics(),
+              slivers: [
+                _buildAppBar(context),
+                const SliverFillRemaining(
+                  hasScrollBody: false,
+                  child: _EmptyState(),
+                ),
+              ],
+            );
+          }
 
-          if (allAchievements.isEmpty) {
-            return const _EmptyState();
+          final filtered = _applyFilter(all, _filter);
+          final counts = _FilterCounts.from(all);
+
+          if (!_entrancePlayed) {
+            WidgetsBinding.instance.addPostFrameCallback((_) {
+              if (mounted && !_entrancePlayed) {
+                setState(() => _entrancePlayed = true);
+              }
+            });
           }
 
           return RefreshIndicator(
             color: AppColors.primary,
-            backgroundColor: context.sac.surface,
+            backgroundColor: c.surface,
+            edgeOffset: MediaQuery.paddingOf(context).top + 56,
             onRefresh: () async {
               ref.invalidate(userAchievementsProvider);
               await ref.read(userAchievementsProvider.future);
             },
-            child: GridView.builder(
-              padding: const EdgeInsets.all(16),
-              gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
-                crossAxisCount: 3,
-                crossAxisSpacing: 12,
-                mainAxisSpacing: 12,
-                // Enough vertical space: badge 64 + counter + name 2 lines + bar
-                childAspectRatio: 0.72,
+            child: CustomScrollView(
+              physics: const AlwaysScrollableScrollPhysics(
+                parent: BouncingScrollPhysics(),
               ),
-              itemCount: allAchievements.length,
-              itemBuilder: (context, index) {
-                final item = allAchievements[index];
-                return AchievementGridCard(
-                  achievementWithProgress: item,
-                  onTap: () => _showDetailSheet(context, item, ref),
-                );
-              },
+              slivers: [
+                _buildAppBar(context),
+                SliverToBoxAdapter(
+                  child: _SummaryHeader(
+                    completed: response.summary.totalCompleted,
+                    total: all.length,
+                    points: response.summary.totalPoints,
+                    percentage: response.summary.completionPercentage,
+                  ),
+                ),
+                SliverToBoxAdapter(
+                  child: _FilterBar(
+                    filter: _filter,
+                    counts: counts,
+                    onChanged: (value) => setState(() => _filter = value),
+                  ),
+                ),
+                if (filtered.isEmpty)
+                  SliverFillRemaining(
+                    hasScrollBody: false,
+                    child: _FilterEmptyState(
+                      onClear: () =>
+                          setState(() => _filter = _AchievementFilter.all),
+                    ),
+                  )
+                else
+                  SliverPadding(
+                    padding: const EdgeInsets.fromLTRB(16, 4, 16, 32),
+                    sliver: SliverGrid(
+                      gridDelegate:
+                          const SliverGridDelegateWithFixedCrossAxisCount(
+                        crossAxisCount: 3,
+                        crossAxisSpacing: 10,
+                        mainAxisSpacing: 10,
+                        childAspectRatio: 0.62,
+                      ),
+                      delegate: SliverChildBuilderDelegate(
+                        (context, index) {
+                          final item = filtered[index];
+                          // Stagger only on first paint — filter/scroll must not re-play.
+                          final delayMs = _entrancePlayed
+                              ? 0
+                              : (index.clamp(0, 11)) *
+                                  SacMotion.stagger.inMilliseconds;
+                          return AchievementGridCard(
+                            key: ValueKey(item.achievement.achievementId),
+                            achievementWithProgress: item,
+                            animationDelay: Duration(milliseconds: delayMs),
+                            animateEntrance: !_entrancePlayed,
+                            onTap: () => _showDetailSheet(context, item),
+                          );
+                        },
+                        childCount: filtered.length,
+                      ),
+                    ),
+                  ),
+              ],
             ),
           );
         },
@@ -100,15 +154,97 @@ class AchievementsView extends ConsumerWidget {
     );
   }
 
+  SliverAppBar _buildAppBar(BuildContext context) {
+    final c = context.sac;
+    return SliverAppBar(
+      pinned: true,
+      floating: false,
+      stretch: false,
+      backgroundColor: c.background.withValues(alpha: 0.88),
+      surfaceTintColor: Colors.transparent,
+      elevation: 0,
+      scrolledUnderElevation: 0,
+      systemOverlayStyle: Theme.of(context).brightness == Brightness.dark
+          ? SystemUiOverlayStyle.light
+          : SystemUiOverlayStyle.dark,
+      foregroundColor: c.text,
+      centerTitle: true,
+      title: Text(
+        'achievements.views.title'.tr(),
+        style: TextStyle(
+          color: c.text,
+          fontSize: 17,
+          fontWeight: FontWeight.w700,
+          letterSpacing: -0.2,
+        ),
+      ),
+      leading: IconButton(
+        icon: HugeIcon(
+          icon: HugeIcons.strokeRoundedArrowLeft01,
+          color: c.text,
+          size: 22,
+        ),
+        onPressed: () => Navigator.of(context).pop(),
+      ),
+      flexibleSpace: ClipRect(
+        child: BackdropFilter(
+          filter: ImageFilter.blur(sigmaX: 16, sigmaY: 16),
+          child: Container(color: c.background.withValues(alpha: 0.72)),
+        ),
+      ),
+    );
+  }
+
+  List<AchievementWithProgress> _flattenSorted(
+    UserAchievementsResponse response,
+  ) {
+    final all = response.categories
+        .expand((group) => group.achievements)
+        .toList();
+
+    int rank(AchievementWithProgress item) {
+      final state =
+          item.userAchievement?.visualState ?? AchievementVisualState.locked;
+      return switch (state) {
+        AchievementVisualState.unlocked => 0,
+        AchievementVisualState.inProgress => 1,
+        AchievementVisualState.locked => 2,
+      };
+    }
+
+    all.sort((a, b) => rank(a).compareTo(rank(b)));
+    return all;
+  }
+
+  List<AchievementWithProgress> _applyFilter(
+    List<AchievementWithProgress> all,
+    _AchievementFilter filter,
+  ) {
+    if (filter == _AchievementFilter.all) return all;
+    return all.where((item) {
+      final state =
+          item.userAchievement?.visualState ?? AchievementVisualState.locked;
+      return switch (filter) {
+        _AchievementFilter.all => true,
+        _AchievementFilter.unlocked =>
+          state == AchievementVisualState.unlocked,
+        _AchievementFilter.inProgress =>
+          state == AchievementVisualState.inProgress,
+        _AchievementFilter.locked => state == AchievementVisualState.locked,
+      };
+    }).toList();
+  }
+
   void _showDetailSheet(
     BuildContext context,
     AchievementWithProgress item,
-    WidgetRef ref,
   ) {
     showModalBottomSheet(
       context: context,
       isScrollControlled: true,
+      useRootNavigator: true,
       backgroundColor: Colors.transparent,
+      barrierColor: Colors.black.withValues(alpha: 0.4),
       builder: (_) => AchievementDetailSheet(
         achievementWithProgress: item,
       ),
@@ -116,7 +252,279 @@ class AchievementsView extends ConsumerWidget {
   }
 }
 
-// ── Empty State ──────────────────────────────────────────────────────────────────
+class _FilterCounts {
+  final int all;
+  final int unlocked;
+  final int inProgress;
+  final int locked;
+
+  const _FilterCounts({
+    required this.all,
+    required this.unlocked,
+    required this.inProgress,
+    required this.locked,
+  });
+
+  factory _FilterCounts.from(List<AchievementWithProgress> items) {
+    var unlocked = 0;
+    var inProgress = 0;
+    var locked = 0;
+    for (final item in items) {
+      final state =
+          item.userAchievement?.visualState ?? AchievementVisualState.locked;
+      switch (state) {
+        case AchievementVisualState.unlocked:
+          unlocked++;
+        case AchievementVisualState.inProgress:
+          inProgress++;
+        case AchievementVisualState.locked:
+          locked++;
+      }
+    }
+    return _FilterCounts(
+      all: items.length,
+      unlocked: unlocked,
+      inProgress: inProgress,
+      locked: locked,
+    );
+  }
+}
+
+// ── Summary header ─────────────────────────────────────────────────────────────
+
+class _SummaryHeader extends StatelessWidget {
+  final int completed;
+  final int total;
+  final int points;
+  final double percentage;
+
+  const _SummaryHeader({
+    required this.completed,
+    required this.total,
+    required this.points,
+    required this.percentage,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final c = context.sac;
+    final progress = (percentage / 100).clamp(0.0, 1.0);
+
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(20, 4, 20, 12),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.end,
+            children: [
+              Text(
+                '$completed',
+                style: TextStyle(
+                  fontSize: 40,
+                  fontWeight: FontWeight.w800,
+                  height: 1,
+                  letterSpacing: -1.2,
+                  color: c.text,
+                ),
+              ),
+              Padding(
+                padding: const EdgeInsets.only(bottom: 6, left: 6),
+                child: Text(
+                  'achievements.views.summary_of'.tr(
+                    namedArgs: {'total': '$total'},
+                  ),
+                  style: TextStyle(
+                    fontSize: 15,
+                    fontWeight: FontWeight.w500,
+                    color: c.textSecondary,
+                  ),
+                ),
+              ),
+              const Spacer(),
+              if (points > 0)
+                Padding(
+                  padding: const EdgeInsets.only(bottom: 6),
+                  child: Text(
+                    'achievements.views.summary_points'.tr(
+                      namedArgs: {'points': '$points'},
+                    ),
+                    style: TextStyle(
+                      fontSize: 13,
+                      fontWeight: FontWeight.w600,
+                      color: AppColors.primary,
+                    ),
+                  ),
+                ),
+            ],
+          ),
+          const SizedBox(height: 14),
+          ClipRRect(
+            borderRadius: BorderRadius.circular(4),
+            child: SizedBox(
+              height: 5,
+              child: Stack(
+                children: [
+                  Container(color: c.border),
+                  FractionallySizedBox(
+                    widthFactor: progress,
+                    child: Container(
+                      decoration: BoxDecoration(
+                        color: AppColors.primary,
+                        borderRadius: BorderRadius.circular(4),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+// ── Filter bar ─────────────────────────────────────────────────────────────────
+
+class _FilterBar extends StatelessWidget {
+  final _AchievementFilter filter;
+  final _FilterCounts counts;
+  final ValueChanged<_AchievementFilter> onChanged;
+
+  const _FilterBar({
+    required this.filter,
+    required this.counts,
+    required this.onChanged,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      height: 44,
+      child: ListView(
+        scrollDirection: Axis.horizontal,
+        padding: const EdgeInsets.fromLTRB(16, 0, 16, 8),
+        children: [
+          _FilterChip(
+            label: 'achievements.views.filter_all'.tr(),
+            count: counts.all,
+            selected: filter == _AchievementFilter.all,
+            onTap: () => onChanged(_AchievementFilter.all),
+          ),
+          const SizedBox(width: 8),
+          _FilterChip(
+            label: 'achievements.views.filter_unlocked'.tr(),
+            count: counts.unlocked,
+            selected: filter == _AchievementFilter.unlocked,
+            onTap: () => onChanged(_AchievementFilter.unlocked),
+          ),
+          const SizedBox(width: 8),
+          _FilterChip(
+            label: 'achievements.views.filter_in_progress'.tr(),
+            count: counts.inProgress,
+            selected: filter == _AchievementFilter.inProgress,
+            onTap: () => onChanged(_AchievementFilter.inProgress),
+          ),
+          const SizedBox(width: 8),
+          _FilterChip(
+            label: 'achievements.views.filter_locked'.tr(),
+            count: counts.locked,
+            selected: filter == _AchievementFilter.locked,
+            onTap: () => onChanged(_AchievementFilter.locked),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _FilterChip extends StatefulWidget {
+  final String label;
+  final int count;
+  final bool selected;
+  final VoidCallback onTap;
+
+  const _FilterChip({
+    required this.label,
+    required this.count,
+    required this.selected,
+    required this.onTap,
+  });
+
+  @override
+  State<_FilterChip> createState() => _FilterChipState();
+}
+
+class _FilterChipState extends State<_FilterChip> {
+  bool _pressed = false;
+
+  void _setPressed(bool value) {
+    if (_pressed == value) return;
+    setState(() => _pressed = value);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final c = context.sac;
+    final reduce = SacMotion.reduceMotionOf(context);
+    final bg = widget.selected
+        ? AppColors.primary.withValues(alpha: 0.14)
+        : c.surfaceVariant.withValues(alpha: 0.7);
+    final fg = widget.selected ? AppColors.primary : c.textSecondary;
+
+    return GestureDetector(
+      behavior: HitTestBehavior.opaque,
+      onTapDown: (_) => _setPressed(true),
+      onTapUp: (_) => _setPressed(false),
+      onTapCancel: () => _setPressed(false),
+      onTap: widget.onTap,
+      child: AnimatedScale(
+        scale: (!reduce && _pressed) ? 0.97 : 1,
+        duration: SacMotion.press,
+        curve: SacMotion.easeOut,
+        child: AnimatedContainer(
+          duration: SacMotion.standard,
+          curve: SacMotion.easeOut,
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 7),
+          decoration: BoxDecoration(
+            color: bg,
+            borderRadius: BorderRadius.circular(20),
+            border: Border.all(
+              color: widget.selected
+                  ? AppColors.primary.withValues(alpha: 0.35)
+                  : c.border.withValues(alpha: 0.5),
+            ),
+          ),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text(
+                widget.label,
+                style: TextStyle(
+                  fontSize: 13,
+                  fontWeight: widget.selected ? FontWeight.w700 : FontWeight.w500,
+                  color: fg,
+                ),
+              ),
+              const SizedBox(width: 6),
+              Text(
+                '${widget.count}',
+                style: TextStyle(
+                  fontSize: 12,
+                  fontWeight: FontWeight.w700,
+                  color: fg.withValues(alpha: 0.85),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+// ── Empty / error ──────────────────────────────────────────────────────────────
 
 class _EmptyState extends StatelessWidget {
   const _EmptyState();
@@ -151,7 +559,45 @@ class _EmptyState extends StatelessWidget {
   }
 }
 
-// ── Error State ──────────────────────────────────────────────────────────────────
+class _FilterEmptyState extends StatelessWidget {
+  final VoidCallback onClear;
+
+  const _FilterEmptyState({required this.onClear});
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(40),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            HugeIcon(
+              icon: HugeIcons.strokeRoundedFilter,
+              size: 40,
+              color: context.sac.textTertiary,
+            ),
+            const SizedBox(height: 12),
+            Text(
+              'achievements.views.filter_empty'.tr(),
+              style: TextStyle(
+                color: context.sac.textSecondary,
+                fontSize: 15,
+                fontWeight: FontWeight.w500,
+              ),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 16),
+            TextButton(
+              onPressed: onClear,
+              child: Text('achievements.views.filter_all'.tr()),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
 
 class _ErrorState extends StatelessWidget {
   final VoidCallback onRetry;

--- a/lib/features/achievements/presentation/widgets/achievement_badge.dart
+++ b/lib/features/achievements/presentation/widgets/achievement_badge.dart
@@ -1,16 +1,16 @@
 import 'dart:math' as math;
 
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:hugeicons/hugeicons.dart';
 import 'package:sacdia_app/core/animations/motion_tokens.dart';
 import 'package:sacdia_app/core/theme/sac_colors.dart';
+import 'package:sacdia_app/core/widgets/sac_network_image.dart';
 
 import '../../domain/entities/achievement.dart'
     show AchievementTier, kDefaultLockedAchievementBadgeUrl;
 import '../../domain/entities/user_achievement.dart';
 
-/// Devuelve el color del tier de un logro.
+/// Color metálico del tier (glow, borde de badge, fill de progreso).
 Color achievementTierColor(AchievementTier tier) => switch (tier) {
       AchievementTier.bronze => const Color(0xFFCD7F32),
       AchievementTier.silver => const Color(0xFFC0C0C0),
@@ -19,6 +19,41 @@ Color achievementTierColor(AchievementTier tier) => switch (tier) {
       AchievementTier.diamond => const Color(0xFFB9F2FF),
       AchievementTier.unknown => Colors.grey,
     };
+
+/// Tinta legible del tier para chips/labels (plata/oro/platino claros fallan en UI).
+Color achievementTierInkColor(AchievementTier tier) => switch (tier) {
+      AchievementTier.bronze => const Color(0xFF8B5314),
+      AchievementTier.silver => const Color(0xFF4A5560),
+      AchievementTier.gold => const Color(0xFF9A7200),
+      AchievementTier.platinum => const Color(0xFF4E5664),
+      AchievementTier.diamond => const Color(0xFF0E7FA3),
+      AchievementTier.unknown => const Color(0xFF5A5A5A),
+    };
+
+/// Fondo de chip de tier con contraste suficiente sobre surface clara/oscura.
+Color achievementTierChipBackground(AchievementTier tier, Brightness brightness) {
+  final isDark = brightness == Brightness.dark;
+  return switch (tier) {
+    AchievementTier.bronze => isDark
+        ? const Color(0xFFCD7F32).withValues(alpha: 0.28)
+        : const Color(0xFFF3D9B8),
+    AchievementTier.silver => isDark
+        ? const Color(0xFF9AA3AD).withValues(alpha: 0.32)
+        : const Color(0xFFDDE2E8),
+    AchievementTier.gold => isDark
+        ? const Color(0xFFFFD700).withValues(alpha: 0.28)
+        : const Color(0xFFF8E7A0),
+    AchievementTier.platinum => isDark
+        ? const Color(0xFFB8BEC8).withValues(alpha: 0.30)
+        : const Color(0xFFE2E6EC),
+    AchievementTier.diamond => isDark
+        ? const Color(0xFFB9F2FF).withValues(alpha: 0.28)
+        : const Color(0xFFC9EEF8),
+    AchievementTier.unknown => isDark
+        ? Colors.grey.withValues(alpha: 0.28)
+        : const Color(0xFFE5E5E5),
+  };
+}
 
 /// Badge visual de logro con soporte para tres estados:
 /// LOCKED, IN_PROGRESS y UNLOCKED.
@@ -190,7 +225,7 @@ class _AchievementBadgeState extends State<AchievementBadge>
               : kDefaultLockedAchievementBadgeUrl)
           : kDefaultLockedAchievementBadgeUrl;
 
-      imageContent = CachedNetworkImage(
+      imageContent = SacNetworkImage(
         imageUrl: effectiveUrl,
         width: widget.size,
         height: widget.size,

--- a/lib/features/achievements/presentation/widgets/achievement_grid_card.dart
+++ b/lib/features/achievements/presentation/widgets/achievement_grid_card.dart
@@ -1,118 +1,253 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
+import 'package:sacdia_app/core/animations/motion_tokens.dart';
 import 'package:sacdia_app/core/theme/sac_colors.dart';
 
 import '../../domain/entities/user_achievement.dart';
 import '../../domain/repositories/achievements_repository.dart';
 import 'achievement_badge.dart';
 
-/// Grid card for a single achievement — YouVersion badge style.
+const double _kBadgeSize = 68;
+
+/// Grid card v2 — badge-first, quieter chrome, press + enter motion.
 ///
-/// Dark card (#1C1C1E), centered column:
-///   1. AchievementBadge (56px) — color if unlocked, grayscale if locked/in-progress
-///   2. Counter pill — timesCompleted or progressValue
-///   3. Achievement name (2 lines max)
-///   4. Thin progress bar (3px)
-///
-/// Secret + locked: shows "?" icon, hides name, no progress bar.
-class AchievementGridCard extends StatelessWidget {
+/// Hierarchy:
+/// - Unlocked: color badge, stronger name, optional counter
+/// - In progress: progress ring + thin bar only
+/// - Locked: muted surface, no empty "0" counter, no empty bar
+/// - Secret + locked: "?" badge, "???" label
+class AchievementGridCard extends StatefulWidget {
   final AchievementWithProgress achievementWithProgress;
   final VoidCallback? onTap;
+
+  /// Stagger delay for entrance (capped by parent).
+  final Duration animationDelay;
+
+  /// When false, skip entrance and render at rest (filter/scroll reuse).
+  final bool animateEntrance;
 
   const AchievementGridCard({
     super.key,
     required this.achievementWithProgress,
     this.onTap,
+    this.animationDelay = Duration.zero,
+    this.animateEntrance = true,
   });
 
   @override
+  State<AchievementGridCard> createState() => _AchievementGridCardState();
+}
+
+class _AchievementGridCardState extends State<AchievementGridCard>
+    with SingleTickerProviderStateMixin {
+  bool _pressed = false;
+  late final AnimationController _enterController;
+  late final Animation<double> _fade;
+  late final Animation<Offset> _slide;
+  Timer? _delayedStart;
+  bool? _reduceMotion;
+
+  @override
+  void initState() {
+    super.initState();
+    _enterController = AnimationController(
+      vsync: this,
+      duration: SacMotion.standard,
+    );
+    _fade = CurvedAnimation(parent: _enterController, curve: SacMotion.easeOut);
+    _slide = Tween<Offset>(
+      begin: const Offset(0, 0.06),
+      end: Offset.zero,
+    ).animate(
+      CurvedAnimation(parent: _enterController, curve: SacMotion.easeOut),
+    );
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    final reduceMotion = SacMotion.reduceMotionOf(context);
+    if (_reduceMotion == reduceMotion) return;
+
+    final firstRead = _reduceMotion == null;
+    _reduceMotion = reduceMotion;
+
+    if (reduceMotion || !widget.animateEntrance) {
+      _delayedStart?.cancel();
+      _enterController.value = 1;
+    } else if (firstRead) {
+      _delayedStart = Timer(widget.animationDelay, () {
+        if (mounted && _reduceMotion == false) _enterController.forward();
+      });
+    }
+  }
+
+  @override
+  void dispose() {
+    _delayedStart?.cancel();
+    _enterController.dispose();
+    super.dispose();
+  }
+
+  void _setPressed(bool value) {
+    if (_pressed == value || widget.onTap == null) return;
+    setState(() => _pressed = value);
+  }
+
+  @override
   Widget build(BuildContext context) {
-    final achievement = achievementWithProgress.achievement;
-    final userAchievement = achievementWithProgress.userAchievement;
+    final achievement = widget.achievementWithProgress.achievement;
+    final userAchievement = widget.achievementWithProgress.userAchievement;
 
     final isCompleted = userAchievement?.isCompleted ?? false;
     final isSecret = achievement.secret && !isCompleted;
     final visualState =
         userAchievement?.visualState ?? AchievementVisualState.locked;
+    final isInProgress = visualState == AchievementVisualState.inProgress;
 
     final progressValue = userAchievement?.progressValue ?? 0;
     final progressPercentage = userAchievement?.progressPercentage ?? 0.0;
     final timesCompleted = userAchievement?.timesCompleted ?? 0;
-
     final tierColor = achievementTierColor(achievement.tier);
+    final tierInk = achievementTierInkColor(achievement.tier);
 
-    // Counter label: times completed for repeatable, progressValue otherwise
-    final String counterLabel = isCompleted
+    final showCounter = !isSecret &&
+        (isCompleted || (isInProgress && progressValue > 0));
+    final counterLabel = isCompleted
         ? (achievement.repeatable && timesCompleted > 0
             ? timesCompleted.toString()
             : '1')
         : progressValue.toString();
 
-    return GestureDetector(
-      onTap: onTap,
-      child: Container(
-        decoration: BoxDecoration(
-          color: context.sac.surfaceVariant,
-          borderRadius: BorderRadius.circular(16),
-        ),
-        padding: const EdgeInsets.symmetric(vertical: 12, horizontal: 8),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            // 1. Badge
-            if (isSecret)
-              _SecretBadge()
-            else
-              AchievementBadge(
-                badgeImageUrl: achievement.badgeImageUrl,
-                tier: achievement.tier,
-                visualState: visualState,
-                isSecret: false,
-                size: 56,
-                progress: progressPercentage,
-              ),
+    final reduce = _reduceMotion ?? SacMotion.reduceMotionOf(context);
+    final c = context.sac;
 
-            const SizedBox(height: 4),
+    final surfaceColor = switch (visualState) {
+      AchievementVisualState.unlocked => c.surface,
+      AchievementVisualState.inProgress => c.surface,
+      AchievementVisualState.locked => c.surfaceVariant.withValues(alpha: 0.55),
+    };
 
-            // 2. Counter pill
-            if (!isSecret)
-              _CounterPill(
-                label: counterLabel,
-                isCompleted: isCompleted,
-                tierColor: tierColor,
-              ),
+    final borderColor = switch (visualState) {
+      // Ink (not metallic) so silver/gold borders stay visible on white cards.
+      AchievementVisualState.unlocked =>
+        tierInk.withValues(alpha: 0.45),
+      AchievementVisualState.inProgress => c.border.withValues(alpha: 0.85),
+      AchievementVisualState.locked => c.border.withValues(alpha: 0.45),
+    };
 
-            if (!isSecret) const SizedBox(height: 4),
+    final nameColor = isCompleted ? c.text : c.textSecondary;
+    final nameWeight = isCompleted ? FontWeight.w600 : FontWeight.w500;
 
-            // 3. Name — Flexible so it compresses instead of overflowing
-            Flexible(
-              child: Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 4),
-                child: Text(
-                  isSecret ? '???' : achievement.name,
-                  style: TextStyle(
-                    color: context.sac.textSecondary,
-                    fontSize: 11,
-                    fontWeight: FontWeight.w400,
-                    height: 1.3,
-                  ),
-                  textAlign: TextAlign.center,
-                  maxLines: 2,
-                  overflow: TextOverflow.ellipsis,
-                ),
-              ),
+    // Fixed top stack keeps every badge on the same horizontal baseline.
+    // Ring overflow (+8) and counter slot are always reserved.
+    const badgeSize = _kBadgeSize;
+    const badgeSlot = badgeSize + 8.0;
+    const counterSlot = 24.0;
+    const progressSlot = 9.0;
+
+    Widget card = Semantics(
+      button: true,
+      label: isSecret ? '???' : achievement.name,
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onTapDown: (_) => _setPressed(true),
+        onTapUp: (_) => _setPressed(false),
+        onTapCancel: () => _setPressed(false),
+        onTap: widget.onTap,
+        child: AnimatedScale(
+          scale: (!reduce && _pressed) ? 0.97 : 1,
+          duration: SacMotion.press,
+          curve: SacMotion.easeOut,
+          child: AnimatedContainer(
+            duration: SacMotion.standard,
+            curve: SacMotion.easeOut,
+            decoration: BoxDecoration(
+              color: surfaceColor,
+              borderRadius: BorderRadius.circular(18),
+              border: Border.all(color: borderColor, width: 1),
             ),
-
-            const SizedBox(height: 4),
-
-            // 4. Progress bar — hidden for secret locked
-            if (!isSecret)
-              _ThinProgressBar(
-                progress: progressPercentage,
-                tierColor: tierColor,
-              ),
-          ],
+            padding: const EdgeInsets.fromLTRB(6, 10, 6, 10),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: [
+                SizedBox(
+                  height: badgeSlot,
+                  width: badgeSlot,
+                  child: Center(
+                    child: isSecret
+                        ? const _SecretBadge()
+                        : AchievementBadge(
+                            badgeImageUrl: achievement.badgeImageUrl,
+                            tier: achievement.tier,
+                            visualState: visualState,
+                            isSecret: false,
+                            size: badgeSize,
+                            progress: progressPercentage,
+                          ),
+                  ),
+                ),
+                SizedBox(
+                  height: counterSlot,
+                  child: showCounter
+                      ? Align(
+                          alignment: Alignment.center,
+                          child: _CounterPill(
+                            label: counterLabel,
+                            isCompleted: isCompleted,
+                            tierColor: tierInk,
+                          ),
+                        )
+                      : null,
+                ),
+                Expanded(
+                  child: Align(
+                    alignment: Alignment.topCenter,
+                    child: Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 2),
+                      child: Text(
+                        isSecret ? '???' : achievement.name,
+                        style: TextStyle(
+                          color: nameColor,
+                          fontSize: 11.5,
+                          fontWeight: nameWeight,
+                          height: 1.25,
+                          letterSpacing: 0.1,
+                        ),
+                        textAlign: TextAlign.center,
+                        maxLines: 3,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ),
+                  ),
+                ),
+                SizedBox(
+                  height: progressSlot,
+                  child: (isInProgress && !isSecret)
+                      ? Align(
+                          alignment: Alignment.bottomCenter,
+                          child: _ThinProgressBar(
+                            progress: progressPercentage,
+                            tierColor: tierColor,
+                          ),
+                        )
+                      : null,
+                ),
+              ],
+            ),
+          ),
         ),
+      ),
+    );
+
+    if (reduce) return card;
+
+    return FadeTransition(
+      opacity: _fade,
+      child: SlideTransition(
+        position: _slide,
+        child: card,
       ),
     );
   }
@@ -121,25 +256,27 @@ class AchievementGridCard extends StatelessWidget {
 // ── Secret badge placeholder ────────────────────────────────────────────────────
 
 class _SecretBadge extends StatelessWidget {
+  const _SecretBadge();
+
   @override
   Widget build(BuildContext context) {
     final isDark = Theme.of(context).brightness == Brightness.dark;
     return Container(
-      width: 56,
-      height: 56,
+      width: _kBadgeSize,
+      height: _kBadgeSize,
       decoration: BoxDecoration(
         shape: BoxShape.circle,
         color: isDark
             ? Colors.white.withValues(alpha: 0.06)
-            : Colors.black.withValues(alpha: 0.05),
+            : Colors.black.withValues(alpha: 0.04),
         border: Border.all(color: context.sac.border, width: 1.5),
       ),
       child: Center(
         child: Text(
           '?',
           style: TextStyle(
-            fontSize: 26,
-            fontWeight: FontWeight.w900,
+            fontSize: _kBadgeSize * 0.42,
+            fontWeight: FontWeight.w800,
             color: context.sac.textTertiary,
           ),
         ),
@@ -163,21 +300,25 @@ class _CounterPill extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final bgColor =
-        isCompleted ? tierColor.withValues(alpha: 0.22) : context.sac.border;
+    final bgColor = isCompleted
+        ? tierColor.withValues(alpha: 0.16)
+        : context.sac.border;
 
     return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+      constraints: const BoxConstraints(minWidth: 22),
+      padding: const EdgeInsets.symmetric(horizontal: 7, vertical: 2),
       decoration: BoxDecoration(
         color: bgColor,
-        borderRadius: BorderRadius.circular(12),
+        borderRadius: BorderRadius.circular(10),
       ),
       child: Text(
         label,
+        textAlign: TextAlign.center,
         style: TextStyle(
           color: isCompleted ? tierColor : context.sac.textSecondary,
-          fontSize: 12,
+          fontSize: 11,
           fontWeight: FontWeight.w700,
+          height: 1.1,
         ),
       ),
     );
@@ -198,25 +339,25 @@ class _ThinProgressBar extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 6),
+      padding: const EdgeInsets.symmetric(horizontal: 8),
       child: LayoutBuilder(
         builder: (context, constraints) {
           final totalWidth = constraints.maxWidth;
-          final fillWidth = (totalWidth * progress.clamp(0.0, 1.0));
+          final fillWidth = totalWidth * progress.clamp(0.0, 1.0);
 
           return ClipRRect(
             borderRadius: BorderRadius.circular(2),
             child: Stack(
               children: [
-                // Track
                 Container(
                   height: 3,
                   width: totalWidth,
                   color: context.sac.border,
                 ),
-                // Fill
                 if (fillWidth > 0)
-                  Container(
+                  AnimatedContainer(
+                    duration: SacMotion.standard,
+                    curve: SacMotion.easeOut,
                     height: 3,
                     width: fillWidth,
                     decoration: BoxDecoration(

--- a/lib/features/achievements/presentation/widgets/achievement_progress_bar.dart
+++ b/lib/features/achievements/presentation/widgets/achievement_progress_bar.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:sacdia_app/core/animations/motion_tokens.dart';
 
 import '../../domain/entities/achievement.dart';
 import 'achievement_badge.dart';
@@ -36,36 +37,54 @@ class _AchievementProgressBarState extends State<AchievementProgressBar>
     with SingleTickerProviderStateMixin {
   late final AnimationController _controller;
   late Animation<double> _fillAnimation;
+  bool? _reduceMotion;
 
   @override
   void initState() {
     super.initState();
     _controller = AnimationController(
       vsync: this,
-      duration: const Duration(milliseconds: 700),
+      duration: SacMotion.standard,
     );
     _fillAnimation = Tween<double>(
       begin: 0.0,
       end: widget.progress.clamp(0.0, 1.0),
-    ).animate(CurvedAnimation(parent: _controller, curve: Curves.easeOutCubic));
+    ).animate(CurvedAnimation(parent: _controller, curve: SacMotion.easeOut));
+  }
 
-    _controller.forward();
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    final reduce = SacMotion.reduceMotionOf(context);
+    if (_reduceMotion == reduce) return;
+    _reduceMotion = reduce;
+
+    if (reduce) {
+      _controller.value = 1;
+    } else if (_controller.value == 0) {
+      _controller.forward();
+    }
   }
 
   @override
   void didUpdateWidget(AchievementProgressBar oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (oldWidget.progress != widget.progress) {
-      final current = _fillAnimation.value;
+      final reduce = _reduceMotion ?? SacMotion.reduceMotionOf(context);
+      final current = reduce ? widget.progress : _fillAnimation.value;
       _fillAnimation = Tween<double>(
-        begin: current,
+        begin: current.clamp(0.0, 1.0),
         end: widget.progress.clamp(0.0, 1.0),
       ).animate(
-        CurvedAnimation(parent: _controller, curve: Curves.easeOutCubic),
+        CurvedAnimation(parent: _controller, curve: SacMotion.easeOut),
       );
-      _controller
-        ..reset()
-        ..forward();
+      if (reduce) {
+        _controller.value = 1;
+      } else {
+        _controller
+          ..reset()
+          ..forward();
+      }
     }
   }
 
@@ -91,14 +110,12 @@ class _AchievementProgressBarState extends State<AchievementProgressBar>
                 builder: (context, _) {
                   return Stack(
                     children: [
-                      // Track background
                       Container(
                         decoration: BoxDecoration(
                           color: tierColor.withValues(alpha: 0.15),
                           borderRadius: BorderRadius.circular(100),
                         ),
                       ),
-                      // Filled portion with tier color
                       FractionallySizedBox(
                         widthFactor: _fillAnimation.value,
                         alignment: Alignment.centerLeft,

--- a/lib/features/classes/presentation/sheets/enroll_previous_class_sheet.dart
+++ b/lib/features/classes/presentation/sheets/enroll_previous_class_sheet.dart
@@ -1,8 +1,8 @@
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:hugeicons/hugeicons.dart';
+import 'package:sacdia_app/core/widgets/sac_network_image.dart';
 import 'package:sacdia_app/core/theme/app_colors.dart';
 import 'package:sacdia_app/core/theme/sac_colors.dart';
 import 'package:sacdia_app/core/widgets/sac_button.dart';
@@ -364,7 +364,7 @@ class _EnrollPreviousClassSheetState
                             child: cls.imageUrl != null
                                 ? ClipRRect(
                                     borderRadius: BorderRadius.circular(8),
-                                    child: CachedNetworkImage(
+                                    child: SacNetworkImage(
                                       imageUrl: cls.imageUrl!,
                                       memCacheWidth:
                                           108, // 36 * 3 (max device pixel ratio)

--- a/lib/features/classes/presentation/widgets/class_card.dart
+++ b/lib/features/classes/presentation/widgets/class_card.dart
@@ -1,4 +1,3 @@
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:hugeicons/hugeicons.dart';
@@ -6,6 +5,7 @@ import 'package:sacdia_app/core/theme/app_colors.dart';
 import 'package:sacdia_app/core/theme/sac_colors.dart';
 import 'package:sacdia_app/core/widgets/sac_badge.dart';
 import 'package:sacdia_app/core/widgets/sac_card.dart';
+import 'package:sacdia_app/core/widgets/sac_network_image.dart';
 import 'package:sacdia_app/core/widgets/sac_progress_bar.dart';
 
 import '../../domain/entities/progressive_class.dart';
@@ -61,7 +61,7 @@ class ClassCard extends StatelessWidget {
                 child: progressiveClass.imageUrl != null
                     ? ClipRRect(
                         borderRadius: BorderRadius.circular(12),
-                        child: CachedNetworkImage(
+                        child: SacNetworkImage(
                           imageUrl: progressiveClass.imageUrl!,
                           memCacheWidth: 132, // 44 * 3 (max device pixel ratio)
                           memCacheHeight: 132, // 44 * 3

--- a/lib/features/classes/presentation/widgets/class_identity_badge.dart
+++ b/lib/features/classes/presentation/widgets/class_identity_badge.dart
@@ -1,6 +1,6 @@
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:hugeicons/hugeicons.dart';
+import 'package:sacdia_app/core/widgets/sac_network_image.dart';
 
 import '../../../../core/theme/app_colors.dart';
 
@@ -63,7 +63,7 @@ class ClassIdentityBadge extends StatelessWidget {
           ? fallback()
           : ClipRRect(
               borderRadius: BorderRadius.circular(borderRadius),
-              child: CachedNetworkImage(
+              child: SacNetworkImage(
                 imageUrl: trimmedImageUrl,
                 memCacheWidth: cacheSize,
                 memCacheHeight: cacheSize,

--- a/lib/features/club/presentation/views/club_view.dart
+++ b/lib/features/club/presentation/views/club_view.dart
@@ -1,4 +1,3 @@
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:google_maps_flutter/google_maps_flutter.dart';
@@ -12,6 +11,7 @@ import '../../../../core/theme/app_theme.dart';
 import '../../../../core/theme/sac_colors.dart';
 import '../../../../core/widgets/sac_button.dart';
 import '../../../../core/widgets/sac_loading.dart';
+import '../../../../core/widgets/sac_network_image.dart';
 import '../../../../core/widgets/sac_text_field.dart';
 import '../../../activities/presentation/views/location_picker_view.dart';
 import '../../domain/entities/club_info.dart';
@@ -848,9 +848,9 @@ class _LogoPreview extends StatelessWidget {
           ],
         ),
         clipBehavior: Clip.antiAlias,
-        child: CachedNetworkImage(
+        child: SacNetworkImage(
           imageUrl: logoUrl,
-          fit: BoxFit.cover,
+          fit: BoxFit.contain,
           memCacheWidth: 300,
           memCacheHeight: 300,
           errorWidget: (_, __, ___) => Center(

--- a/lib/features/dashboard/presentation/widgets/current_class_card.dart
+++ b/lib/features/dashboard/presentation/widgets/current_class_card.dart
@@ -1,8 +1,8 @@
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:hugeicons/hugeicons.dart';
+import 'package:sacdia_app/core/widgets/sac_network_image.dart';
 import 'package:sacdia_app/core/theme/app_colors.dart';
 import 'package:sacdia_app/core/theme/sac_colors.dart';
 import 'package:sacdia_app/core/widgets/sac_card.dart';
@@ -177,7 +177,7 @@ class CurrentClassCard extends ConsumerWidget {
       child: imageUrl != null
           ? ClipRRect(
               borderRadius: BorderRadius.circular(10),
-              child: CachedNetworkImage(
+              child: SacNetworkImage(
                 imageUrl: imageUrl,
                 memCacheWidth: 120, // 40 * 3 (max device pixel ratio)
                 memCacheHeight: 120,

--- a/lib/features/honors/data/models/honor_model.dart
+++ b/lib/features/honors/data/models/honor_model.dart
@@ -18,6 +18,7 @@ String? _readCategoryName(Map<String, dynamic> json) {
 }
 
 String? _buildImageUrl(String? raw) {
+  // Relative keys are joined to the CDN base. Supports svg/png/webp/jpg.
   if (raw == null || raw.isEmpty) return null;
   if (raw.startsWith('http')) return raw;
   return '$_honorImagesBase$raw';

--- a/lib/features/honors/presentation/widgets/honor_badge_image.dart
+++ b/lib/features/honors/presentation/widgets/honor_badge_image.dart
@@ -1,6 +1,6 @@
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:hugeicons/hugeicons.dart';
+import 'package:sacdia_app/core/widgets/sac_network_image.dart';
 
 /// Displays an honor badge without forcing an oval or circular mask.
 ///
@@ -8,6 +8,8 @@ import 'package:hugeicons/hugeicons.dart';
 /// are often inverted triangles. The image asset already carries the correct
 /// silhouette, usually with transparent pixels around it, so the UI must keep
 /// the natural aspect and shape using [BoxFit.contain].
+///
+/// Supports raster (png/webp/jpg) and SVG URLs via [SacNetworkImage].
 class HonorBadgeImage extends StatelessWidget {
   final String? imageUrl;
   final double width;
@@ -45,7 +47,7 @@ class HonorBadgeImage extends StatelessWidget {
       height: height,
       child: Padding(
         padding: padding,
-        child: CachedNetworkImage(
+        child: SacNetworkImage(
           imageUrl: imageUrl!,
           memCacheWidth: memCacheWidth,
           memCacheHeight: memCacheHeight,

--- a/lib/features/master_honors/presentation/widgets/master_honor_badge.dart
+++ b/lib/features/master_honors/presentation/widgets/master_honor_badge.dart
@@ -1,7 +1,7 @@
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:hugeicons/hugeicons.dart';
 import 'package:sacdia_app/core/theme/app_colors.dart';
+import 'package:sacdia_app/core/widgets/sac_network_image.dart';
 import 'package:sacdia_app/features/master_honors/domain/entities/user_master_honor.dart';
 
 /// Badge visual de maestría para usar en la tarjeta virtual y en listas
@@ -141,7 +141,7 @@ class _HonorImage extends StatelessWidget {
       height: height,
       child: ClipRRect(
         borderRadius: BorderRadius.circular(999),
-        child: CachedNetworkImage(
+        child: SacNetworkImage(
           imageUrl: image,
           fit: BoxFit.contain,
           memCacheWidth: (width * 3).round(),

--- a/lib/features/master_honors/presentation/widgets/master_honor_roadmap_grid.dart
+++ b/lib/features/master_honors/presentation/widgets/master_honor_roadmap_grid.dart
@@ -1,8 +1,8 @@
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:hugeicons/hugeicons.dart';
 import 'package:sacdia_app/core/theme/app_colors.dart';
 import 'package:sacdia_app/core/theme/sac_colors.dart';
+import 'package:sacdia_app/core/widgets/sac_network_image.dart';
 import 'package:sacdia_app/features/master_honors/domain/entities/master_honor_roadmap.dart';
 
 class MasterHonorRoadmapGrid extends StatelessWidget {
@@ -158,7 +158,7 @@ class MasterHonorLogo extends StatelessWidget {
     return SizedBox(
       width: width,
       height: size,
-      child: CachedNetworkImage(
+      child: SacNetworkImage(
         imageUrl: image,
         fit: BoxFit.contain,
         memCacheWidth: (width * 3).round(),

--- a/lib/features/profile/presentation/widgets/profile_honors_section.dart
+++ b/lib/features/profile/presentation/widgets/profile_honors_section.dart
@@ -1,4 +1,3 @@
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -9,6 +8,7 @@ import 'package:sacdia_app/features/honors/presentation/theme/honor_category_pal
 import 'package:go_router/go_router.dart';
 import 'package:sacdia_app/core/config/route_names.dart';
 import 'package:sacdia_app/core/widgets/sac_button.dart';
+import 'package:sacdia_app/core/widgets/sac_network_image.dart';
 import 'package:sacdia_app/features/honors/domain/entities/user_honor.dart';
 import 'package:sacdia_app/features/honors/presentation/providers/honors_providers.dart';
 import 'package:sacdia_app/features/master_honors/presentation/widgets/master_honor_history_section.dart';
@@ -358,7 +358,7 @@ class _HonorGridItem extends StatelessWidget {
               fit: StackFit.expand,
               children: [
                 imageUrl != null && imageUrl.isNotEmpty
-                    ? CachedNetworkImage(
+                    ? SacNetworkImage(
                         imageUrl: imageUrl,
                         fit: BoxFit.contain,
                         memCacheWidth: 288,

--- a/lib/features/units/presentation/views/unit_form_sheet.dart
+++ b/lib/features/units/presentation/views/unit_form_sheet.dart
@@ -7,6 +7,7 @@ import '../../../../core/theme/app_colors.dart';
 import '../../../../core/theme/app_theme.dart';
 import '../../../../core/theme/sac_colors.dart';
 import '../../../../core/utils/icon_helper.dart';
+import '../../../../core/utils/role_utils.dart';
 import '../../../../core/widgets/fixed_input_icon_slot.dart';
 import '../../../../core/widgets/sac_text_field.dart';
 import '../../domain/entities/unit.dart';
@@ -850,7 +851,10 @@ class _MemberPickerSheetState extends State<_MemberPickerSheet> {
                         ),
                         subtitle: m.clubRole != null
                             ? Text(
-                                m.clubRole!,
+                                RoleUtils.translate(
+                                  m.clubRole,
+                                  gender: m.gender,
+                                ),
                                 style: theme.textTheme.bodySmall
                                     ?.copyWith(color: c.textSecondary),
                               )
@@ -1108,7 +1112,10 @@ class _MultiMemberPickerSheetState extends State<_MultiMemberPickerSheet> {
                         ),
                         subtitle: m.clubRole != null
                             ? Text(
-                                m.clubRole!,
+                                RoleUtils.translate(
+                                  m.clubRole,
+                                  gender: m.gender,
+                                ),
                                 style: theme.textTheme.bodySmall
                                     ?.copyWith(color: c.textSecondary),
                               )
@@ -1236,7 +1243,10 @@ class _MemberPickerField extends StatelessWidget {
                   ),
                   if (hasValue && selected!.clubRole != null)
                     Text(
-                      selected!.clubRole!,
+                      RoleUtils.translate(
+                        selected!.clubRole,
+                        gender: selected!.gender,
+                      ),
                       style: theme.textTheme.bodySmall
                           ?.copyWith(color: c.textSecondary),
                     ),

--- a/test/core/utils/network_image_url_test.dart
+++ b/test/core/utils/network_image_url_test.dart
@@ -1,0 +1,35 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sacdia_app/core/utils/network_image_url.dart';
+
+void main() {
+  group('isSvgNetworkUrl', () {
+    test('detects .svg paths', () {
+      expect(
+        isSvgNetworkUrl(
+          'https://pub-c8aa231ae66c46ff96fc5e811994d9d2.r2.dev/achievements/badge.svg',
+        ),
+        isTrue,
+      );
+      expect(isSvgNetworkUrl('badges/achievement-42.SVG'), isTrue);
+    });
+
+    test('ignores query and fragment', () {
+      expect(
+        isSvgNetworkUrl(
+          'https://example.com/achievements/badge.svg?X-Amz-Signature=abc#frag',
+        ),
+        isTrue,
+      );
+    });
+
+    test('rejects raster extensions', () {
+      expect(isSvgNetworkUrl('https://example.com/badge.png'), isFalse);
+      expect(isSvgNetworkUrl('https://example.com/badge.webp'), isFalse);
+      expect(isSvgNetworkUrl('https://example.com/badge.jpg'), isFalse);
+      expect(
+        isSvgNetworkUrl('https://example.com/badge.png?format=svg'),
+        isFalse,
+      );
+    });
+  });
+}

--- a/test/features/honors/presentation/widgets/honor_badge_image_test.dart
+++ b/test/features/honors/presentation/widgets/honor_badge_image_test.dart
@@ -1,6 +1,6 @@
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:sacdia_app/core/widgets/sac_network_image.dart';
 import 'package:sacdia_app/features/honors/presentation/widgets/honor_badge_image.dart';
 
 void main() {
@@ -20,8 +20,8 @@ void main() {
       ),
     );
 
-    final image = tester.widget<CachedNetworkImage>(
-      find.byType(CachedNetworkImage),
+    final image = tester.widget<SacNetworkImage>(
+      find.byType(SacNetworkImage),
     );
 
     expect(image.fit, BoxFit.contain);


### PR DESCRIPTION
## Summary
- Redesigns the achievements grid (summary hero, filters, aligned larger badges, press/stagger motion).
- Redesigns the achievement detail sheet (tier wash, readable tier chips, quieter completion caption, root navigator so content is not clipped by the tab bar).
- Adds `SacNetworkImage` / URL helper and wires badge/honor/class image consumers through it.

## Test plan
- [ ] Open Logros from profile: summary count, points, filters work
- [ ] Grid badges stay horizontally aligned; long titles truncate without shifting icons
- [ ] Open earned/in-progress/locked/secret achievements; detail content fully visible above chrome
- [ ] Tier chips (bronce/plata/oro/platino/diamante) remain readable on light background
- [ ] Pull-to-refresh and reduced-motion still behave correctly
- [ ] Honor/class badge images still load


Made with [Cursor](https://cursor.com)